### PR TITLE
File structure reformatting and stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ You will create a "feature branch" so you can develop your feature without impac
 
 ### Write your pipeline step
 
-In `corgidrp`, each pipeline step is a function. 
-Think about how your feature can be implemented as a function that takes in some data and outputs processed data. 
-All function should follow this example:
+In `corgidrp`, each pipeline step is a function, that is contained in one of the lX_to_lY.py files (where X and Y are various data levels). 
+Think about how your feature can be implemented as a function that takes in some data and outputs processed data. Please see below for some 
+`corgidrp` design principles. 
+
+All functions should follow this example:
 
 ```
 def example_step(dataset, calib_data, tuneable_arg=1, another_arg="test"):
@@ -79,13 +81,13 @@ Inside the function can be nearly anything you want, but the function signature 
 
   * Each function should include a docstring that descibes what the function is doing, what the inputs (including units if appropriate) are and what the outputs (also with units). The dosctrings should be [goggle style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). 
   * The input dataset should always be the first input
-  * Additional arguments and keywords exist only if you need them. A pipeline step can only have a single argument (the input dataset) if needed.
+  * Additional arguments and keywords exist only if you need them--many relevant parameters might already by in Dataset headers. A pipeline step can only have a single argument (the input dataset) if needed.
   * All additional function arguments/keywords should only consist of the following types: int, float, str, or a class defined in corgidrp.Data. 
-    * (Long explaination for the curious: The reason for this is that pipeline steps can be written out as text files. Int/float/str are easily represented succinctly by textfiles. All classes in kpcidrp.Data can be created simply by passing in a filepath. Therefore, all pipeline steps have easily recordable arguments for easy reproducibility.)
+    * (Long explaination for the curious: The reason for this is that pipeline steps can be written out as text files. Int/float/str are easily represented succinctly by textfiles. All classes in corgidrp.Data can be created simply by passing in a filepath. Therefore, all pipeline steps have easily recordable arguments for easy reproducibility.)
   * The first line of the function generally should be creating a copy of the dataset (which will be the output dataset). This way, the output dataset is not the same instance as the input dataset. This will make it easier to ensure reproducibility. 
   * The function should always end with updating the header and (typically) the data of the output dataset. The history of running this pipeline step should be recorded in the header. 
 
-You can check out `corgidrp.detector.dark_subtraction` function as an example of a basic pipeline step.
+You can check out `corgidrp.l2a_to_l2b.dark_subtraction` function as an example of a basic pipeline step.
 
 ### Write a unit test to debug your pipeline step
 
@@ -110,15 +112,15 @@ Before creating a pull request, review the design Principles below. Use the Gith
 ## Overarching Design Principles
 * Minimize the use of external packages, unless it saves us a lot of time. If you need to use something external, default to well-established and maintained packages, such as `numpy`, `scipy` or `Astropy`. If you think you need to use something else, please check with Jason and Max. 
 * Minimize the use of new classes, with the exception of new classes that extend the existing data framework.
-* The python module files (i.e. the *.py files) should typically hold on the order of 5-10 different functions. You can create new ones if need by, but they should be general enough to encapsulate other future functions as well.
+* The python module files (i.e. the *.py files) should typically hold on the order of 5-10 different functions. You can create new ones if need be, but the new files should be general enough in topic to encapsulate other future functions as well.
 * All the image data in the Dataset and Image objects should be saved as standard numpy arrays. Other types of arrays (such as masked arrays) can be used as intermediate products within a function.
 * Keep things simple
-* Use __descriptive__ variable names **always**.
-* Comments should be used to describe section of the code where it's not immediately obvious what the code is doing. Using descriptive variable names will minimize the about of comments required.
+* Use _descriptive_ variable names **always**.
+* Comments should be used to describe a section of the code where it's not immediately obvious what the code is doing. Using descriptive variable names will minimize the amount of comments required.
 
 ## FAQ
 
-  * What about saving files?
+  * Does my pipeline function need to save files?
     * Files will be saved by a higher level pipeline code. As long as you output an object that's an instance of a `corgidrp.Data` class, it will have a `save()` function that will be used.
   * Can I create new data classes?
     * Yes, you can feel free to make new data classes. Generally, they should be a subclass of the `Image` class, and you can look at the `Dark` class as an example. Each calibration type should have its own `Image` subclass defined. Talk with Jason and Max to discuss how your class should be implemented!
@@ -128,9 +130,9 @@ Before creating a pull request, review the design Principles below. Use the Gith
     
 * How should I treat hard-coded variables
   * If a variable value is extremely unlikely to change AND is only required by one module, it can be hard coded inside that module.
-  * If it is unlikely to change but will need to be referenced by multiple modules, it should be added to the central conatants file (name TBD). 
+  * If it is unlikely to change but will need to be referenced by multiple modules, it should be added to the central constants file (name TBD). 
   * If it is likely to change, it should be implemented by a config file.
  
 * Where should I store computed variables so they can be referenced later in the pipeline?
-  * If possible, in the header of the dataset being processed.
+  * If possible, in the header of the dataset being processed or in a hew HDU extension
   * If not possible, then let's chat! 

--- a/corgidrp/detector.py
+++ b/corgidrp/detector.py
@@ -1,3 +1,5 @@
+# Place to put detector-related utility functions
+
 import numpy as np
 import corgidrp.data as data
 
@@ -18,27 +20,3 @@ def create_dark_calib(dark_dataset):
                          ext_hdr=dark_dataset[0].ext_hdr.copy(), input_dataset=dark_dataset)
 
     return new_dark
-
-
-def dark_subtraction(input_dataset, dark_frame):
-    """
-    Perform dark current subtraction of a dataset using the corresponding dark frame
-
-    Args:
-        input_dataset (corgidrp.data.Dataset): a dataset of Images that need dark subtraction (L2a-level)
-        dark_frame (corgidrp.data.Dark): a Dark frame to model the dark current
-
-    Returns:
-        corgidrp.data.Dataset: a dark subtracted version of the input dataset
-    """
-    # you should make a copy the dataset to start
-    darksub_dataset = input_dataset.copy()
-
-    darksub_cube = darksub_dataset.all_data - dark_frame.data
-
-    history_msg = "Dark current subtracted using dark {0}".format(dark_frame.filename)
-
-    # update the output dataset with this new dark subtracted data and update the history
-    darksub_dataset.update_after_processing_step(history_msg, new_all_data=darksub_cube)
-
-    return darksub_dataset

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -53,7 +53,7 @@ def prescan_biassub(input_dataset, bias_offset=0., return_full_frame=False):
     Args:
         input_dataset (corgidrp.data.Dataset): a dataset of Images (L1a-level)
         bias_offset (float): an offset value to be subtracted from the bias
-        return_full_frame (bool): flag indicating whether to return the full frame or only the bias-subtracted image area
+        return_full_frame (bool, optional): flag indicating whether to return the full frame or only the bias-subtracted image area
     Returns:
         corgidrp.data.Dataset: a pre-scan bias subtracted version of the input dataset
     """

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -54,6 +54,7 @@ def prescan_biassub(input_dataset, bias_offset=0., return_full_frame=False):
         input_dataset (corgidrp.data.Dataset): a dataset of Images (L1a-level)
         bias_offset (float): an offset value to be subtracted from the bias
         return_full_frame (bool, optional): flag indicating whether to return the full frame or only the bias-subtracted image area
+    
     Returns:
         corgidrp.data.Dataset: a pre-scan bias subtracted version of the input dataset
     """

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -13,7 +13,7 @@ def prescan_process(input_dataset):
         corgidrp.data.Dataset: a prescan-processed version of the input dataset
     """
 
-    pass
+    return None
 
 
 
@@ -30,7 +30,7 @@ def detect_cosmic_rays(input_dataset):
         corgidrp.data.Dataset: a version of the input dataset of the input dataset where the cosmic rays have been identified. 
     """
 
-    pass
+    return None
 
 def correct_nonlinearity(input_dataset, non_lin_correction):
     """
@@ -44,7 +44,7 @@ def correct_nonlinearity(input_dataset, non_lin_correction):
         corgidrp.data.Dataset: a non-linearity corrected version of the input dataset
     """
 
-    pass
+    return None
 
 def prescan_biassub(input_dataset, bias_offset=0., return_full_frame=False):
     """
@@ -57,4 +57,4 @@ def prescan_biassub(input_dataset, bias_offset=0., return_full_frame=False):
     Returns:
         corgidrp.data.Dataset: a pre-scan bias subtracted version of the input dataset
     """
-    pass
+    return None

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -31,3 +31,30 @@ def detect_cosmic_rays(input_dataset):
     """
 
     pass
+
+def correct_nonlinearity(input_dataset, non_lin_correction):
+    """
+    Perform non-linearity correction of a dataset using the corresponding non-linearity correction
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images that need non-linearity correction (L2a-level)
+        non_lin_correction (corgidrp.data.NonLinearityCorrection): a NonLinearityCorrection calibration file to model the non-linearity
+
+    Returns:
+        corgidrp.data.Dataset: a non-linearity corrected version of the input dataset
+    """
+
+    pass
+
+def prescan_biassub(input_dataset, bias_offset=0., return_full_frame=False):
+    """
+    Perform pre-scan bias subtraction of a dataset.
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L1a-level)
+        bias_offset (float): an offset value to be subtracted from the bias
+        return_full_frame (bool): flag indicating whether to return the full frame or only the bias-subtracted image area
+    Returns:
+        corgidrp.data.Dataset: a pre-scan bias subtracted version of the input dataset
+    """
+    pass

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -1,0 +1,33 @@
+# A file that holds the functions that transmogrify l1 data to l2a data 
+
+
+def prescan_process(input_dataset): 
+    """
+    
+    Crops the data arrays if appropriate and subtracts the prescan-bias
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images that need prescan processing (L1-level)
+
+    Returns:
+        corgidrp.data.Dataset: a prescan-processed version of the input dataset
+    """
+
+    pass
+
+
+
+def detect_cosmic_rays(input_dataset):
+    """
+    
+    Detects cosmis rays in a given images. Updates the DQ to reflect the pixels that are affected. 
+    TODO: Decide if we want this step to optionally compensate for them, or if that's a different step. 
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images that need cosmic ray identification (L1-level)
+
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset of the input dataset where the cosmic rays have been identified. 
+    """
+
+    pass

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -1,0 +1,28 @@
+# A file that holds the functions that transmogrify l2a data to l2b data 
+
+# A file that holds the functions that transmogrify l1 data to l2a data 
+
+
+def dark_subtraction(input_dataset, dark_frame):
+    """
+    
+    Perform dark current subtraction of a dataset using the corresponding dark frame
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images that need dark subtraction (L2a-level)
+        dark_frame (corgidrp.data.Dark): a Dark frame to model the dark current
+
+    Returns:
+        corgidrp.data.Dataset: a dark subtracted version of the input dataset
+    """
+    # you should make a copy the dataset to start
+    darksub_dataset = input_dataset.copy()
+
+    darksub_cube = darksub_dataset.all_data - dark_frame.data
+
+    history_msg = "Dark current subtracted using dark {0}".format(dark_frame.filename)
+
+    # update the output dataset with this new dark subtracted data and update the history
+    darksub_dataset.update_after_processing_step(history_msg, new_all_data=darksub_cube)
+
+    return darksub_dataset

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -1,8 +1,5 @@
 # A file that holds the functions that transmogrify l2a data to l2b data 
 
-# A file that holds the functions that transmogrify l1 data to l2a data 
-
-
 def dark_subtraction(input_dataset, dark_frame):
     """
     
@@ -26,3 +23,88 @@ def dark_subtraction(input_dataset, dark_frame):
     darksub_dataset.update_after_processing_step(history_msg, new_all_data=darksub_cube)
 
     return darksub_dataset
+
+def frame_select(input_dataset):
+    """
+    
+    Selects the frames that we want to use for further processing. 
+    TODO: Decide on frame selection criteria
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)
+
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset with only the frames we want to use
+    """
+    pass
+
+def convert_to_electrons(input_dataset): 
+    """
+    
+    Convert the data from ADU to electrons. 
+    TODO: Establish the interaction with the CalDB for obtaining gain calibration 
+    TODO: Make sure to update the headers to reflect the change in units
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)
+
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset with the data in electrons
+    """
+
+    pass 
+
+def cti_correction(input_dataset):
+    """
+    
+    Apply the CTI correction to the dataset.
+    TODO: Establish the interaction with the CalDB for obtaining CTI correction calibrations
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)
+        
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset with the CTI correction applied
+    """
+
+    pass
+
+def flat_division(input_dataset, master_flat):
+    """
+    
+    Divide the dataset by the master flat field. 
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)
+        master_flat (corgidrp.data.Flat): a master flat field to divide by
+
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset with the flat field divided out
+    """
+
+    pass
+
+def correct_bad_pixels(input_dataset):
+    """
+    
+    Compute bad pixel map and correct for bad pixels. 
+
+    MMB Notes: 
+        - We'll likely want to be able to accept an external bad pixel map, either 
+        from the CalDB or input by a user. 
+        - We may want to accept just a list of bad pixels from a user too, thus 
+        saving them the trouble of actually making their own map. 
+        - We may want flags to decide which pixels in the DQ we correct. We may 
+        not want to correct everything in the DQ extension
+        - Different bad pixels in the DQ may be corrected differently.
+
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)
+
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset with bad pixels corrected
+    """
+
+    pass
+

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -36,7 +36,7 @@ def frame_select(input_dataset):
     Returns:
         corgidrp.data.Dataset: a version of the input dataset with only the frames we want to use
     """
-    pass
+    return None
 
 def convert_to_electrons(input_dataset): 
     """
@@ -52,7 +52,7 @@ def convert_to_electrons(input_dataset):
         corgidrp.data.Dataset: a version of the input dataset with the data in electrons
     """
 
-    pass 
+    return None 
 
 def cti_correction(input_dataset):
     """
@@ -67,7 +67,7 @@ def cti_correction(input_dataset):
         corgidrp.data.Dataset: a version of the input dataset with the CTI correction applied
     """
 
-    pass
+    return None
 
 def flat_division(input_dataset, master_flat):
     """
@@ -82,7 +82,7 @@ def flat_division(input_dataset, master_flat):
         corgidrp.data.Dataset: a version of the input dataset with the flat field divided out
     """
 
-    pass
+    return None
 
 def correct_bad_pixels(input_dataset):
     """
@@ -106,5 +106,5 @@ def correct_bad_pixels(input_dataset):
         corgidrp.data.Dataset: a version of the input dataset with bad pixels corrected
     """
 
-    pass
+    return None
 

--- a/corgidrp/l2b_to_l3.py
+++ b/corgidrp/l2b_to_l3.py
@@ -12,7 +12,7 @@ def create_wcs(input_dataset):
         corgidrp.data.Dataset: a version of the input dataset with the WCS headers added
     """
 
-    pass
+    return None
 
 def divide_by_exptime(input_dataset):
     """
@@ -28,4 +28,4 @@ def divide_by_exptime(input_dataset):
         corgidrp.data.Dataset: a version of the input dataset with the data in units of electrons/s
     """
 
-    pass
+    return None

--- a/corgidrp/l2b_to_l3.py
+++ b/corgidrp/l2b_to_l3.py
@@ -1,0 +1,31 @@
+# A file that holds the functions that transmogrify l2b data to l3 data 
+
+def create_wcs(input_dataset):
+    """
+    
+    Create the WCS headers for the dataset.
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2b-level)
+
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset with the WCS headers added
+    """
+
+    pass
+
+def divide_by_exptime(input_dataset):
+    """
+    
+    Divide the data by the exposure time to get the units in electrons/s
+
+    TODO: Make sure to update the headers to reflect the change in units
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2b-level)
+
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset with the data in units of electrons/s
+    """
+
+    pass

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -13,7 +13,7 @@ def distortion_correction(input_dataset, distortion_calibration):
         corgidrp.data.Dataset: a version of the input dataset with the distortion correction applied
     """
 
-    pass
+    return None
 
 def find_star(input_dataset):
     """
@@ -27,7 +27,7 @@ def find_star(input_dataset):
         corgidrp.data.Dataset: a version of the input dataset with the stars identified
     """
 
-    pass
+    return None
 
 def do_psf_subtraction(input_dataset, reference_star_dataset=None):
     """
@@ -42,4 +42,4 @@ def do_psf_subtraction(input_dataset, reference_star_dataset=None):
         corgidrp.data.Dataset: a version of the input dataset with the PSF subtraction applied
     """
 
-    pass
+    return None

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -1,0 +1,45 @@
+# A file that holds the functions that transmogrify l3 data to l4 data 
+
+def distortion_correction(input_dataset, distortion_calibration):
+    """
+    
+    Apply the distortion correction to the dataset.
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L3-level)
+        distortion_calibration (corgidrp.data.DistortionCalibration): a DistortionCalibration calibration file to model the distortion
+
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset with the distortion correction applied
+    """
+
+    pass
+
+def find_star(input_dataset):
+    """
+    
+    Find the star position in each Image in the dataset.
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L3-level)
+
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset with the stars identified
+    """
+
+    pass
+
+def do_psf_subtraction(input_dataset, reference_star_dataset=None):
+    """
+    
+    Perform PSF subtraction on the dataset. Optionally using a reference star dataset.
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L3-level)
+        reference_star_dataset (corgidrp.data.Dataset): a dataset of Images of the reference star [optional]
+
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset with the PSF subtraction applied
+    """
+
+    pass

--- a/examples/ttr5_analog.py
+++ b/examples/ttr5_analog.py
@@ -9,7 +9,8 @@ from corgidrp.data import Dataset, Dark, Flat, generate_filelist
 # from corgidrp.detector import crop_dataset, subtract_bias, detect_cosmic_rays, correct_nonlinearity, convert_to_electrons, divide_by_em_gain, dark_subtraction, cti_correction
 import corgidrp.detector as detector
 import corgidrp.image_utils as image_utils
-from corgidrp.caldb import CalDB, find_best_dark
+from corgidrp import l1_to_l2a, l2a_to_l2b, l2b_to_l3, l3_to_l4
+from corgidrp.caldb import CalDB
 
 input_filepath = "my/bank/passwords/"
 output_filepath = "where/the/planets/will/go/"
@@ -29,17 +30,17 @@ calibration_db = CalDB(caldb_filepath)
 #############################
 
 #Crop the data to only the main region of interest
-l1_dataset_cropped = detector.crop_dataset(l1_dataset) # This function doesn't exist yet
+l1_dataset_cropped = l1_to_l2a.crop_dataset(l1_dataset) # This function doesn't exist yet
 
 #Measure and subtract the bias
-l1_dataset_bias_subtracted = detector.subtract_bias(l1_dataset_cropped) # There is II&T code that we can port over for this
+l1_dataset_bias_subtracted = l1_to_l2a.subtract_bias(l1_dataset_cropped) # There is II&T code that we can port over for this
 
 #Detect cosmic rays and make a mask
-l1_dataset_cosmic_ray_masked = detector.detect_cosmic_rays(l1_dataset_bias_subtracted) # There is II&T code that we can port over for this
+l1_dataset_cosmic_ray_masked = l1_to_l2a.detect_cosmic_rays(l1_dataset_bias_subtracted) # There is II&T code that we can port over for this
 
 #Correct for non-linearity
 #This may need an outside calibration file if nonlinearity is not constant
-l1_dataset_nonlinearity_corrected = detector.correct_nonlinearity(l1_dataset_cosmic_ray_masked) # There is II&T code that we can port over for this
+l1_dataset_nonlinearity_corrected = l1_to_l2a.correct_nonlinearity(l1_dataset_cosmic_ray_masked) # There is II&T code that we can port over for this
 
 #Change the dataset level from L1 to L2a
 l2a_dataset = l1_dataset_nonlinearity_corrected.update_to_l2a() # This function doesn't exist yet
@@ -51,11 +52,11 @@ l2a_dataset.save(output_filepath)
 #############################
 
 #Select the frames that we want to use
-l2_dataset_frame_selected = image_utils.frame_select(l2a_dataset) # This function doesn't exist yet
+l2_dataset_frame_selected = l2a_to_l2b.frame_select(l2a_dataset) # This function doesn't exist yet
 
 #Convert to e-
 # If we expect the detector gain to vary with time, we may need to pass in the caldb here
-l2_dataset_electrons = detector.convert_to_electrons(l2_dataset_frame_selected) # This function doesn't exist yet
+l2_dataset_electrons = l2a_to_l2b.convert_to_electrons(l2_dataset_frame_selected) # This function doesn't exist yet
 
 #Divide by the em gain -- if applicable -- not assuming photon counting in this example
 #This may need an outside calibration file if em_gain < 1000
@@ -63,17 +64,17 @@ l2_dataset_electrons = detector.convert_to_electrons(l2_dataset_frame_selected) 
 
 #Subtract_master_dark
 master_dark = CalDB.get_calib(l2_dataset_electrons.frames[0],Dark)
-l2_dataset_dark_subtracted = detector.dark_subtraction(l2_dataset_electrons, master_dark)
+l2_dataset_dark_subtracted = l2a_to_l2b.dark_subtraction(l2_dataset_electrons, master_dark)
 
 #Apply CTI Correction
-l2_dataset_cti_corrected = detector.cti_correction(l2_dataset_dark_subtracted) # This function doesn't exist yet
+l2_dataset_cti_corrected = l2a_to_l2b.cti_correction(l2_dataset_dark_subtracted) # This function doesn't exist yet
 
 #Divide by master flat
 master_flat = CalDB.get_calib(l2_dataset_cti_corrected.frames[0],Flat)
-l2_dataset_flat_divided = detector.flat_division(l2_dataset_cti_corrected, master_flat) # This function doesn't exist yet
+l2_dataset_flat_divided = l2a_to_l2b.flat_division(l2_dataset_cti_corrected, master_flat) # This function doesn't exist yet
 
 #Compute bad_pixel map and correct for bad pixels
-l2_dataset_bad_pixel_corrected = detector.bad_pixel_correction(l2_dataset_flat_divided) # This function doesn't exist yet
+l2_dataset_bad_pixel_corrected = l2a_to_l2b.bad_pixel_correction(l2_dataset_flat_divided) # This function doesn't exist yet
 
 #Change the dataset level from L2a to L2b
 l2b_dataset = l2_dataset_bad_pixel_corrected.update_to_l2b() # This function doesn't exist yet

--- a/tests/test_dark_sub.py
+++ b/tests/test_dark_sub.py
@@ -5,6 +5,7 @@ import numpy as np
 import corgidrp.data as data
 import corgidrp.mocks as mocks
 import corgidrp.detector as detector
+import corgidrp.l2a_to_l2b as l2a_to_l2b
 
 def test_dark_sub():
     """
@@ -47,7 +48,7 @@ def test_dark_sub():
     dark_filepath = os.path.join(calibdir, dark_filename)
     new_dark = data.Dark(dark_filepath)
     # subtract darks from itself
-    darkest_dataset = detector.dark_subtraction(dark_dataset, new_dark)
+    darkest_dataset = l2a_to_l2b.dark_subtraction(dark_dataset, new_dark)
 
     # check the level of the dataset is now approximately 0 
     assert np.mean(darkest_dataset.all_data) == pytest.approx(0, abs=1e-2)


### PR DESCRIPTION
I set up a new file structure where pipeline steps will be functions in lX_to_lY.py files (heavily inspired by @mygouf's suggestions!). Hopefully this will help us stay more organized and limit the number of functions per module. Within those functions I created some very basic stubs for the current list of functions in the ttr5_analog example. These should be expanded, but we now have a start. 


