### PR TITLE
end-to-end processing of L1 to L2b 

### DIFF
--- a/corgidrp/caldb.py
+++ b/corgidrp/caldb.py
@@ -30,7 +30,8 @@ labels = {data.Dark: "Dark",
           data.BadPixelMap: "BadPixelMap",
           data.KGain : "KGain",
           data.DetectorNoiseMaps: "DetectorNoiseMaps",
-          data.DetectorParams : "DetectorParams"}
+          data.DetectorParams : "DetectorParams",
+          data.FlatField : "FlatField"}
 
 class CalDB:
     """
@@ -252,6 +253,9 @@ class CalDB:
             ]
         else:
             options = calibdf
+
+        if len(options) == 0:
+            raise ValueError("No valid {0} calibration in caldb located at {1}".format(dtype_label, self.filepath))
 
         # select the one closest in time
         result_index = np.abs(options["MJD"] - frame_dict["MJD"]).argmin()

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -282,7 +282,7 @@ def update_to_l2a(input_dataset):
     # check that we are running this on L1 data
     for orig_frame in input_dataset:
         if orig_frame.ext_hdr['DATA_LEVEL'] != "L1":
-            err_msg = "{0} needs to be L1 data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATA_LEVEL'] != "L1")
+            err_msg = "{0} needs to be L1 data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATA_LEVEL'])
             raise ValueError(err_msg)
 
     # we aren't altering the data

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -372,7 +372,7 @@ def update_to_l2b(input_dataset):
     # check that we are running this on L1 data
     for orig_frame in input_dataset:
         if orig_frame.ext_hdr['DATA_LEVEL'] != "L2a":
-            err_msg = "{0} needs to be L2a data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATA_LEVEL'] != "L1")
+            err_msg = "{0} needs to be L2a data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATA_LEVEL'])
             raise ValueError(err_msg)
 
     # we aren't altering the data

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -305,7 +305,7 @@ def correct_bad_pixels(input_dataset, bp_mask):
 
     for i in range(data_cube.shape[0]):
         # combine DQ and BP masks
-        bp_dq_mask = np.bitwise_or(dq_cube[i],bp_mask[0].data.astype(np.uint8))
+        bp_dq_mask = np.bitwise_or(dq_cube[i],bp_mask.data.astype(np.uint8))
         # mask affected pixels with NaN
         bp = np.where(bp_dq_mask != 0)
         data_cube[i, bp[0], bp[1]] = np.nan
@@ -356,3 +356,36 @@ def desmear(input_dataset, detector_params):
     data.update_after_processing_step(history_msg, new_all_data=data_cube)
 
     return data
+
+def update_to_l2b(input_dataset):
+    """
+    Updates the data level to L2b. Only works on L2a data.
+
+    Currently only checks that data is at the L2a level
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)
+
+    Returns:
+        corgidrp.data.Dataset: same dataset now at L2b-level
+    """
+    # check that we are running this on L1 data
+    for orig_frame in input_dataset:
+        if orig_frame.ext_hdr['DATA_LEVEL'] != "L2a":
+            err_msg = "{0} needs to be L2a data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATA_LEVEL'] != "L1")
+            raise ValueError(err_msg)
+
+    # we aren't altering the data
+    updated_dataset = input_dataset.copy(copy_data=False)
+
+    for frame in updated_dataset:
+        # update header
+        frame.ext_hdr['DATA_LEVEL'] = "L2b"
+        # update filename convention. The file convention should be
+        # "CGI_[dataleel_*]" so we should be same just replacing the just instance of L1
+        frame.filename = frame.filename.replace("_L2a_", "_L2b_", 1)
+
+    history_msg = "Updated Data Level to L2b"
+    updated_dataset.update_after_processing_step(history_msg)
+
+    return updated_dataset

--- a/corgidrp/l2b_to_l3.py
+++ b/corgidrp/l2b_to_l3.py
@@ -29,3 +29,36 @@ def divide_by_exptime(input_dataset):
     """
 
     return input_dataset.copy()
