### PR TITLE
A proposal for how to add more flexible hdus without hardcoding attributes

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -265,7 +265,7 @@ class Image():
         filedir (str): the file directory on disk where this image is to be/already saved.
         filepath (str): full path to the file on disk (if it exists)
     """
-    def __init__(self, data_or_filepath, pri_hdr=None, ext_hdr=None, err = None, dq = None, bias=None, err_hdr = None, dq_hdr = None, bias_hdr=None):
+    def __init__(self, data_or_filepath, pri_hdr=None, ext_hdr=None, err = None, dq = None, err_hdr = None, dq_hdr = None, input_hdulist = None:
         if isinstance(data_or_filepath, str):
             # a filepath is passed in
             with fits.open(data_or_filepath) as hdulist:
@@ -278,7 +278,7 @@ class Image():
                 self.data = first_hdu.data
 
                 #A list of extensions
-                hdu_names = [hdu.name for hdu in hdulist]
+                self.hdu_names = [hdu.name for hdu in hdulist]
 
                 # we assume that if the err and dq array is given as parameter they supersede eventual err and dq extensions
                 if err is not None:
@@ -289,8 +289,7 @@ class Image():
                         self.err = err
                     else:
                         self.err = err.reshape((1,)+err.shape)
-                # we assume that the ERR extension is index 2 of hdulist
-                elif "ERR" in hdu_names:
+                elif "ERR" in self.hdu_names:
                     err_hdu = hdulist.pop("ERR")
                     self.err = err_hdu.data
                     self.err_hdr = err_hdu.header
@@ -303,24 +302,31 @@ class Image():
                     if np.shape(self.data) != np.shape(dq):
                         raise ValueError("The shape of dq is {0} while we are expecting shape {1}".format(dq.shape, self.data.shape))
                     self.dq = dq
-                # we assume that the DQ extension is index 3 of hdulist
-                elif "DQ" in hdu_names:
+                
+                elif "DQ" in self.hdu_names:
                     dq_hdu = hdulist.pop("DQ")
                     self.dq = dq_hdu.data
                     self.dq_hdr = dq_hdu.header
                 else:
                     self.dq = np.zeros(self.data.shape, dtype = int)
 
-                if bias is not None:
-                    if (np.shape(self.data)[0],) != np.shape(bias):
-                        raise ValueError("The shape of bias is {0} while we are expecting shape {1}".format(bias.shape, self.data.shape))
-                    self.bias = bias
-                # we assume that the bias extension is index 4 of hdulist
-                elif len(hdulist)>4:
-                    self.bias = hdulist[4].data
-                    self.bias_hdr = hdulist[4].header
-                else:
-                    self.bias = np.zeros(self.data.shape[0], dtype = np.float32)
+
+                if hdulist is not None:
+                    self.hdu_list = input_hdulist
+                else: 
+                    #After the data, err and dqs are popped out, the rest of the hdulist is stored in hdu_list
+                    self.hdu_list = hdulist
+
+                # if bias is not None:
+                #     if (np.shape(self.data)[0],) != np.shape(bias):
+                #         raise ValueError("The shape of bias is {0} while we are expecting shape {1}".format(bias.shape, self.data.shape))
+                #     self.bias = bias
+                # # we assume that the bias extension is index 4 of hdulist
+                # elif len(hdulist)>4:
+                #     self.bias = hdulist[4].data
+                #     self.bias_hdr = hdulist[4].header
+                # else:
+                #     self.bias = np.zeros(self.data.shape[0], dtype = np.float32)
 
             # parse the filepath to store the filedir and filename
             filepath_args = data_or_filepath.split(os.path.sep)
@@ -367,6 +373,12 @@ class Image():
             else:
                 self.bias = np.zeros(self.data.shape[0], dtype = np.float32)
 
+            #Take the input hdulist or make a blank one. 
+            if input_hdulist is not None:
+                self.hdu_list = input_hdulist
+            else: 
+                self.hdu_list = fits.HDUList()
+
             # record when this file was created and with which version of the pipeline
             self.ext_hdr.set('DRPVERSN', corgidrp.version, "corgidrp version that produced this file")
             self.ext_hdr.set('DRPCTIME', time.Time.now().isot, "When this file was saved")
@@ -384,9 +396,9 @@ class Image():
         if not hasattr(self, 'dq_hdr'):
             self.dq_hdr = fits.Header()
         self.dq_hdr["EXTNAME"] = "DQ"
-        if not hasattr(self, 'bias_hdr'):
-            self.bias_hdr = fits.Header()
-        self.bias_hdr["EXTNAME"] = "BIAS"
+        # if not hasattr(self, 'bias_hdr'):
+        #     self.bias_hdr = fits.Header()
+        # self.bias_hdr["EXTNAME"] = "BIAS"
         
         # discard individual errors if we aren't tracking them but multiple error terms are passed in
         if not corgidrp.track_individual_errors and self.err.shape[0] > 1:
@@ -431,8 +443,11 @@ class Image():
         dqhdu = fits.ImageHDU(data=self.dq, header = self.dq_hdr)
         hdulist.append(dqhdu)
 
-        biashdu = fits.ImageHDU(data=self.bias, header = self.bias_hdr)
-        hdulist.append(biashdu)
+        for hdu in self.hdu_list:
+            hdulist.append(hdu)
+
+        # biashdu = fits.ImageHDU(data=self.bias, header = self.bias_hdr)
+        # hdulist.append(biashdu)
 
         hdulist.writeto(self.filepath, overwrite=True)
         hdulist.close()
@@ -466,14 +481,16 @@ class Image():
             new_data = np.copy(self.data)
             new_err = np.copy(self.err)
             new_dq = np.copy(self.dq)
-            new_bias = np.copy(self.bias)
+            # new_bias = np.copy(self.bias)
+            new_hdulist = self.hdu_list.copy()
         else:
             new_data = self.data # this is just pointer referencing
             new_err = self.err
             new_dq = self.dq
-            new_bias = self.bias
-        new_img = Image(new_data, pri_hdr=self.pri_hdr.copy(), ext_hdr=self.ext_hdr.copy(), err = new_err, dq = new_dq, bias=new_bias, 
-                        err_hdr = self.err_hdr.copy(), dq_hdr = self.dq_hdr.copy(), bias_hdr = self.bias_hdr.copy())
+            new_hdulist = self.hdu_list
+            # new_bias = self.bias
+        new_img = Image(new_data, pri_hdr=self.pri_hdr.copy(), ext_hdr=self.ext_hdr.copy(), err = new_err, dq = new_dq, input_hdulist = new_hdulist,
+                        err_hdr = self.err_hdr.copy(), dq_hdr = self.dq_hdr.copy())
 
         # annoying, but we got to manually update some parameters. Need to keep track of which ones to update
         new_img.filename = self.filename
@@ -548,8 +565,6 @@ class Image():
         # record history since 2-D error map doesn't track individual terms
         self.err_hdr['HISTORY'] = "Errors rescaled by: {0}".format(err_name)    
 
-    
-
     def get_hash(self):
         """
         Computes the hash of the data, err, and dq. Does not use the header information.
