### PR TITLE
Mocks should not access test_data dir

### DIFF
--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -291,11 +291,12 @@ def create_flatfield_dummy(filedir=None, numfiles=2):
     flatfield = data.Dataset(frames)
     return flatfield
 
-def create_nonlinear_dataset(filedir=None, numfiles=2,em_gain=2000):
+def create_nonlinear_dataset(nonlin_filepath, filedir=None, numfiles=2,em_gain=2000):
     """
     Create simulated data to non-linear data to test non-linearity correction.
 
     Args:
+        nonlin_filepath (str): path to FITS file containing nonlinear calibration data (e.g., tests/test_data/nonlin_sample.fits)
         filedir (str): (Optional) Full path to directory to save to.
         numfiles (int): Number of files in dataset.  Defaults to 2 (not creating the cal here, just testing the function)
         em_gain (int): The EM gain to use for the simulated data.  Defaults to 2000.
@@ -323,7 +324,7 @@ def create_nonlinear_dataset(filedir=None, numfiles=2,em_gain=2000):
         for x in range(size):
             np.random.seed(123+x); sim_data[:, x] = np.random.poisson(data_range[x], size).astype(np.float64)
 
-        non_linearity_correction = data.NonLinearityCalibration(os.path.join(os.path.dirname(os.path.abspath(__file__)),'..',"tests","test_data","nonlin_sample.fits"))
+        non_linearity_correction = data.NonLinearityCalibration(nonlin_filepath)
 
         #Apply the non-linearity to the data. When we correct we multiple, here when we simulate we divide
         sim_data /= detector.get_relgains(sim_data,em_gain,non_linearity_correction)

--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -336,11 +336,12 @@ def create_nonlinear_dataset(nonlin_filepath, filedir=None, numfiles=2,em_gain=2
     dataset = data.Dataset(frames)
     return dataset
 
-def create_cr_dataset(filedir=None, datetime=None, numfiles=2, em_gain=500, numCRs=5, plateau_length=10):
+def create_cr_dataset(nonlin_filepath, filedir=None, datetime=None, numfiles=2, em_gain=500, numCRs=5, plateau_length=10):
     """
     Create simulated non-linear data with cosmic rays to test CR detection.
 
     Args:
+        nonlin_filepath (str): path to FITS file containing nonlinear calibration data (e.g., tests/test_data/nonlin_sample.fits)
         filedir (str): (Optional) Full path to directory to save to.
         datetime (astropy.time.Time): (Optional) Date and time of the observations to simulate.
         numfiles (int): Number of files in dataset.  Defaults to 2 (not creating the cal here, just testing the function)