+
+def update_to_l3(input_dataset):
+    """
+    Updates the data level to L3. Only works on L2b data.
+
+    Currently only checks that data is at the L2b level
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2b-level)
+
+    Returns:
+        corgidrp.data.Dataset: same dataset now at L3-level
+    """
+    # check that we are running this on L1 data
+    for orig_frame in input_dataset:
+        if orig_frame.ext_hdr['DATA_LEVEL'] != "L2b":
+            err_msg = "{0} needs to be L2b data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATA_LEVEL'])
+            raise ValueError(err_msg)
+
+    # we aren't altering the data
+    updated_dataset = input_dataset.copy(copy_data=False)
+
+    for frame in updated_dataset:
+        # update header
+        frame.ext_hdr['DATA_LEVEL'] = "L3"
+        # update filename convention. The file convention should be
+        # "CGI_[dataleel_*]" so we should be same just replacing the just instance of L1
+        frame.filename = frame.filename.replace("_L2b_", "_L3_", 1)
+
+    history_msg = "Updated Data Level to L3"
+    updated_dataset.update_after_processing_step(history_msg)
+
+    return updated_dataset

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -43,3 +43,36 @@ def do_psf_subtraction(input_dataset, reference_star_dataset=None):
     """
 
     return input_dataset.copy()
+
+def update_to_l4(input_dataset):
+    """
+    Updates the data level to L4. Only works on L3 data.
+
+    Currently only checks that data is at the L3 level
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L3-level)
+
+    Returns:
+        corgidrp.data.Dataset: same dataset now at L4-level
+    """
+    # check that we are running this on L1 data
+    for orig_frame in input_dataset:
+        if orig_frame.ext_hdr['DATA_LEVEL'] != "L3":
+            err_msg = "{0} needs to be L3 data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATA_LEVEL'])
+            raise ValueError(err_msg)
+
+    # we aren't altering the data
+    updated_dataset = input_dataset.copy(copy_data=False)
+
+    for frame in updated_dataset:
+        # update header
+        frame.ext_hdr['DATA_LEVEL'] = "L4"
+        # update filename convention. The file convention should be
+        # "CGI_[dataleel_*]" so we should be same just replacing the just instance of L1
+        frame.filename = frame.filename.replace("_L3_", "_L4_", 1)
+
+    history_msg = "Updated Data Level to L4"
+    updated_dataset.update_after_processing_step(history_msg)
+
+    return updated_dataset

--- a/corgidrp/recipe_templates/l1_to_l2b.json
+++ b/corgidrp/recipe_templates/l1_to_l2b.json
@@ -1,0 +1,77 @@
+{
+    "name" : "l1_to_l2b",
+    "template" : true,
+    "drpconfig" : {
+        "track_individual_errors" : false
+    },
+    "inputs" : [],
+    "outputdir" : "",
+    "steps" : [
+        {
+            "name" : "prescan_biassub",
+            "keywords" : {
+                "return_full_frame" : false
+            }
+        },
+        {
+            "name" : "detect_cosmic_rays",
+            "calibs" : {
+                "DetectorParams" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "correct_nonlinearity",
+            "calibs" : {
+                "NonLinearityCalibration" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "update_to_l2a"
+        },
+        {
+            "name" : "save"
+        },
+        {
+            "name" : "convert_to_electrons",
+            "calibs" : {
+                "KGain" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "em_gain_division"
+        },
+        {
+            "name" : "dark_subtraction",
+            "calibs" : {
+                "DetectorNoiseMaps" : "AUTOMATIC"
+            },
+            "keywords" : {
+                "outputdir" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "desmear",
+            "calibs" : {
+                "DetectorParams" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "flat_division",
+            "calibs" : {
+                "FlatField" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "correct_bad_pixels",
+            "calibs" : {
+                "BadPixelMap" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "update_to_l2b"
+        },
+        {
+            "name" : "save"
+        }
+    ]
+}

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -5,17 +5,28 @@ import corgidrp
 import corgidrp.data as data
 import corgidrp.caldb as caldb
 import corgidrp.l1_to_l2a
+import corgidrp.l2a_to_l2b
 
 all_steps = {
     "prescan_biassub" : corgidrp.l1_to_l2a.prescan_biassub,
     "detect_cosmic_rays" : corgidrp.l1_to_l2a.detect_cosmic_rays,
     "correct_nonlinearity" : corgidrp.l1_to_l2a.correct_nonlinearity,
-    "update_to_l2a" : corgidrp.l1_to_l2a.update_to_l2a
+    "update_to_l2a" : corgidrp.l1_to_l2a.update_to_l2a,
+    "add_photon_noise" : corgidrp.l2a_to_l2b.add_photon_noise,
+    "dark_subtraction" : corgidrp.l2a_to_l2b.dark_subtraction,
+    "flat_division" : corgidrp.l2a_to_l2b.flat_division,
+    "frame_select" : corgidrp.l2a_to_l2b.frame_select,
+    "convert_to_electrons" : corgidrp.l2a_to_l2b.convert_to_electrons,
+    "em_gain_division" : corgidrp.l2a_to_l2b.em_gain_division,
+    "cti_correction" : corgidrp.l2a_to_l2b.cti_correction,
+    "correct_bad_pixels" : corgidrp.l2a_to_l2b.correct_bad_pixels,
+    "desmear" : corgidrp.l2a_to_l2b.desmear,
+    "update_to_l2b" : corgidrp.l2a_to_l2b.update_to_l2b
 }
 
 recipe_dir = os.path.join(os.path.dirname(__file__), "recipe_templates")
 
-def walk_corgidrp(filelist, CPGS_XML_filepath, outputdir):
+def walk_corgidrp(filelist, CPGS_XML_filepath, outputdir, template=None):
     """
     Automatically create a recipe and process the input filelist.
     Does both the `autogen_recipe` and `run_recipe` steps.
