### PR TITLE
Desmear step function

### DIFF
--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -1,5 +1,6 @@
 # A file that holds the functions that transmogrify l2a data to l2b data 
 import numpy as np
+import corgidrp.detector as detector
 
 def add_photon_noise(input_dataset):
     """

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -160,7 +160,10 @@ def flat_division(input_dataset, master_flat):
 def desmear(input_dataset):
     """
 
-    Desmear data frames.
+    EXCAM has no shutter, and so continues to illuminate the detector during
+    readout. This creates a "smearing" effect into the resulting images. The
+    desmear function corrects for this effect. There are a small number of use
+    cases for not desmearing data (e.g. time-varying raster data).
 
     Args:
         input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -20,7 +20,6 @@ def add_photon_noise(input_dataset):
         frame.add_error_term(np.sqrt(frame.data), "photnoise_error")
     
     new_all_err = np.array([frame.err for frame in phot_noise_dataset.frames])        
-                
     history_msg = "photon noise propagated to error map"
     # update the output dataset
     phot_noise_dataset.update_after_processing_step(history_msg, new_all_err = new_all_err)
@@ -174,8 +173,7 @@ def desmear(input_dataset):
     data = input_dataset.copy()
     data_cube = data.all_data
 
-    ##rowreadtime_sec = detector.get_rowreadtime_sec()
-    rowreadtime_sec = 223.5e-6
+    rowreadtime_sec = detector.get_rowreadtime_sec()
 
     for i in range(data_cube.shape[0]):
         exptime_sec = float(data[i].ext_hdr['EXPTIME'])
@@ -185,7 +183,7 @@ def desmear(input_dataset):
             columnsum = 0
             for s in range(r+1):
                 columnsum = columnsum + rowreadtime_sec/exptime_sec*((1 
-                + rowreadtime_sec/exptime_sec)**((s+1)-(s+1)-1))*data_cube[i,s,:]
+                + rowreadtime_sec/exptime_sec)**((s+1)-(r+1)-1))*data_cube[i,s,:]
             smear[r,:] = columnsum
         data_cube[i] -= smear
    

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -135,10 +135,11 @@ def desmear(input_dataset):
     data = input_dataset.copy()
     data_cube = data.all_data
 
-    rowreadtime_sec = detector.get_rowreadtime_sec()
+    ##rowreadtime_sec = detector.get_rowreadtime_sec()
+    rowreadtime_sec = 223.5e-6
 
     for i in range(data_cube.shape[0]):
-        exptime_sec = float(datacube[i].ext_hdr['EXPTIME'])
+        exptime_sec = float(data[i].ext_hdr['EXPTIME'])
         smear = np.zeros_like(data_cube[i])
         m = len(smear)
         for r in range(m):

--- a/tests/test_desmear.py
+++ b/tests/test_desmear.py
@@ -1,0 +1,46 @@
+import os
+import pytest
+import corgidrp
+import numpy as np
+from corgidrp.mocks import create_default_headers
+from corgidrp.l2a_to_l2b import desmear
+from corgidrp.data import Image, Dataset, BadPixelMap
+
+old_err_tracking = corgidrp.track_individual_errors
+
+data = np.ones([1024,1024])*2.
+err = np.ones([1024,1024]) *0.5
+dq = np.zeros([1024,1024], dtype = np.uint16)
+prhd, exthd = create_default_headers()
+
+def test_desmear():
+
+    corgidrp.track_individual_errors = True
+
+    print("test desmear step")
+
+    image1 = Image(data, pri_hdr = prhd, ext_hdr = exthd, err = err, dq = dq)
+    dataset = Dataset([image1])
+
+    corgidrp.track_individual_errors = old_err_tracking
+
+    data_cube = dataset.all_data # 3D data cube for all frames in the dataset
+    dq_cube = dataset.all_dq # 3D DQ array cube for all frames in the dataset
+
+    # Add some smear effect? (Peter Williams)
+
+    history_msg = "Pixels affected by Smear added"
+    dataset.update_after_processing_step(history_msg, new_all_data=data_cube,
+        new_all_dq=dq_cube)
+
+    assert type(dataset) == corgidrp.data.Dataset
+
+    # Apply desmear correction
+    new_dataset = desmear(dataset)
+
+    assert type(new_dataset) == corgidrp.data.Dataset
+
+    # Test desmear correction (Peter Williams)
+    
+
+    

--- a/tests/test_desmear.py
+++ b/tests/test_desmear.py
@@ -10,47 +10,53 @@ from corgidrp.data import Image, Dataset, BadPixelMap
 
 old_err_tracking = corgidrp.track_individual_errors
 
-##rowreadtime_sec = detector.get_rowreadtime_sec()
-rowreadtime_sec = 223.5e-6
-
-data = np.ones([1024,1024])
-err = np.ones([1024,1024]) *0.5
-dq = np.zeros([1024,1024], dtype = np.uint16)
-prhd, exthd = create_default_headers()
-
 def test_desmear():
     # Tolerance for comparisons
-    tol = 1e-13
+    tol = 1e-12
 
     corgidrp.track_individual_errors = True
 
-    print("test desmear step")
+    print("Testing desmear step function")
 
-    image1 = Image(data, pri_hdr = prhd, ext_hdr = exthd, err = err, dq = dq)
-    dataset = Dataset([image1])
+    rowreadtime_sec = detector.get_rowreadtime_sec()
 