@@ -564,6 +579,23 @@ class Image():
         total_bytes = data_bytes + err_bytes + dq_bytes
 
         return str(hash(total_bytes))
+
+    def add_extension_hdu(self, name, data = None, header=None):
+        """
+
+        Create a new hdu extension and append it to the hdu_list
+
+        Args:
+            name (str): The name of the new extension
+            data (array, optional): Some kind of data. Defaults to None.
+            header (astropy.io.fits.Header, optional): _description_. Defaults to None.
+        """
+        new_hdu = fits.ImageHDU(data=data, header=header, name=name)
+
+        if name in self.hdu_names:
+            raise ValueError("Extension name already exists in HDU list")
+        else: 
+            self.hdu_list.append(new_hdu)
 
 
 class Dark(Image):

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -961,6 +961,8 @@ class DetectorParams(Image):
             self.err_hdr = fits.Header()
             self.dq_hdr = fits.Header()
 
+            self.hdu_list = fits.HDUList()
+
         # make a dictionary that's easy to use
         self.params = {}
         # load back in all the values from the header

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -925,7 +925,7 @@ class DetectorParams(Image):
             # run the image class contructor
             super().__init__(data_or_filepath)
 
-            # double check that this is actually a bad pixel map that got read in
+            # double check that this is actually a DetectorParams file that got read in
             # since if only a filepath was passed in, any file could have been read in
             if 'DATATYPE' not in self.ext_hdr or self.ext_hdr['DATATYPE'] != 'DetectorParams':
                 raise ValueError("File that was loaded was not a DetectorParams file.")

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -108,7 +108,8 @@ def prescan_biassub(input_dataset, bias_offset=0., return_full_frame=False):
         frame.data = out_frames_data_arr[i]
         frame.err = out_frames_err_arr[i]
         frame.dq = out_frames_dq_arr[i]
-        frame.bias = out_frames_bias_arr[i]
+        # frame.bias = out_frames_bias_arr[i]
+        frame.add_extension_hdu("BIAS",data=out_frames_bias_arr[i])
 
     # Add new error component from this step to each frame using the Dataset class method
     output_dataset.add_error_term(np.array(new_err_list),"prescan_bias_sub")

