### PR TITLE
bug_fixes_related to dark.err being only 2D

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -206,9 +206,11 @@ class Image():
                 elif len(hdulist)>2:
                     self.err = hdulist[2].data
                     self.err_hdr = hdulist[2].header
+                    if self.err.ndim == 2:
+                        self.err = self.err.reshape((1,)+self.err.shape)
                 else:
                     self.err = np.zeros((1,)+self.data.shape)
-
+           
                 if dq is not None:
                     if np.shape(self.data) != np.shape(dq):
                         raise ValueError("The shape of dq is {0} while we are expecting shape {1}".format(dq.shape, self.data.shape))

--- a/corgidrp/detector.py
+++ b/corgidrp/detector.py
@@ -23,6 +23,7 @@ def create_dark_calib(dark_dataset):
     
     # determine the standard error of the mean: stddev/sqrt(n_frames)
     new_dark.err = np.nanstd(dark_dataset.all_data, axis=0)/np.sqrt(len(dark_dataset))
+    new_dark.err = new_dark.err.reshape((1,)+new_dark.err.shape) #Get it into the right dimensions
 
     return new_dark
 

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -46,7 +46,7 @@ def dark_subtraction(input_dataset, dark_frame):
     
     # propagate the error of the dark frame
     if hasattr(dark_frame, "err"):
-        darksub_dataset.add_error_term(dark_frame.err, "dark_error")   
+        darksub_dataset.add_error_term(dark_frame.err[0], "dark_error")   
     else:
         raise Warning("no error attribute in the dark frame")
     

--- a/tests/test_dark_sub.py
+++ b/tests/test_dark_sub.py
@@ -45,7 +45,7 @@ def test_dark_sub():
     assert np.mean(dark_frame.data) == pytest.approx(150, abs=1e-2)
     
     # check that the error is determined correctly
-    assert np.array_equal(np.std(dark_dataset.all_data, axis = 0)/np.sqrt(len(dark_dataset)), dark_frame.err)
+    assert np.array_equal(np.std(dark_dataset.all_data, axis = 0)/np.sqrt(len(dark_dataset)), dark_frame.err[0])
     
     # save dark
     calibdir = os.path.join(os.path.dirname(__file__), "testcalib")


### PR DESCRIPTION
It turns out that when we create a new master Dark calibration file, letting it have a 2D error term, rather than a 3D error, can cause errors, in part because of the new ability to turn off tracking of the individual error terms. I suggest this bug fix that increase the dimension of the error array just after creation. There were a couple places where I had to include [0]s to address the new zeroth dimension. 