### PR TITLE
Update installation and enable toggling of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ pip install -e .
 ```
 Then you can import `corgidrp` like any other python package!
 
-The installation will create a configuration file in your home directory called `.corgidrp`. 
-That configuration directory will be used to locate things on your computer such as the location of the calibration database. 
+The installation will create a configuration folder in your home directory called `.corgidrp`. 
+That configuration directory will be used to locate things on your computer such as the location of the calibration database and the pipeline configuration file. The configuration files stores setting such as whether to track each individual error term added to the noise. 
 
 ## How to Contribute
 
@@ -147,7 +147,7 @@ Before creating a pull request, review the design Principles below. Use the Gith
 * How should I treat hard-coded variables
   * If a variable value is extremely unlikely to change AND is only required by one module, it can be hard coded inside that module.
   * If it is unlikely to change but will need to be referenced by multiple modules, it should be added to the central constants file (name TBD). 
-  * If it is likely to change, it should be implemented by a config file.
+  * If it is a setting about pipeline behavior that may change, it should be implemented by a config file (examples are location of the calibration database and whether to save individual error terms in the output FITS files).
  
 * Where should I store computed variables so they can be referenced later in the pipeline?
   * If possible, in the header of the dataset being processed or in a hew HDU extension

--- a/corgidrp/__init__.py
+++ b/corgidrp/__init__.py
@@ -5,10 +5,15 @@ import configparser
 
 version = "0.1"
 
+_bool_map = {"true" : True, "false" : False}
+
 # borrowed from the kpicdrp caldb
 # load in default caldbs based on configuration file
-config_filepath = os.path.join(pathlib.Path.home(), ".corgidrp")
+config_filepath = os.path.join(pathlib.Path.home(), ".corgidrp", "corgidrp.cfg")
 config = configparser.ConfigParser()
 config.read(config_filepath)
+
+## pipeline settings
 aux_dir = config.get("PATH", "auxdir", fallback=None)
 caldb_filepath = config.get("PATH", "caldb", fallback=None)
+track_individual_errors = _bool_map[config.get("DATA", "track_individual_errors").lower()]

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -340,6 +340,9 @@ class Image():
         and update the combined uncertainty in the first layer.
         Update the error header and assign the error name. 
         
+        Only tracks individual errors if the "track_individual_errors" setting is set to True
+        in the configuration file
+        
         Args:
           input_error (np.array): 2-d error layer
           err_name (str): name of the uncertainty layer  
@@ -347,16 +350,17 @@ class Image():
         if input_error.ndim != 2 or input_error.shape != self.data.shape:
             raise ValueError("we expect a 2-dimensional error layer with dimensions {0}".format(self.data.shape))
         
-        #append new error as layer on 3D cube
-        self.err=np.append(self.err, [input_error], axis=0)
-
         #first layer is always the updated combined error
         self.err[0,:,:] = np.sqrt(self.err[0,:,:]**2 + input_error**2)
-    
-        layer = str(self.err.shape[0])
         self.err_hdr["Layer_1"] = "combined_error"
-        self.err_hdr["Layer_" + layer] = err_name    
-        
+
+        if corgidrp.track_individual_errors:
+            #append new error as layer on 3D cube
+            self.err=np.append(self.err, [input_error], axis=0)
+
+            layer = str(self.err.shape[0])
+            self.err_hdr["Layer_" + layer] = err_name    
+            
 
 class Dark(Image):
     """

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -339,7 +339,7 @@ class Image():
         Add a layer of a specific additive uncertainty on the 3-dim error array extension 
         and update the combined uncertainty in the first layer.
         Update the error header and assign the error name. 
-        
+
         Only tracks individual errors if the "track_individual_errors" setting is set to True
         in the configuration file
         
@@ -360,7 +360,9 @@ class Image():
 
             layer = str(self.err.shape[0])
             self.err_hdr["Layer_" + layer] = err_name    
-            
+        
+        # record history since 2-D error map doesn't track individual terms
+        self.err_hdr['HISTORY'] = "Added error term: {0}".format(err_name)
 
 class Dark(Image):
     """

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -304,8 +304,9 @@ class Image():
             for i in range(num_errs):
                 del self.err_hdr['Layer_{0}'.format(i + 2)]
             self.err = self.err[:1] # only save the total err, preserve 3-D shape
+        self.err_hdr['TRK_ERRS'] = corgidrp.track_individual_errors # specify whether we are tracing errors
 
-        # can do fancier things here if needed or storing more meta data
+
 
     # create this field dynamically
     @property

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -243,7 +243,14 @@ class Image():
         if not hasattr(self, 'dq_hdr'):
             self.dq_hdr = fits.Header()
         self.dq_hdr["EXTNAME"] = "DQ"
-        # can do fancier things here if needed or storing more meta data
+
+        # discard individual errors if we aren't tracking them but multiple error terms are passed in
+        if not corgidrp.track_individual_errors and self.err.shape[0] > 1:
+            num_errs = self.err.shape[0] - 1
+            # delete keywords specifying the error of each individual slice
+            for i in range(num_errs):
+                del self.err_hdr['Layer_{0}'.format(i + 2)]
+            self.err = self.err[:1] # only save the total err, preserve 3-D shape
 
     # create this field dynamically
     @property

--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,35 @@ import os
 import pathlib
 import configparser
 
-## Create a configuration file for the corgidrp if it doesn't exist. 
+#### Create a configuration file for the corgidrp if it doesn't exist. 
+
 homedir = pathlib.Path.home()
-config_filepath = os.path.join(homedir, ".corgidrp")
+config_folder = os.path.join(homedir, ".corgidrp")
+# replace legacy file with folder if needed
+if os.path.isfile(config_folder):
+    oldconfig = configparser.ConfigParser()
+    oldconfig.read(config_folder)
+    os.remove(config_folder)
+else:
+    oldconfig = None
+# make folder if doesn't exist
+if not os.path.isdir(config_folder):
+    os.mkdir(config_folder)
+
+# write config 
+config_filepath = os.path.join(config_folder, "corgidrp.cfg")
 if not os.path.exists(config_filepath):
-    corgidrp_basedir = os.path.dirname(__file__)
     config = configparser.ConfigParser()
     config["PATH"] = {}
-    config["PATH"]["caldb"] = os.path.join(corgidrp_basedir, "corgidrp_caldb.csv") # location to store caldb
-    config["PATH"]["auxdata"] = os.path.join(corgidrp_basedir, "aux") + os.path.sep # folder for auxiliary data
+    config["PATH"]["caldb"] = os.path.join(config_folder, "corgidrp_caldb.csv") # location to store caldb
+    config["DATA"] = {}
+    config["DATA"]["track_individual_errors"] = "False"
+    # overwrite with old settings if needed
+    if oldconfig is not None:
+        config["PATH"]["caldb"] = oldconfig["PATH"]["caldb"]
+
     with open(config_filepath, 'w') as f:
-            config.write(f)
+        config.write(f)
 
     print("corgidrp: Configuration file written to {0}. Please edit if you want things stored in different locations.".format(config_filepath))
 

--- a/tests/test_add_phot_noise.py
+++ b/tests/test_add_phot_noise.py
@@ -1,10 +1,12 @@
 import os
 import numpy as np
+import corgidrp
 from corgidrp.mocks import create_default_headers
 from corgidrp.data import Image, Dataset
 from corgidrp.l2a_to_l2b import add_photon_noise
 import pytest
 
+old_err_tracking = corgidrp.track_individual_errors
 
 data = np.ones([1024,1024])*2.
 err = np.ones([1024,1024]) *0.5
@@ -12,6 +14,8 @@ dq = np.zeros([1024,1024], dtype = np.uint16)
 prhd, exthd = create_default_headers()
 
 def test_add_phot_noise():
+    corgidrp.track_individual_errors = True
+
     print("test add_photon_noise pipeline step")
     image1 = Image(data,pri_hdr = prhd, ext_hdr = exthd, err = err, dq = dq)
     image2 = Image(data,pri_hdr = prhd, ext_hdr = exthd, err = err, dq = dq)
@@ -24,6 +28,8 @@ def test_add_phot_noise():
     assert np.array_equal(all_err1[0,1], np.sqrt(data))
     assert np.allclose(all_err1[0,0], np.sqrt(data + np.square(err)))
     assert "noise" in str(dataset_add.frames[0].ext_hdr["HISTORY"])
+
+    corgidrp.track_individual_errors = old_err_tracking
     
 if __name__ == '__main__':
     test_add_phot_noise()

--- a/tests/test_dark_sub.py
+++ b/tests/test_dark_sub.py
@@ -2,15 +2,20 @@ import os
 import glob
 import pytest
 import numpy as np
+import corgidrp
 import corgidrp.data as data
 import corgidrp.mocks as mocks
 import corgidrp.detector as detector
 import corgidrp.l2a_to_l2b as l2a_to_l2b
 
+old_err_tracking = corgidrp.track_individual_errors
+
 def test_dark_sub():
     """
     Generate mock input data and pass into dark subtraction function
     """
+    corgidrp.track_individual_errors = True # this test uses individual error components
+
     ###### create simulated data
     # check that simulated data folder exists, and create if not
     datadir = os.path.join(os.path.dirname(__file__), "simdata")
@@ -65,6 +70,8 @@ def test_dark_sub():
     print("mean of all data:", np.mean(darkest_dataset.all_data))
     print("mean of all errors:", np.mean(darkest_dataset.all_err))
     print(darkest_dataset[0].ext_hdr)
+
+    corgidrp.track_individual_errors = old_err_tracking
     
 
 if __name__ == "__main__":

--- a/tests/test_err_dq.py
+++ b/tests/test_err_dq.py
@@ -182,7 +182,7 @@ def test_read_many_errors_notrack():
         assert image_test.err_hdr["Layer_3"] == "error_nuts"
 
     
-def teardown_module(module):
+def teardown_module():
     """
     Runs automatically at the end. ONLY IN PYTEST
 

--- a/tests/test_err_dq.py
+++ b/tests/test_err_dq.py
@@ -21,6 +21,8 @@ errhd["CASE"] = "test"
 dqhd = fits.Header()
 dqhd["CASE"] = "test"
 
+old_err_tracking = corgidrp.track_individual_errors
+
 def test_err_dq_creation():
     """
     test the initialization of error and dq attributes of the Image class including saving and loading
@@ -181,11 +183,15 @@ def test_read_many_errors_notrack():
 
     
 def teardown_module(module):
-    """teardown any state that was previously setup with a setup_module
-    method.
+    """
+    Runs automatically at the end. ONLY IN PYTEST
+
+    Removes new FITS files and restores track individual error setting.
     """
     for i in range(3):
         os.remove('test_image{0}.fits'.format(i))
+
+    corgidrp.track_individual_errors = old_err_tracking
 
 # for debugging. does not run with pytest!!
 if __name__ == '__main__':

--- a/tests/test_prescan_sub.py
+++ b/tests/test_prescan_sub.py
@@ -1,6 +1,7 @@
 import glob
 import os
 
+import corgidrp
 import corgidrp.data as data
 from corgidrp.l1_to_l2a import prescan_biassub
 import corgidrp.mocks as mocks
@@ -12,6 +13,8 @@ from astropy.io import fits
 from pathlib import Path
 
 from pytest import approx
+
+old_err_tracking = corgidrp.track_individual_errors
 
 # Expected output image shapes
 shapes = {
@@ -368,7 +371,8 @@ def test_bias_hvoff():
     The error tolerance is set by the standard error on the median of 
     the Gaussian noise, not the mean.
     """
-    
+    corgidrp.track_individual_errors = True # needs to run with error tracking on
+
     # Set tolerance
     tol = 1.
     err_tol = 0.02
@@ -401,6 +405,8 @@ def test_bias_hvoff():
             std_err = sig / np.sqrt(detector_areas[obstype]['prescan_reliable']['cols']) * np.sqrt(np.pi / 2.)
             if np.max(np.abs(output_dataset[0].err[1]) - std_err) > err_tol:
                 raise Exception(f'Higher than expected std. error in bias measurement for hvoff distribution: \n{np.max(np.abs(output_dataset[0].err[1]))} when we expect {std_err} +- {err_tol} ')
+
+    corgidrp.track_individual_errors = old_err_tracking
 
 def test_bias_hvon():
     """
@@ -507,6 +513,7 @@ def test_bias_offset():
 
             if not np.nanmax(np.abs(image_slice_0 - image_slice_10)) < tol:
                 raise Exception(f"Bias offset subtraction did not produce the correct result. absmax value : {np.nanmax(np.abs(image_slice_0 - image_slice_10))}")
+
 
 if __name__ == "__main__":
     test_prescan_sub()


### PR DESCRIPTION
corgidrp config file and caldb now save to `~/.corgidrp` folder by default

New setting to enable whether individual error terms are saved or not. By default, this is set to false. 

Hopefully this didn't break anything (waiting on tests)