@@ -24,12 +35,18 @@ def walk_corgidrp(filelist, CPGS_XML_filepath, outputdir):
         filelist (list of str): list of filepaths to files
         CPGS_XML_filepath (str): path to CPGS XML file for this set of files in filelist
         outputdir (str): output directory folderpath
+        template (str or json): custom template. either the full json file, or a filename of
+                                a template that's already in the recipe_templates folder
 
     Returns:
         json: the JSON recipe that was used for processing
     """
+    if isinstance(template, str):
+        recipe_filepath = os.path.join(recipe_dir, template)
+        template = json.load(open(recipe_filepath, 'r'))
+
     # generate recipe
-    recipe = autogen_recipe(filelist, outputdir)
+    recipe = autogen_recipe(filelist, outputdir, template=template)
 
     # process_recipe
     run_recipe(recipe)
@@ -69,7 +86,9 @@ def autogen_recipe(filelist, outputdir, template=None):
 
     recipe["outputdir"] = outputdir
 
-    ## Populate calibration files that need to be automatically populated
+    ## Populate default values
+    ## This includes calibration files that need to be automatically determined
+    ## This also includes the dark subtraction outputdir for synthetic darks
     this_caldb = caldb.CalDB()
     for step in recipe["steps"]:
         if "calibs" in step:
@@ -81,6 +100,9 @@ def autogen_recipe(filelist, outputdir, template=None):
                     best_cal_file = this_caldb.get_calib(first_frame, calib_dtype)
                     # set calibration file to this one
                     step["calibs"][calib] = best_cal_file.filepath
+        if step["name"].lower() == "dark_subtraction":
+            if step["keywords"]["outputdir"].upper() == "AUTOMATIC":
+                step["keywords"]["outputdir"] = recipe["outputdir"]
 
     return recipe
 
@@ -99,7 +121,7 @@ def guess_template(image):
         if image.pri_hdr['OBSTYPE'] == "ENG":
             recipe_filename = "l1_to_l2a_eng.json"
         else:
-            recipe_filename = "l1_to_l2a_basic.json"
+            recipe_filename = "l1_to_l2b.json"
     else:
         raise NotImplementedError()
 
@@ -137,8 +159,11 @@ def run_recipe(recipe, save_recipe_file=True):
         with open(recipe_filepath, "w") as json_file:
             json.dump(recipe, json_file, indent=4)
 
+    tot_steps = len(recipe["steps"])
+
     # execute each pipeline step
-    for step in recipe["steps"]:
+    for i, step in enumerate(recipe["steps"]):
+        print("Walker step {0}/{1}: {2}".format(i+1, tot_steps, step["name"]))
         if step["name"].lower() == "save":
             # special save instruction
             curr_dataset.save(recipe["outputdir"])
@@ -146,7 +171,6 @@ def run_recipe(recipe, save_recipe_file=True):
         else:
             step_func = all_steps[step["name"]]
 
-            # TODO: handle calibrations; any other possible required args?
             other_args = ()
             if "calibs" in step:
                 for calib in step["calibs"]:

--- a/tests/e2e_tests/l1_to_l2a_e2e.py
+++ b/tests/e2e_tests/l1_to_l2a_e2e.py
@@ -2,6 +2,7 @@ import os
 import glob
 import numpy as np
 import astropy.time as time
+import astropy.io.fits as fits
 import corgidrp
 import corgidrp.data as data
 import corgidrp.mocks as mocks
@@ -13,16 +14,17 @@ corgidrp_dir = os.path.join(os.path.dirname(corgidrp.__file__), "..") # basedir 
 # paths (CHANGE THESE!!!)
 nonlin_path = "/home/jwang/Jason/Downloads/20240723_TVAC_data_for_DRP_Testing_LRS/nonlin_table_240322.txt"
 l1_datadir = "/home/jwang/Jason/Downloads/20240723_TVAC_data_for_DRP_Testing_LRS/input_data_TV-36/"
+l2a_datadir = "/home/jwang/Jason/Downloads/20240723_TVAC_data_for_DRP_Testing_LRS/input_data_TV-36/"
 outputdir = "./l1_to_l2a_output/"
 
 if not os.path.exists(outputdir):
     os.mkdir(outputdir)
 
 # define the raw science data to process
-all_l1_dat = glob.glob(os.path.join(l1_datadir, "*.fits"))
-all_l1_dat.sort()
-l1_data_filelist = all_l1_dat[:2] # just grab the first two files
-mock_nonlinear_filelist = all_l1_dat[-2:] # grab the last two real data to mock the nonlinearity file
+
+l1_data_filelist = [os.path.join(l1_datadir, "{0}.fits".format(i)) for i in [90499, 90500]] # just grab the first two files
+mock_cal_filelist = [os.path.join(l1_datadir, "{0}.fits".format(i)) for i in [90526, 90527]] # grab the last two real data to mock the calibration 
+tvac_l2a_filelist = [os.path.join(l2a_datadir, "{0}.fits".format(i)) for i in [90528, 90530]] # just grab the first two files
 
 ###### Setup necessary calibration files
 # Create necessary calibration files
@@ -36,7 +38,7 @@ nonlin_dat = np.genfromtxt(nonlin_path, delimiter=",")
 pri_hdr, ext_hdr = mocks.create_default_headers()
 ext_hdr["DRPCTIME"] = time.Time.now().isot
 ext_hdr['DRPVERSN'] =  corgidrp.__version__
-mock_input_dataset = data.Dataset(mock_nonlinear_filelist)
+mock_input_dataset = data.Dataset(mock_cal_filelist)
 nonlinear_cal = data.NonLinearityCalibration(nonlin_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr,
                                              input_dataset=mock_input_dataset)
 nonlinear_cal.save(filedir=outputdir, filename="mock_nonlinearcal.fits" )
@@ -47,7 +49,44 @@ this_caldb.create_entry(nonlinear_cal)
 
 ####### Run the walker on some test_data
 
-walker.walk_corgidrp(l1_data_filelist, "", outputdir)
+walker.walk_corgidrp(l1_data_filelist, "", outputdir, template="l1_to_l2a_basic.json")
 
 # clean up by removing entry
 this_caldb.remove_entry(nonlinear_cal)
+
+
+##### Check against TVAC data
+new_l2a_filenames = [os.path.join(outputdir, "{0}.fits".format(i)) for i in [90499, 90500]]
+
+for new_filename, tvac_filename in zip(new_l2a_filenames, tvac_l2a_filelist):
+    img = data.Image(new_filename)
+
+    with fits.open(tvac_filename) as hdulist:
+        tvac_dat = hdulist[1].data
+    
+    diff = img.data - tvac_dat
+
+    assert np.all(np.abs(diff) < 1e-5)
+
+    # plotting script for debugging
+    import matplotlib.pylab as plt
+    fig = plt.figure(figsize=(10,3.5))
+    fig.add_subplot(131)
+    plt.imshow(img.data, vmin=-20, vmax=2000, cmap="viridis")
+    plt.title("corgidrp")
+    plt.xlim([500, 560])
+    plt.ylim([475, 535])
+
+    fig.add_subplot(132)
+    plt.imshow(tvac_dat, vmin=-20, vmax=2000, cmap="viridis")
+    plt.title("TVAC")
+    plt.xlim([500, 560])
+    plt.ylim([475, 535])
+
+    fig.add_subplot(133)
+    plt.imshow(diff, vmin=-0.01, vmax=0.01, cmap="inferno")
+    plt.title("difference")
+    plt.xlim([500, 560])
+    plt.ylim([475, 535])
+
+    plt.show()

--- a/tests/e2e_tests/l1_to_l2b_e2e.py
+++ b/tests/e2e_tests/l1_to_l2b_e2e.py
@@ -1,0 +1,148 @@
+import os
+import glob
+import numpy as np
+import astropy.time as time
+import astropy.io.fits as fits
+import corgidrp
+import corgidrp.data as data
+import corgidrp.mocks as mocks
+import corgidrp.walker as walker
+import corgidrp.caldb as caldb
+import corgidrp.detector as detector
+
+corgidrp_dir = os.path.join(os.path.dirname(corgidrp.__file__), "..") # basedir of entire corgidrp github repo
+
+# paths (CHANGE THESE!!!)
+processed_cal_path = "/home/jwang/Jason/Downloads/20240723_TVAC_data_for_DRP_Testing_LRS/"
+l1_datadir = "/home/jwang/Jason/Downloads/20240723_TVAC_data_for_DRP_Testing_LRS/input_data_TV-36/"
+l2b_datadir = "/home/jwang/Jason/Downloads/20240723_TVAC_data_for_DRP_Testing_LRS/input_data_TV-36/"
+outputdir = "./l1_to_l2b_output/"
+
+if not os.path.exists(outputdir):
+    os.mkdir(outputdir)
+
+# assume all cals are in the same directory
+nonlin_path = os.path.join(processed_cal_path, "nonlin_table_240322.txt")
+dark_path = os.path.join(processed_cal_path, "Dark_map_240322.fits")
+flat_path = os.path.join(processed_cal_path, "flat.fits")
+fpn_path = os.path.join(processed_cal_path, "FPN_map_240318.fits")
+cic_path = os.path.join(processed_cal_path, "CIC_map_240322.fits")
+bp_path = os.path.join(processed_cal_path, "bad_pix.fits")
+
+# define the raw science data to process
+
+l1_data_filelist = [os.path.join(l1_datadir, "{0}.fits".format(i)) for i in [90499, 90500]] # just grab the first two files
+mock_cal_filelist = [os.path.join(l1_datadir, "{0}.fits".format(i)) for i in [90526, 90527]] # grab the last two real data to mock the calibration 
+tvac_l2b_filelist = [os.path.join(l2b_datadir, "{0}.fits".format(i)) for i in [90529, 90531]] # just grab the first two files
+
+
+###### Setup necessary calibration files
+# Create necessary calibration files
+# we are going to make calibration files using
+# a combination of the II&T nonlinearty file and the mock headers from
+# our unit test version
+pri_hdr, ext_hdr = mocks.create_default_headers()
+ext_hdr["DRPCTIME"] = time.Time.now().isot
+ext_hdr['DRPVERSN'] =  corgidrp.__version__
+mock_input_dataset = data.Dataset(mock_cal_filelist)
+
+this_caldb = caldb.CalDB() # connection to cal DB
+
+# Nonlinearity calibration
+nonlin_dat = np.genfromtxt(nonlin_path, delimiter=",")
+nonlinear_cal = data.NonLinearityCalibration(nonlin_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr,
+                                             input_dataset=mock_input_dataset)
+nonlinear_cal.save(filedir=outputdir, filename="mock_nonlinearcal.fits" )
+this_caldb.create_entry(nonlinear_cal)
+
+# KGain
+kgain_val = 8.7
+kgain = data.KGain(np.array([[kgain_val]]), pri_hdr=pri_hdr, ext_hdr=ext_hdr, 
+                   input_dataset=mock_input_dataset)
+kgain.save(filedir=outputdir, filename="mock_kgain.fits")
+this_caldb.create_entry(kgain)
+
+# NoiseMap
+with fits.open(fpn_path) as hdulist:
+    fpn_dat = hdulist[0].data
+with fits.open(cic_path) as hdulist:
+    cic_dat = hdulist[0].data
+with fits.open(dark_path) as hdulist:
+    dark_dat = hdulist[0].data
+noise_map_dat_img = np.array([fpn_dat, cic_dat, dark_dat])
+noise_map_dat = np.zeros((3, detector.detector_areas['SCI']['frame_rows'], detector.detector_areas['SCI']['frame_cols']))
+rows, cols, r0c0 = detector.unpack_geom('SCI', 'image')
+noise_map_dat[:, r0c0[0]:r0c0[0]+rows, r0c0[1]:r0c0[1]+cols] = noise_map_dat_img
+noise_map_noise = np.zeros([1,] + list(noise_map_dat.shape))
+noise_map_dq = np.zeros(noise_map_dat.shape, dtype=int)
+err_hdr = fits.Header()
+err_hdr['BUNIT'] = 'detected EM electrons'
+ext_hdr['B_O'] = 0
+ext_hdr['B_O_ERR'] = 0
+noise_map = data.DetectorNoiseMaps(noise_map_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr,
+                                   input_dataset=mock_input_dataset, err=noise_map_noise,
+                                   dq = noise_map_dq, err_hdr=err_hdr)
+noise_map.save(filedir=outputdir, filename="mock_detnoisemaps.fits")
+this_caldb.create_entry(noise_map)
+
+## Flat field
+with fits.open(flat_path) as hdulist:
+    flat_dat = hdulist[0].data
+flat = data.FlatField(flat_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=mock_input_dataset)
+flat.save(filedir=outputdir, filename="mock_flat.fits")
+this_caldb.create_entry(flat)
+
+# bad pixel map
+with fits.open(bp_path) as hdulist:
+    bp_dat = hdulist[0].data
+bp_map = data.BadPixelMap(bp_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=mock_input_dataset)
+bp_map.save(filedir=outputdir, filename="mock_bpmap.fits")
+this_caldb.create_entry(bp_map)
+
+####### Run the walker on some test_data
+
+walker.walk_corgidrp(l1_data_filelist, "", outputdir)
+
+
+# clean up by removing entry
+this_caldb.remove_entry(nonlinear_cal)
+this_caldb.remove_entry(kgain)
+this_caldb.remove_entry(noise_map)
+this_caldb.remove_entry(flat)
+this_caldb.remove_entry(bp_map)
+
+##### Check against TVAC data
+new_l2b_filenames = [os.path.join(outputdir, "{0}.fits".format(i)) for i in [90499, 90500]]
+
+for new_filename, tvac_filename in zip(new_l2b_filenames, tvac_l2b_filelist):
+    img = data.Image(new_filename)
+
+    with fits.open(tvac_filename) as hdulist:
+        tvac_dat = hdulist[1].data
+    
+    diff = img.data - tvac_dat
+
+    assert np.all(np.abs(diff) < 1e-5)
+
+    # plotting script for debugging
+    # import matplotlib.pylab as plt
+    # fig = plt.figure(figsize=(10,3.5))
+    # fig.add_subplot(131)
+    # plt.imshow(img.data, vmin=-0.01, vmax=45, cmap="viridis")
+    # plt.title("corgidrp")
+    # plt.xlim([500, 560])
+    # plt.ylim([475, 535])
+
+    # fig.add_subplot(132)
+    # plt.imshow(tvac_dat, vmin=-0.01, vmax=45, cmap="viridis")
+    # plt.title("TVAC")
+    # plt.xlim([500, 560])
+    # plt.ylim([475, 535])
+
+    # fig.add_subplot(133)
+    # plt.imshow(diff, vmin=-0.01, vmax=0.01, cmap="inferno")
+    # plt.title("difference")
+    # plt.xlim([500, 560])
+    # plt.ylim([475, 535])
+
+    # plt.show()

--- a/tests/test_badpixel_correction.py
+++ b/tests/test_badpixel_correction.py
@@ -48,12 +48,12 @@ def test_bad_pixels():
     row_bp_test=[546, 89, 123, 243, 447, 675]
     bp_mask = mocks.create_badpixelmap_files(filedir=datadir,
         col_bp=col_bp_test, row_bp=row_bp_test)
-    new_bp_mask = BadPixelMap(bp_mask.all_data, pri_hdr=bp_mask[0].pri_hdr.copy(),
+    new_bp_mask = BadPixelMap(bp_mask.all_data[0], pri_hdr=bp_mask[0].pri_hdr.copy(),
                      ext_hdr=bp_mask[0].ext_hdr.copy(), input_dataset=bp_mask)
 
     assert type(new_bp_mask) == corgidrp.data.BadPixelMap
 
-    new_dataset = correct_bad_pixels(dataset, bp_mask)
+    new_dataset = correct_bad_pixels(dataset, new_bp_mask)
 
     assert type(new_dataset) == corgidrp.data.Dataset
 

--- a/tests/test_caldb.py
+++ b/tests/test_caldb.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import corgidrp
 import corgidrp.caldb as caldb
 import corgidrp.data as data
@@ -119,6 +120,9 @@ def test_get_calib():
     auto_dark = testcaldb.get_calib(dark_dataset[2], data.Dark)
     assert(auto_dark.filepath == master_dark.filepath)
 
+    with pytest.raises(ValueError):
+        _ = testcaldb.get_calib(dark_dataset[2], data.DetectorNoiseMaps)
+        
     # reset everything
     os.remove(testcaldb_filepath)
 
@@ -149,4 +153,4 @@ def test_caldb_scan():
     os.remove(testcaldb_filepath)
 
 if __name__ == "__main__":
-    test_caldb_scan()
+    test_get_calib()

--- a/tests/test_data_levels.py
+++ b/tests/test_data_levels.py
@@ -1,0 +1,91 @@
+"""
+Test the data level specification
+"""
+import pytest
+import corgidrp.mocks as mocks
+import corgidrp.l1_to_l2a as l1_to_l2a
+import corgidrp.l2a_to_l2b as l2a_to_l2b
+import corgidrp.l2b_to_l3 as l2b_to_l3
+import corgidrp.l3_to_l4 as l3_to_l4
+
+def test_l1_to_l4():
+    """
+    Tests a successful upgrade of L1 to L4 in bookkeeping only
+    """
+    l1_dataset = mocks.create_prescan_files(obstype="SCI", numfiles=2)
+    # edit filenames
+    fname_template = "CGI_L1_100_0200001001001100001_20270101T120000_{0:03d}.fits"
+    for i, image in enumerate(l1_dataset):
+        image.filename = fname_template.format(i)
+
+    l2a_dataset = l1_to_l2a.update_to_l2a(l1_dataset)
+
+    for frame in l2a_dataset:
+        assert frame.ext_hdr['DATA_LEVEL'] == "L2a"
+        assert "L2a" in frame.filename
+    
+
+    l2b_dataset = l2a_to_l2b.update_to_l2b(l2a_dataset)
+
+    for frame in l2b_dataset:
+        assert frame.ext_hdr['DATA_LEVEL'] == "L2b"
+        assert "L2b" in frame.filename
+
+    l3_dataset = l2b_to_l3.update_to_l3(l2b_dataset)
+
+    for frame in l3_dataset:
+        assert frame.ext_hdr['DATA_LEVEL'] == "L3"
+        assert "L3" in frame.filename
+
+    l4_dataset = l3_to_l4.update_to_l4(l3_dataset)
+
+    for frame in l4_dataset:
+        assert frame.ext_hdr['DATA_LEVEL'] == "L4"
+        assert "L4" in frame.filename
+
+def test_l1_to_l2a_bad():
+    """
+    Tests an unsuccessful upgrade of L1 to L2a data because the input is not L1
+    """
+    l2a_dataset = mocks.create_dark_calib_files(numfiles=2)
+    for frame in l2a_dataset:
+        frame.ext_hdr['DATA_LEVEL'] = "L2a"
+    
+    # expect an exception
+    with pytest.raises(ValueError):
+        l2a_dataset_2 = l1_to_l2a.update_to_l2a(l2a_dataset)
+
+def test_l1a_to_l2b_bad():
+    """
+    Tests an unsuccessful upgrade because input is not L2a
+    """
+    l1_dataset = mocks.create_dark_calib_files(numfiles=2)
+    
+    # expect an exception
+    with pytest.raises(ValueError):
+        l2b_dataset = l2a_to_l2b.update_to_l2b(l1_dataset)
+
+def test_l2b_to_l3_bad():
+    """
+    Tests an unsuccessful upgrade because input is not L2b
+    """
+    l1_dataset = mocks.create_dark_calib_files(numfiles=2)
+    
+    # expect an exception
+    with pytest.raises(ValueError):
+        _ = l2b_to_l3.update_to_l3(l1_dataset)
+
+def test_l3_to_l4_bad():
+    """
+    Tests an unsuccessful upgrade because input is not L3
+    """
+    l1_dataset = mocks.create_dark_calib_files(numfiles=2)
+    
+    # expect an exception
+    with pytest.raises(ValueError):
+        _ = l3_to_l4.update_to_l4(l1_dataset)
+
+
+if __name__ == "__main__":
+    # test_l1_to_l4()
+    test_l1_to_l2a_bad()

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -4,12 +4,15 @@ Test the walker infrastructure to read and execute recipes
 import os
 import glob
 import json
+import numpy as np
 import astropy.time as time
+import astropy.io.fits as fits
 import corgidrp
 import corgidrp.data as data
 import corgidrp.mocks as mocks
 import corgidrp.caldb as caldb
 import corgidrp.walker as walker
+import corgidrp.detector as detector
 
 
 def test_autoreducing():
@@ -52,7 +55,8 @@ def test_autoreducing():
     CPGS_XML_filepath = "" # not yet implemented
 
     # generate recipe and run it
-    recipe = walker.walk_corgidrp(filelist, CPGS_XML_filepath, outputdir)
+    # basic l2a recipe to keep things simple
+    recipe = walker.walk_corgidrp(filelist, CPGS_XML_filepath, outputdir, template="l1_to_l2a_basic.json")
 
     # check that the output dataset is saved to the output dir
     # filenames have been updated to L2a. 
@@ -70,7 +74,97 @@ def test_autoreducing():
     # clean up
     mycaldb.remove_entry(new_nonlinearity)
 
+def test_auto_template_identification():
+    """
+    Tests the process of coming up with the right template and filling in calibration files
+    """
+    # create dirs
+    datadir = os.path.join(os.path.dirname(__file__), "simdata")
+    if not os.path.exists(datadir):
+        os.mkdir(datadir)
+    outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
+    if not os.path.exists(outputdir):
+        os.mkdir(outputdir)
 
+    # create simulated data
+    l1_dataset = mocks.create_prescan_files(filedir=datadir, obstype="SCI", numfiles=2)
+    # fake the emgain
+    for image in l1_dataset:
+        image.ext_hdr['EMGAIN'] = 1
+    # simulate the expected CGI naming convention
+    fname_template = "CGI_L1_100_0200001001001100001_20270101T120000_{0:03d}.fits"
+    for i, image in enumerate(l1_dataset):
+        image.filename = fname_template.format(i)
+    l1_dataset.save(datadir)
+    filelist = [frame.filepath for frame in l1_dataset]
+
+
+    ###### Setup necessary calibration files
+    # Create necessary calibration files
+    # we are going to make calibration files using
+    # a combination of the II&T nonlinearty file and the mock headers from
+    # our unit test version
+    pri_hdr, ext_hdr = mocks.create_default_headers()
+    ext_hdr["DRPCTIME"] = time.Time.now().isot
+    ext_hdr['DRPVERSN'] =  corgidrp.__version__
+    mock_input_dataset = data.Dataset(filelist)
+
+    this_caldb = caldb.CalDB() # connection to cal DB
+
+    # Nonlinearity calibration
+    new_nonlinearity = data.NonLinearityCalibration(os.path.join(os.path.dirname(__file__),"test_data",'nonlin_sample.fits'))
+    # fake the headers because this frame doesn't have the proper headers
+    new_nonlinearity.pri_hdr = pri_hdr
+    new_nonlinearity.ext_hdr = ext_hdr
+    this_caldb.create_entry(new_nonlinearity)
+
+    # KGain
+    kgain_val = 8.7
+    kgain = data.KGain(np.array([[kgain_val]]), pri_hdr=pri_hdr, ext_hdr=ext_hdr, 
+                    input_dataset=mock_input_dataset)
+    kgain.save(filedir=outputdir, filename="mock_kgain.fits")
+    this_caldb.create_entry(kgain)
+
+    # NoiseMap
+    noise_map_dat = np.zeros((3, detector.detector_areas['SCI']['frame_rows'], detector.detector_areas['SCI']['frame_cols']))
+    rows, cols, r0c0 = detector.unpack_geom('SCI', 'image')
+    noise_map_noise = np.zeros([1,] + list(noise_map_dat.shape))
+    noise_map_dq = np.zeros(noise_map_dat.shape, dtype=int)
+    err_hdr = fits.Header()
+    err_hdr['BUNIT'] = 'detected EM electrons'
+    ext_hdr['B_O'] = 0
+    ext_hdr['B_O_ERR'] = 0
+    noise_map = data.DetectorNoiseMaps(noise_map_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr,
+                                    input_dataset=mock_input_dataset, err=noise_map_noise,
+                                    dq = noise_map_dq, err_hdr=err_hdr)
+    noise_map.save(filedir=outputdir, filename="mock_detnoisemaps.fits")
+    this_caldb.create_entry(noise_map)
+
+    ## Flat field
+    flat_dat = np.ones((1024, 1024))
+    flat = data.FlatField(flat_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=mock_input_dataset)
+    flat.save(filedir=outputdir, filename="mock_flat.fits")
+    this_caldb.create_entry(flat)
+
+    # bad pixel map
+    bp_dat = np.zeros((1024, 1024), dtype=int)
+    bp_map = data.BadPixelMap(bp_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=mock_input_dataset)
+    bp_map.save(filedir=outputdir, filename="mock_bpmap.fits")
+    this_caldb.create_entry(bp_map)
+
+
+    ### Finally, test the recipe identification
+    recipe = walker.autogen_recipe(filelist, outputdir)
+
+    assert recipe['name'] == 'l1_to_l2b'
+    assert recipe['template'] == False
+
+    # now cleanup
+    this_caldb.remove_entry(new_nonlinearity)
+    this_caldb.remove_entry(kgain)
+    this_caldb.remove_entry(noise_map)
+    this_caldb.remove_entry(flat)
+    this_caldb.remove_entry(bp_map)
 
 if __name__ == "__main__":
     test_autoreducing()


### PR DESCRIPTION
## Describe your changes
Sorry, this one was kind of big.. 

 - End to end test for L1 to L2b (note this does not run automatically, since we have not cleared the TVAC data for release yet)
 - Updated L1 to L2a e2e test made for v0.1 sprint release to test against the TVAC outputs numerically 
 - Added new L1 to L2b recipe
 - `walker.walk_corgidrp` can take a specific recipe template as input
 - Improved testing of walker and caldb in prep for even more expanded functionality
 - Added new step functions to advance data levels to L2b, L3, and L4 along with associated unit tests
 - Fix bug in correct bad pixels step function (previously expecting the bad pixel map as a single Image dataset)

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)

Closes #90 

## Checklist before requesting a review
- [ ] I have linted my code
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
