### PR TITLE
Save Prescan Bias as 1D Fits Extension

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -153,22 +153,26 @@ class Image():
         ext_hdr (astropy.io.fits.Header): the image extension header (required only if raw 2D data is passed in)
         err (np.array): 2-D/3-D uncertainty data
         dq (np.array): 2-D data quality, 0: good, 1: bad
+        bias (np.array): 1-D bias data
         err_hdr (astropy.io.fits.Header): the error extension header
         dq_hdr (astropy.io.fits.Header): the data quality extension header
+        bias_hdr (astropy.io.fits.Header): the bias extension header
 
     Attributes:
         data (np.array): 2-D data for this Image
         err (np.array): 2-D uncertainty
         dq (np.array): 2-D data quality
+        bias (np.array): 1-D bias data
         pri_hdr (astropy.io.fits.Header): primary header
         ext_hdr (astropy.io.fits.Header): image extension header. Generally this header will be edited/added to
         err_hdr (astropy.io.fits.Header): the error extension header
         dq_hdr (astropy.io.fits.Header): the data quality extension header
+        bias_hdr (astropy.io.fits.Header): the bias extension header
         filename (str): the filename corresponding to this Image
         filedir (str): the file directory on disk where this image is to be/already saved.
         filepath (str): full path to the file on disk (if it exists)
     """
-    def __init__(self, data_or_filepath, pri_hdr=None, ext_hdr=None, err = None, dq = None, err_hdr = None, dq_hdr = None):
+    def __init__(self, data_or_filepath, pri_hdr=None, ext_hdr=None, err = None, dq = None, bias=None, err_hdr = None, dq_hdr = None, bias_hdr=None):
         if isinstance(data_or_filepath, str):
             # a filepath is passed in
             with fits.open(data_or_filepath) as hdulist:
@@ -203,6 +207,17 @@ class Image():
                     self.dq_hdr = hdulist[3].header
                 else:
                     self.dq = np.zeros(self.data.shape, dtype = int)
+
+                if bias is not None:
+                    if (np.shape(self.data)[0],) != np.shape(bias):
+                        raise ValueError("The shape of bias is {0} while we are expecting shape {1}".format(bias.shape, self.data.shape))
+                    self.bias = bias
+                # we assume that the bias extension is index 4 of hdulist
+                elif len(hdulist)>4:
+                    self.bias = hdulist[4].data
+                    self.bias_hdr = hdulist[4].header
+                else:
+                    self.bias = np.zeros(self.data.shape[0], dtype = np.float32)
 
             # parse the filepath to store the filedir and filename
             filepath_args = data_or_filepath.split(os.path.sep)
@@ -242,6 +257,13 @@ class Image():
             else:
                 self.dq = np.zeros(self.data.shape, dtype = int)
 
+            if bias is not None:
+                if (np.shape(self.data)[0],) != np.shape(bias):
+                    raise ValueError("The shape of bias is {0} while we are expecting shape {1}".format(bias.shape, self.data.shape))
+                self.bias = bias.astype(np.float32)
+            else:
+                self.bias = np.zeros(self.data.shape[0], dtype = np.float32)
+
             # record when this file was created and with which version of the pipeline
             self.ext_hdr.set('DRPVERSN', corgidrp.version, "corgidrp version that produced this file")
             self.ext_hdr.set('DRPCTIME', time.Time.now().isot, "When this file was saved")
@@ -251,12 +273,17 @@ class Image():
             self.err_hdr = err_hdr
         if dq_hdr is not None:
             self.dq_hdr = dq_hdr
+        if bias_hdr is not None:
+            self.bias_hdr = bias_hdr
         if not hasattr(self, 'err_hdr'):
             self.err_hdr = fits.Header()
         self.err_hdr["EXTNAME"] = "ERR"
         if not hasattr(self, 'dq_hdr'):
             self.dq_hdr = fits.Header()
         self.dq_hdr["EXTNAME"] = "DQ"
+        if not hasattr(self, 'bias_hdr'):
+            self.bias_hdr = fits.Header()
+        self.bias_hdr["EXTNAME"] = "BIAS"
         # can do fancier things here if needed or storing more meta data
 
     # create this field dynamically
@@ -290,6 +317,10 @@ class Image():
 
         dqhdu = fits.ImageHDU(data=self.dq, header = self.dq_hdr)
         hdulist.append(dqhdu)
+
+        biashdu = fits.ImageHDU(data=self.bias, header = self.bias_hdr)
+        hdulist.append(biashdu)
+
         hdulist.writeto(self.filepath, overwrite=True)
         hdulist.close()
 
@@ -322,11 +353,14 @@ class Image():
             new_data = np.copy(self.data)
             new_err = np.copy(self.err)
             new_dq = np.copy(self.dq)
+            new_bias = np.copy(self.bias)
         else:
             new_data = self.data # this is just pointer referencing
             new_err = self.err
             new_dq = self.dq
-        new_img = Image(new_data, pri_hdr=self.pri_hdr.copy(), ext_hdr=self.ext_hdr.copy(), err = new_err, dq = new_dq, err_hdr = self.err_hdr.copy(), dq_hdr = self.dq_hdr.copy())
+            new_bias = self.bias
+        new_img = Image(new_data, pri_hdr=self.pri_hdr.copy(), ext_hdr=self.ext_hdr.copy(), err = new_err, dq = new_dq, bias=new_bias, 
+                        err_hdr = self.err_hdr.copy(), dq_hdr = self.dq_hdr.copy(), bias_hdr = self.bias_hdr.copy())
 
         # annoying, but we got to manually update some parameters. Need to keep track of which ones to update
         new_img.filename = self.filename

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -22,6 +22,7 @@ def prescan_biassub(input_dataset, bias_offset=0., return_full_frame=False):
     out_frames_data = []
     out_frames_err = []
     out_frames_dq = []
+    out_frames_bias = []
 
     # Iterate over frames
     for i, frame in enumerate(output_dataset):
@@ -70,19 +71,17 @@ def prescan_biassub(input_dataset, bias_offset=0., return_full_frame=False):
         out_frames_data.append(image_bias_corrected)
         out_frames_err.append(image_err)
         out_frames_dq.append(image_dq)
+        out_frames_bias.append(bias[:,0]) # save 1D version of array
 
         # Update header with new frame dimensions
         frame.ext_hdr['NAXIS1'] = image_bias_corrected.shape[1]
         frame.ext_hdr['NAXIS2'] = image_bias_corrected.shape[0]
-        
-        # Save median bias measured in the header
-        frame.ext_hdr['MED_BIAS'] = np.median(bias)
-
     
     # Update all_data and reassign frame pointers (only necessary because the array size has changed)
     out_frames_data_arr = np.array(out_frames_data)
     out_frames_err_arr = np.array(out_frames_err)
     out_frames_dq_arr = np.array(out_frames_dq)
+    out_frames_bias_arr = np.array(out_frames_bias, dtype=np.float32)
 
     output_dataset.all_data = out_frames_data_arr
     output_dataset.all_err = out_frames_err_arr
@@ -92,8 +91,8 @@ def prescan_biassub(input_dataset, bias_offset=0., return_full_frame=False):
         frame.data = out_frames_data_arr[i]
         frame.err = out_frames_err_arr[i]
         frame.dq = out_frames_dq_arr[i]
+        frame.bias = out_frames_bias_arr[i]
 
-            
     history_msg = "Frames cropped and bias subtracted"
 
     # update the output dataset with this new dark subtracted data and update the history

--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -27,7 +27,7 @@ def create_dark_calib_files(filedir=None, numfiles=10):
     frames = []
     for i in range(numfiles):
         prihdr, exthdr = create_default_headers()
-        np.random.seed(456+i); sim_data = np.random.poisson(lam=150, size=(1024, 1024))
+        np.random.seed(456+i); sim_data = np.random.poisson(lam=150., size=(1024, 1024)).astype(np.float64)
         frame = data.Image(sim_data, pri_hdr=prihdr, ext_hdr=exthdr)
         if filedir is not None:
             frame.save(filedir=filedir, filename=filepattern.format(i))
@@ -65,7 +65,7 @@ def create_nonlinear_dataset(filedir=None, numfiles=2,em_gain=2000):
         data_range = np.linspace(10,65536,size)
         # Generate data for each row, where the mean increase from 10 to 65536
         for x in range(size):
-            np.random.seed(123+x); sim_data[:, x] = np.random.poisson(data_range[x], size)
+            np.random.seed(123+x); sim_data[:, x] = np.random.poisson(data_range[x], size).astype(np.float64)
 
         non_linearity_correction = data.NonLinearityCalibration(os.path.join(os.path.dirname(os.path.abspath(__file__)),'..',"tests","test_data","nonlin_sample.fits"))
 
@@ -114,7 +114,7 @@ def create_prescan_files(filedir=None, numfiles=2, obstype="SCI"):
     frames = []
     for i in range(numfiles):
         prihdr, exthdr = create_default_headers(obstype=obstype)
-        sim_data = np.random.poisson(lam=150, size=size)
+        sim_data = np.random.poisson(lam=150., size=size).astype(np.float64)
         frame = data.Image(sim_data, pri_hdr=prihdr, ext_hdr=exthdr)
 
         if filedir is not None:

--- a/tests/test_prescan_sub.py
+++ b/tests/test_prescan_sub.py
@@ -151,8 +151,6 @@ class Metadata(object):
     
 # EMCCDFrame code from https://github.com/roman-corgi/cgi_iit_drp/blob/main/proc_cgi_frame_NTR/proc_cgi_frame/gsw_emccd_frame.py#L9
 
-# EMCCDFrame code from https://github.com/roman-corgi/cgi_iit_drp/blob/main/proc_cgi_frame_NTR/proc_cgi_frame/gsw_emccd_frame.py#L9
-
 class EMCCDFrameException(Exception):
     """Exception class for emccd_frame module."""
 
@@ -321,25 +319,6 @@ def test_prescan_sub():
 
             if np.nanmax(np.abs(corgidrp_result-iit_result)) > tol:
                 raise Exception(f"corgidrp result does not match II&T result for generated mock data, obstype={obstype}, return_full_frame={return_full_frame}.")
-
-            # Plot for debugging
-            # import matplotlib.pyplot as plt
-            # fig,axes = plt.subplots(1,3,figsize=(10,4))
-
-            # im0 = axes[0].imshow(corgidrp_result,cmap='seismic')
-            # plt.colorbar(im0)
-            # axes[0].set_title('corgidrp result')
-
-            # im1 = axes[1].imshow(iit_result,cmap='seismic')
-            # plt.colorbar(im1)
-            # axes[1].set_title('II&T result')
-
-            # im2 = axes[2].imshow(corgidrp_result-iit_result,cmap='seismic')
-            # plt.colorbar(im2)
-            # axes[2].set_title('Difference')
-
-            # plt.tight_layout()
-            # plt.show()
 
 def test_bias_zeros_frame():
     """Verify prescan_biassub does not break for a frame of all zeros 