@@ -362,7 +363,7 @@ def create_cr_dataset(filedir=None, datetime=None, numfiles=2, em_gain=500, numC
     fwc_em_dn = detector_params.params['fwc_em'] / kgain
     fwc_pp_dn = detector_params.params['fwc_pp'] / kgain
     fwc = np.min([fwc_em_dn,em_gain*fwc_pp_dn])
-    dataset = create_nonlinear_dataset(filedir=None, numfiles=numfiles,em_gain=em_gain)
+    dataset = create_nonlinear_dataset(nonlin_filepath, filedir=None, numfiles=numfiles,em_gain=em_gain)
 
     im_width = dataset.all_data.shape[-1]
 

--- a/tests/test_cr_detection.py
+++ b/tests/test_cr_detection.py
@@ -11,6 +11,9 @@ from astropy.time import Time
 from scipy.ndimage import median_filter
 from pytest import approx
 
+nonlin_fits_filepath = os.path.join(os.path.dirname(__file__), "test_data", "nonlin_sample.fits")
+
+
 ## Copy-pasted II&T code from https://github.com/roman-corgi/cgi_iit_drp/blob/main/proc_cgi_frame_NTR/proc_cgi_frame/gsw_remove_cosmics.py ##
 
 def find_plateaus_iit(streak_row, fwc, sat_thresh, plat_thresh, cosm_filter):
@@ -196,7 +199,7 @@ def test_iit_vs_corgidrp():
     mode = 'image'
 
     # create simulated data
-    dataset = mocks.create_cr_dataset(filedir=datadir, numfiles=2,em_gain=em_gain, numCRs=5, plateau_length=10)
+    dataset = mocks.create_cr_dataset(nonlin_fits_filepath, filedir=datadir, numfiles=2,em_gain=em_gain, numCRs=5, plateau_length=10)
 
     iit_masks = []
 
@@ -232,7 +235,7 @@ def test_crs_zeros_frame():
     tol = 1e-13
 
     # create simulated data
-    dataset = mocks.create_cr_dataset(filedir=datadir, numfiles=2,numCRs=5, plateau_length=10)
+    dataset = mocks.create_cr_dataset(nonlin_fits_filepath, filedir=datadir, numfiles=2,numCRs=5, plateau_length=10)
 
     # Overwrite data with zeros
     dataset.all_data[:,:,:] = 0.
@@ -247,7 +250,7 @@ def test_correct_headers():
     Asserts "FWC_EM_E", "FWC_PP_E", and "SAT_DN" are tracked in the frame headers.
     """
     # create simulated data
-    dataset = mocks.create_cr_dataset(filedir=datadir, numfiles=2,numCRs=5, plateau_length=10)
+    dataset = mocks.create_cr_dataset(nonlin_fits_filepath, filedir=datadir, numfiles=2,numCRs=5, plateau_length=10)
     output_dataset = detect_cosmic_rays(dataset, detector_params)
 
     for frame in output_dataset:
@@ -331,7 +334,7 @@ tail = np.exp(np.linspace(0, -10, 50)) * 0.1*fwc
 
 # Create bias subtracted image
 
-bs_dataset = mocks.create_cr_dataset(datadir,numfiles=1,numCRs=0)
+bs_dataset = mocks.create_cr_dataset(nonlin_fits_filepath, datadir,numfiles=1,numCRs=0)
 bs_dataset.all_data[:,:,:] = 1.
 im_width = bs_dataset.all_data.shape[-1]
 i_streak_rows_t = np.array([0, im_width//2-1, im_width//2, im_width-1])
@@ -355,7 +358,7 @@ bs_dataset_single_pix.all_data[0,im_width//2, im_width//2] = fwc
 
 def test_mask():
     """Assert correct elements are masked."""
-    dataset = mocks.create_cr_dataset(filedir=datadir, numfiles=1,numCRs=0, plateau_length=10)
+    dataset = mocks.create_cr_dataset(nonlin_fits_filepath, filedir=datadir, numfiles=1,numCRs=0, plateau_length=10)
     dataset.all_data[:,:,:] = 1.
     dataset.all_data[0,1, 2:2+len(cosm_bs)] = cosm_bs
     check_mask = np.zeros_like(dataset.all_dq, dtype=int)

--- a/tests/test_non_linearity_correction.py
+++ b/tests/test_non_linearity_correction.py
@@ -127,8 +127,10 @@ def test_non_linearity_correction():
     if not os.path.exists(datadir):
         os.mkdir(datadir)
     
+    nonlin_fits_filepath = os.path.join(os.path.dirname(__file__), "test_data", "nonlin_sample.fits")
+
     emgain = 2000
-    mocks.create_nonlinear_dataset(filedir=datadir,em_gain=emgain)
+    mocks.create_nonlinear_dataset(nonlin_fits_filepath, filedir=datadir,em_gain=emgain)
 
     ####### open up the files
     sim_data_filenames = glob.glob(os.path.join(datadir, "simcal_nonlin*.fits"))


### PR DESCRIPTION
## Describe your changes
mocks.py should not access tests/test_data dir since regular pip install users will not have access to that dir. Instead, to generate mock data that requires data from tests/test_data, the filepath to the appropriate file should be passed in. 

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)

Closes #162 

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