--- a/tests/test_prescan_sub.py
+++ b/tests/test_prescan_sub.py
@@ -295,11 +295,16 @@ def test_prescan_sub():
             
             # Check that bias extension has the right size, dtype
             for i, frame in enumerate(output_dataset):
+
+                try: 
+                    frame_bias = frame.hdu_list['BIAS'].data
+                except KeyError:
+                    raise Exception(f"BIAS extension not found in frame {i}.")
                 
-                if frame.bias.shape != (frame.data.shape[0],):
+                if frame_bias.shape != (frame.data.shape[0],):
                     raise Exception(f"Bias of frame {i} has shape {frame.bias.shape} when we expected {(frame.data.shape[0],)}.")
                 
-                if frame.bias.dtype != np.float32:
+                if frame_bias.dtype != np.float32:
                     raise Exception(f"Bias of frame {i} does not have datatype np.float32.")
             
             # Check that corgiDRP and II&T pipeline produce the same result
@@ -359,8 +364,13 @@ def test_bias_zeros_frame():
             if np.max(np.abs(output_dataset.all_err)) > tol:
                 raise Exception(f'Operating on all zero frame did not return all zero error.')           
             
-            for frame in dataset:
-                if np.max(np.abs(frame.bias)) > tol:
+            for frame in output_dataset:
+                try: 
+                    frame_bias = frame.hdu_list['BIAS'].data
+                except KeyError:
+                    raise Exception(f"BIAS extension not found in frame {i}.")
+                
+                if np.max(np.abs(frame_bias)) > tol:
                     raise Exception(f'Operating on all zero frame did not return all zero bias.')
 
 def test_bias_hvoff():
@@ -398,7 +408,7 @@ def test_bias_hvoff():
             output_dataset = prescan_biassub(dataset, return_full_frame=return_full_frame)
 
             # Compare bias measurement to expectation
-            if np.any(np.abs(output_dataset[0].bias - bval) > tol):
+            if np.any(np.abs(output_dataset[0].hdu_list['BIAS'].data - bval) > tol):
                 raise Exception(f'Higher than expected error in bias measurement for hvoff distribution.')
             
             # Compare error to expected standard error of the median
@@ -445,7 +455,7 @@ def test_bias_hvon():
 
         for return_full_frame in [True, False]:            
             output_dataset = prescan_biassub(dataset, return_full_frame=return_full_frame)
-            if np.any(np.abs(output_dataset[0].bias - bval) > tol):
+            if np.any(np.abs(output_dataset[0].hdu_list['BIAS'].data - bval) > tol):
                 raise Exception(f'Higher than expected error in bias measurement for hvon distribution.')
 
 def test_bias_uniform_value():

--- a/tests/test_prescan_sub.py
+++ b/tests/test_prescan_sub.py
@@ -364,11 +364,11 @@ def test_bias_zeros_frame():
             if np.max(np.abs(output_dataset.all_err)) > tol:
                 raise Exception(f'Operating on all zero frame did not return all zero error.')           
             
-            for frame in output_dataset:
+            for i,frame in enumerate(output_dataset):
                 try: 
                     frame_bias = frame.hdu_list['BIAS'].data
                 except KeyError:
-                    raise Exception(f"BIAS extension not found in frame {i}.")
+                    raise Exception(f"BIAS extension not found in frame {i}.".format(i))
                 
                 if np.max(np.abs(frame_bias)) > tol:
                     raise Exception(f'Operating on all zero frame did not return all zero bias.')


### PR DESCRIPTION
## Describe your changes

I've added an `hdu_list` attribute to the `Image` class that allows us to flexibly add new HDUs to an Image without having to hardcode in attributes, such as how we are currently treating `Image.bias`. In fact, this PR demonstrates the functionality by completely replacing `Image.bias`. Part of the motivation for this came up in a conversation with @neilzim about future spectroscopic dataset. There is a new `Image.add_extension_hdu()` function. 

Another advantage of this implementation is that means that if we decide at some point we no longer need to carry around some information then we can drop HDUs, e.g. when saving data to a new level. For example, do level 4 data products need to drag around the pre-scan bias information?


## Type of change

- New feature (non-breaking change which adds functionality)


## Reference any relevant issues (don't forget the #)

If we decide to go this route it will affect several current PRs, such as PR #116, PR #105, as it will provide a convenient way to attach new HDUs (e.g. the PTC for the KGain class). Its also relevant for issue #112. 


## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
