### PR TITLE
Use ARRTYPE to determine detector areas

### DIFF
--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -44,7 +44,7 @@ def prescan_biassub(input_dataset, noise_maps=None, return_full_frame=False, det
         frame_dq = frame.dq
 
         # Determine what type of file it is (engineering or science), then choose detector area dict
-        obstype = frame.pri_hdr['OBSTYPE']
+        obstype = frame.ext_hdr['ARRTYPE']
         if not obstype in ['SCI','ENG','ENG_EM','ENG_CONV'] :
                 raise Exception(f"Observation type of frame {i} is not 'SCI' or 'ENG' or 'ENG_EM' or 'EMG_CONV'")
 


### PR DESCRIPTION
## Describe your changes

Use the extension header keyword ARRTYPE instead of OBSTYPE for determining detector areas (E.g., for bias subtraction)

We should check this is indeed the right choice.

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)
- 
## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