### PR DESCRIPTION
Hello! This PR is to track the bias measured in the prescan bias subtraction step as a 1D, single precision array. There are changes in 4 files.
* `data.py`: 
    * Added a `bias` and `bias_hdr` attribute to the `Image` class to store the measured bias.
    * Modified the `Image.__init__()`, `Image.copy()`, and `Image.save()` methods to read in, copy, and save the bias as a new fits extension called "BIAS", and maintain only single point precision (`dtype=np.float32`). If a new Image object is initialized manually and no bias is specifies, the bias array is initialized as an array of all zeros.
* `l1_to_l2a.py`:
    * Saved the measured bias for each row in the image to the bias attribute of the Image class
    * Removed the 'MED_BIAS' header keyword which previously held just the median bias measured in that image, as it's now redundant.
* `test_prescan_sub.py`:
    * Added tests to make sure the bias array is the correct shape and data type
    * Added tests to make sure measured bias is correct within machine precision limits for an input array of all zero, and correct within the specified tolerance for a normal (hvoff) distribution.
    * Removed old/unnecessary comments & print statements
* `mocks.py`:
    * Fixed a bug that caused some mock data to be generated as integer datatype.

Example: performance for gaussian input data is as expected!
![image](https://github.com/roman-corgi/corgidrp/assets/74611610/2168ec73-8d49-4ad1-a328-49d25cb99255)

![image](https://github.com/roman-corgi/corgidrp/assets/74611610/2db7b43f-b30f-40af-851d-00253145e6fd)

Just let me know if you have any thoughts/edits/questions!