-    corgidrp.track_individual_errors = old_err_tracking
+    #make a flux map
+    size = 1024
+    background_flux = 10
+    foreground_flux = 100
+    xx, yy = np.mgrid[:size, :size]
+    circle = ((xx - size//2)**2 + (yy - size//2)**2 ) < (size//4)**2
+    flux = background_flux * np.ones([size,size]) + (foreground_flux - background_flux) * circle
 
-    data_cube = dataset.all_data # 3D data cube for all frames in the dataset
-    dq_cube = dataset.all_dq # 3D DQ array cube for all frames in the dataset
+    #make a truth frame
+    err = np.ones([1024,1024]) *0.5
+    dq = np.zeros([1024,1024], dtype = np.uint16)
+    prhd, exthd = create_default_headers()
+    e_t=exthd['EXPTIME']
+    unsmeared_frame = e_t*flux
 
-    # Add some smear effect
-    e_t=60
-    data_cube_smear = e_t*data_cube + rowreadtime_sec
+    #simulate the smearing
+    smear = np.zeros_like(flux)
+    m = len(smear)
+    for r in range(m):
+        columnsum = 0
+        for i in range(r+1):
+            columnsum = columnsum + rowreadtime_sec*flux[i,:] 
+        smear[r,:] = columnsum
+    smeared_frame = unsmeared_frame + smear
 
-    history_msg = "Added pixels affected by smearing"
-    dataset.update_after_processing_step(history_msg, new_all_data=data_cube_smear,
-        new_all_dq=dq_cube)
-
-    assert type(dataset) == corgidrp.data.Dataset
+    image1 = Image(smeared_frame, pri_hdr = prhd, ext_hdr = exthd, err = err,         dq = dq)
+    dataset_smeared = Dataset([image1])
+    
+    assert type(dataset_smeared) == corgidrp.data.Dataset
 
     # Apply desmear correction
-    dataset_desmear = desmear(dataset)
+    dataset_desmear = desmear(dataset_smeared)
 
     assert type(dataset_desmear) == corgidrp.data.Dataset
 
-#    assert(np.max(np.abs(desmeared_frame - i1)) < tol)
-    
+    assert(np.max(np.abs(dataset_desmear.all_data[0] - unsmeared_frame)) < tol)
+
 if __name__ == '__main__':
     test_desmear()
     

--- a/tests/test_desmear.py
+++ b/tests/test_desmear.py
@@ -2,18 +2,25 @@ import os
 import pytest
 import corgidrp
 import numpy as np
-from corgidrp.mocks import create_default_headers
+import corgidrp.detector as detector
+from astropy.time import Time
 from corgidrp.l2a_to_l2b import desmear
+from corgidrp.mocks import create_default_headers
 from corgidrp.data import Image, Dataset, BadPixelMap
 
 old_err_tracking = corgidrp.track_individual_errors
 
-data = np.ones([1024,1024])*2.
+##rowreadtime_sec = detector.get_rowreadtime_sec()
+rowreadtime_sec = 223.5e-6
+
+data = np.ones([1024,1024])
 err = np.ones([1024,1024]) *0.5
 dq = np.zeros([1024,1024], dtype = np.uint16)
 prhd, exthd = create_default_headers()
 
 def test_desmear():
+    # Tolerance for comparisons
+    tol = 1e-13
 
     corgidrp.track_individual_errors = True
 
@@ -27,20 +34,23 @@ def test_desmear():
     data_cube = dataset.all_data # 3D data cube for all frames in the dataset
     dq_cube = dataset.all_dq # 3D DQ array cube for all frames in the dataset
 
-    # Add some smear effect? (Peter Williams)
+    # Add some smear effect
+    e_t=60
+    data_cube_smear = e_t*data_cube + rowreadtime_sec
 
-    history_msg = "Pixels affected by Smear added"
-    dataset.update_after_processing_step(history_msg, new_all_data=data_cube,
+    history_msg = "Added pixels affected by smearing"
+    dataset.update_after_processing_step(history_msg, new_all_data=data_cube_smear,
         new_all_dq=dq_cube)
 
     assert type(dataset) == corgidrp.data.Dataset
 
     # Apply desmear correction
-    new_dataset = desmear(dataset)
+    dataset_desmear = desmear(dataset)
 
-    assert type(new_dataset) == corgidrp.data.Dataset
+    assert type(dataset_desmear) == corgidrp.data.Dataset
 
-    # Test desmear correction (Peter Williams)
+#    assert(np.max(np.abs(desmeared_frame - i1)) < tol)
     
-
+if __name__ == '__main__':
+    test_desmear()
     

--- a/tests/test_desmear.py
+++ b/tests/test_desmear.py
@@ -14,7 +14,7 @@ def test_desmear():
     # Tolerance for comparisons
     tol = 1e-12
 
-    corgidrp.track_individual_errors = True
+    corgidrp.track_individual_errors = False
 
     print("Testing desmear step function")
 


### PR DESCRIPTION
Now that detetcor has the method to get rowreadtime, I am requesting the review of the desmearing step. It has a unit test associated to it: It checks data types and that the result of desmearing a smeared frame of 1024x1024 elements is equivalent within 1e-12 absolute error. Let me know any changes you'd like and any further tests. 