### PR TITLE
Add hash function to data

### DIFF
--- a/corgidrp/caldb.py
+++ b/corgidrp/caldb.py
@@ -16,6 +16,7 @@ column_names = [
     "EXPTIME",
     "Files Used",
     "Date Created",
+    "Hash",
     "DRPVERSN",
     "OBSID",
     "NAXIS1",
@@ -114,6 +115,8 @@ class CalDB:
 
         obsid = entry.pri_hdr["OBSID"]
 
+        hash_val = entry.get_hash()
+
         # this only works for 2D images. may need to adapt for non-2D calibration frames
         naxis1 = entry.data.shape[-1]
         naxis2 = entry.data.shape[-2]
@@ -125,6 +128,7 @@ class CalDB:
             exptime,
             files_used,
             date_created,
+            hash_val,
             drp_version,
             obsid,
             naxis1,

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -441,6 +441,22 @@ class Image():
         # record history since 2-D error map doesn't track individual terms
         self.err_hdr['HISTORY'] = "Added error term: {0}".format(err_name)
 
+    def get_hash(self):
+        """
+        Computes the hash of the data, err, and dq. Does not use the header information.
+
+        Returns:
+            str: the hash of the data, err, and dq
+        """
+        data_bytes = self.data.data.tobytes()
+        err_bytes = self.err.data.tobytes()
+        dq_bytes = self.dq.data.tobytes()
+
+        total_bytes = data_bytes + err_bytes + dq_bytes
+
+        return int(hash(total_bytes))
+
+
 class Dark(Image):
     """
     Dark calibration frame for a given exposure time.

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -454,7 +454,7 @@ class Image():
 
         total_bytes = data_bytes + err_bytes + dq_bytes
 
-        return int(hash(total_bytes))
+        return str(hash(total_bytes))
 
 
 class Dark(Image):

--- a/tests/test_err_dq.py
+++ b/tests/test_err_dq.py
@@ -223,14 +223,28 @@ def test_hashing():
     Test hashing works on data, err, and dq at the same time
     Two images with same data should be the same
     """
+    # identical images should get the same hash
     image1 = Image(data, err = err, dq = dq, pri_hdr = prhd, ext_hdr = exthd)
     image2 = Image(np.copy(data), err = np.copy(err), dq = np.copy(dq), pri_hdr = prhd, ext_hdr = exthd)
 
     assert image1.get_hash() == image2.get_hash()
 
+    # modifying the data should result in different hashes
     image2.data += 1
 
     assert image1.get_hash() != image2.get_hash()
+
+    # take image 2 and modify the error. should be different hash from before
+    old_hash = image2.get_hash()
+
+    image2.err += 1
+    assert old_hash != image2.get_hash()
+
+    # take image 2 and modify the dq frame. should be different hash from before
+    old_hash = image2.get_hash()
+
+    image2.dq[0] = 1
+    assert old_hash != image2.get_hash()
 
 def teardown_module():
     """

--- a/tests/test_err_dq.py
+++ b/tests/test_err_dq.py
@@ -218,6 +218,20 @@ def test_err_array_sizes():
     dark_frame.save(filedir=calibdir, filename=dark_filename)
     testcaldb.scan_dir_for_new_entries(calibdir)
     
+def test_hashing():
+    """
+    Test hashing works on data, err, and dq at the same time
+    Two images with same data should be the same
+    """
+    image1 = Image(data, err = err, dq = dq, pri_hdr = prhd, ext_hdr = exthd)
+    image2 = Image(np.copy(data), err = np.copy(err), dq = np.copy(dq), pri_hdr = prhd, ext_hdr = exthd)
+
+    assert image1.get_hash() == image2.get_hash()
+
+    image2.data += 1
+
+    assert image1.get_hash() != image2.get_hash()
+
 def teardown_module():
     """
     Runs automatically at the end. ONLY IN PYTEST
@@ -238,6 +252,7 @@ if __name__ == '__main__':
     test_add_error_term()
     test_err_dq_dataset()
     test_get_masked_data()
+    test_hashing()
     
     for i in range(3):
         os.remove('test_image{0}.fits'.format(i))


### PR DESCRIPTION
We now get obtain a unique str for any Image class that is a hash of the data, err, and dq maps. This is useful to quickly see in the caldb if any two entries are functionally the same. We aren't using it in the caldb yet for selection/matching, but we have the option to now. 

Should be pretty straightforward but let me know if there are any comments. 