### PR TITLE
pipeline setting install fix and additions

### DIFF
--- a/corgidrp/__init__.py
+++ b/corgidrp/__init__.py
@@ -39,9 +39,9 @@ def create_config_dir():
         config["PATH"]["default_calibs"] = default_cal_dir
         config["DATA"] = {}
         config["DATA"]["track_individual_errors"] = "False"
-        config["DRP"] = {}
-        config["DRP"]["skip_missing_cal_steps"] = "False"
-        config["DRP"]["jit_calib_id"] = "False"
+        config["WALKER"] = {}
+        config["WALKER"]["skip_missing_cal_steps"] = "False"
+        config["WALKER"]["jit_calib_id"] = "False"
         # overwrite with old settings if needed
         if oldconfig is not None:
             config["PATH"]["caldb"] = oldconfig["PATH"]["caldb"]
@@ -64,5 +64,5 @@ config.read(config_filepath)
 caldb_filepath = config.get("PATH", "caldb", fallback=None) # path to calibration db
 default_cal_dir = config.get("PATH", "default_calibs", fallback=None) # path to default calibrations directory
 track_individual_errors = _bool_map[config.get("DATA", "track_individual_errors", fallback='false').lower()] # save each individual error component separately?
-skip_missing_cal_steps = _bool_map[config.get("DRP", "skip_missing_cal_steps", fallback='false').lower()] # skip steps, instead of crashing, when suitable calibration file cannot be found 
-jit_calib_id = _bool_map[config.get("DRP", "jit_calib_id", fallback='false').lower()] # AUTOMATIC calibration files identified right before the execution of a step, rather than when recipe is first generated
+skip_missing_cal_steps = _bool_map[config.get("WALKER", "skip_missing_cal_steps", fallback='false').lower()] # skip steps, instead of crashing, when suitable calibration file cannot be found 
+jit_calib_id = _bool_map[config.get("WALKER", "jit_calib_id", fallback='false').lower()] # AUTOMATIC calibration files identified right before the execution of a step, rather than when recipe is first generated

--- a/corgidrp/__init__.py
+++ b/corgidrp/__init__.py
@@ -39,6 +39,9 @@ def create_config_dir():
         config["PATH"]["default_calibs"] = default_cal_dir
         config["DATA"] = {}
         config["DATA"]["track_individual_errors"] = "False"
+        config["DRP"] = {}
+        config["DRP"]["skip_missing_cal_steps"] = "False"
+        config["DRP"]["jit_calib_id"] = "False"
         # overwrite with old settings if needed
         if oldconfig is not None:
             config["PATH"]["caldb"] = oldconfig["PATH"]["caldb"]
@@ -58,6 +61,8 @@ config = configparser.ConfigParser()
 config.read(config_filepath)
 
 ## pipeline settings
-caldb_filepath = config.get("PATH", "caldb", fallback=None)
-default_cal_dir = config.get("PATH", "default_calibs", fallback=None)
-track_individual_errors = _bool_map[config.get("DATA", "track_individual_errors").lower()]
+caldb_filepath = config.get("PATH", "caldb", fallback=None) # path to calibration db
+default_cal_dir = config.get("PATH", "default_calibs", fallback=None) # path to default calibrations directory
+track_individual_errors = _bool_map[config.get("DATA", "track_individual_errors", fallback='false').lower()] # save each individual error component separately?
+skip_missing_cal_steps = _bool_map[config.get("DRP", "skip_missing_cal_steps", fallback='false').lower()] # skip steps, instead of crashing, when suitable calibration file cannot be found 
+jit_calib_id = _bool_map[config.get("DRP", "jit_calib_id", fallback='false').lower()] # AUTOMATIC calibration files identified right before the execution of a step, rather than when recipe is first generated

--- a/corgidrp/__init__.py
+++ b/corgidrp/__init__.py
@@ -25,28 +25,28 @@ def create_config_dir():
     if not os.path.isdir(config_folder):
         os.mkdir(config_folder)
 
-        # make default calibrations folder
-        default_cal_dir = os.path.join(config_folder, "default_calibs")
-        if not os.path.exists(default_cal_dir):
-            os.mkdir(default_cal_dir)
+    # make default calibrations folder if it doesn't exist
+    default_cal_dir = os.path.join(config_folder, "default_calibs")
+    if not os.path.exists(default_cal_dir):
+        os.mkdir(default_cal_dir)
 
-        # write config 
-        config_filepath = os.path.join(config_folder, "corgidrp.cfg")
-        if not os.path.exists(config_filepath):
-            config = configparser.ConfigParser()
-            config["PATH"] = {}
-            config["PATH"]["caldb"] = os.path.join(config_folder, "corgidrp_caldb.csv") # location to store caldb
-            config["PATH"]["default_calibs"] = default_cal_dir
-            config["DATA"] = {}
-            config["DATA"]["track_individual_errors"] = "False"
-            # overwrite with old settings if needed
-            if oldconfig is not None:
-                config["PATH"]["caldb"] = oldconfig["PATH"]["caldb"]
+    # write config if it doesn't exist
+    config_filepath = os.path.join(config_folder, "corgidrp.cfg")
+    if not os.path.exists(config_filepath):
+        config = configparser.ConfigParser()
+        config["PATH"] = {}
+        config["PATH"]["caldb"] = os.path.join(config_folder, "corgidrp_caldb.csv") # location to store caldb
+        config["PATH"]["default_calibs"] = default_cal_dir
+        config["DATA"] = {}
+        config["DATA"]["track_individual_errors"] = "False"
+        # overwrite with old settings if needed
+        if oldconfig is not None:
+            config["PATH"]["caldb"] = oldconfig["PATH"]["caldb"]
 
-            with open(config_filepath, 'w') as f:
-                config.write(f)
+        with open(config_filepath, 'w') as f:
+            config.write(f)
 
-            print("corgidrp: Configuration file written to {0}. Please edit if you want things stored in different locations.".format(config_filepath))
+        print("corgidrp: Configuration file written to {0}. Please edit if you want things stored in different locations.".format(config_filepath))
 create_config_dir()
     
 _bool_map = {"true" : True, "false" : False}

--- a/corgidrp/caldb.py
+++ b/corgidrp/caldb.py
@@ -303,6 +303,6 @@ if not os.path.exists(os.path.join(corgidrp.default_cal_dir, "DetectorParams_202
     default_detparams = data.DetectorParams({}, date_valid=time.Time("2023-11-01 00:00:00", scale='utc'))
     default_detparams.save(filedir=corgidrp.default_cal_dir)
 
-    # add default caldb entries
-    default_caldb = CalDB()
-    default_caldb.scan_dir_for_new_entries(corgidrp.default_cal_dir)
+# add default caldb entries
+default_caldb = CalDB()
+default_caldb.scan_dir_for_new_entries(corgidrp.default_cal_dir)

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -112,7 +112,7 @@ def _fill_in_calib_files(step, this_caldb, ref_frame):
 
     Args:
         step (dict): the portion of a recipe for this step
-        caldb (corgidrp.CalDB): calibration database conection
+        this_caldb (corgidrp.CalDB): calibration database conection
         ref_frame (corgidrp.Image): a reference frame to use to determine the optimal calibration
     
     Returns:

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -115,7 +115,7 @@ def _fill_in_calib_files(step, this_caldb, ref_frame):
         caldb (corgidrp.CalDB): calibration database conection
         ref_frame (corgidrp.Image): a reference frame to use to determine the optimal calibration
     
-    Retuns:
+    Returns:
         dict: the step, but with calibration files filled in
     """
     if "calibs" not in step:

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -1,6 +1,7 @@
 import os
 import json
 import astropy.time as time
+import warnings
 import corgidrp
 import corgidrp.data as data
 import corgidrp.caldb as caldb
@@ -91,21 +92,57 @@ def autogen_recipe(filelist, outputdir, template=None):
     ## This also includes the dark subtraction outputdir for synthetic darks
     this_caldb = caldb.CalDB()
     for step in recipe["steps"]:
-        if "calibs" in step:
-            for calib in step["calibs"]:
-                # order matters, so only one calibration file per dictionary
+        # by default, identify all the calibration files needed, unless jit setting is turned on
+        if not corgidrp.jit_calib_id:
+            _fill_in_calib_files(step, this_caldb, first_frame)
 
-                if step["calibs"][calib].upper() == "AUTOMATIC":
-                    calib_dtype = data.datatypes[calib]
-                    best_cal_file = this_caldb.get_calib(first_frame, calib_dtype)
-                    # set calibration file to this one
-                    step["calibs"][calib] = best_cal_file.filepath
         if step["name"].lower() == "dark_subtraction":
             if step["keywords"]["outputdir"].upper() == "AUTOMATIC":
                 step["keywords"]["outputdir"] = recipe["outputdir"]
 
     return recipe
 
+def _fill_in_calib_files(step, this_caldb, ref_frame):
+    """
+    Fills in calibration files defined as "AUTOMATIC" in a recipe
+    
+    By default, throws an error if there are no available cal files of a certian type.
+    Exceptional case is when the pipeline setting `skip_missing_cal_steps = True` is set:
+    in this case, it will mark this step to be skipped, but continue processing the recipe.
+
+    Args:
+        step (dict): the portion of a recipe for this step
+        caldb (corgidrp.CalDB): calibration database conection
+        ref_frame (corgidrp.Image): a reference frame to use to determine the optimal calibration
+    
+    Retuns:
+        dict: the step, but with calibration files filled in
+    """
+    if "calibs" not in step:
+        return step # don't have to do anything if no calibrations
+    
+    for calib in step["calibs"]:
+        # order matters, so only one calibration file per dictionary
+
+        if step["calibs"][calib].upper() == "AUTOMATIC":
+            calib_dtype = data.datatypes[calib]
+
+            # try to look up the best calibration, but it could raise an error
+            try:
+                best_cal_file = this_caldb.get_calib(ref_frame, calib_dtype)
+            except ValueError as e:
+                if corgidrp.skip_missing_cal_steps:
+                    step["skip"] = True # skip this step but continue
+                    step["calibs"][calib] = "None"
+                    warnings.warn("Skipping {0} because no {1} in caldb and skip_missing_cal_steps is True".format(step['name'], calib))
+                    continue # continue on the for loop
+                else:
+                    raise # reraise exception
+
+            # set calibration file to this one
+            step["calibs"][calib] = best_cal_file.filepath
+
+    return step
 
 def guess_template(image):
     """
@@ -222,8 +259,24 @@ def run_recipe(recipe, save_recipe_file=True):
         else:
             step_func = all_steps[step["name"]]
 
+            # edge case if this step has been specified to be skipped
+            if "skip" in step and step["skip"]:
+                continue
+
             other_args = ()
             if "calibs" in step:
+                # if JIT calibration resolving is toggled, figure out the calibrations here
+                # by default, this is false
+                if corgidrp.jit_calib_id:
+                    this_caldb = caldb.CalDB()
+                    _fill_in_calib_files(step, this_caldb, curr_dataset[0])
+
+                    # also update the recipe we used in the headers
+                    for frame in curr_dataset:
+                        frame.ext_hdr["RECIPE"] = json.dumps(recipe)
+
+
+                # load the calibration files in from disk
                 for calib in step["calibs"]:
                     calib_dtype = data.datatypes[calib]
                     cal_file = calib_dtype(step["calibs"][calib])

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -226,8 +226,69 @@ def test_saving():
     this_caldb.remove_entry(new_nonlinearity)
 
 
+
+def test_skip_missing_calib():
+    """
+    Tests the option of skipping steps with missing calibrations
+    """
+    # turn on skipping
+    old_setting = corgidrp.skip_missing_cal_steps
+    corgidrp.skip_missing_cal_steps = True
+
+    # use an empty test caldb
+    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
+    if not os.path.exists(calibdir):
+        os.mkdir(calibdir)
+    testcaldb_filepath = os.path.join(calibdir, "empty_caldb.csv")
+    old_caldb_filepath = corgidrp.caldb_filepath
+    corgidrp.caldb_filepath = testcaldb_filepath
+
+    # create dirs
+    datadir = os.path.join(os.path.dirname(__file__), "simdata")
+    if not os.path.exists(datadir):
+        os.mkdir(datadir)
+    outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
+    if not os.path.exists(outputdir):
+        os.mkdir(outputdir)
+
+    # create simulated data
+    l1_dataset = mocks.create_prescan_files(filedir=datadir, obstype="SCI", numfiles=2)
+    # simulate the expected CGI naming convention
+    fname_template = "CGI_L1_200_0200001001001100001_20270101T120000_{0:03d}.fits"
+    for i, image in enumerate(l1_dataset):
+        image.filename = fname_template.format(i)
+    l1_dataset.save(filedir=datadir)
+    filelist = [frame.filepath for frame in l1_dataset]
+
+
+    ### Test that we are skipping the steps without calibrations
+    recipe = walker.autogen_recipe(filelist, outputdir)
+
+    assert recipe['name'] == 'l1_to_l2b'
+    assert recipe['template'] == False
+
+    assert recipe['steps'][2]['skip'] # nonlinearity
+    assert recipe['steps'][6]['skip'] # kgain
+    
+    # cut down to recipe to just the first 5 steps (to the first save)
+    recipe['steps'] = recipe['steps'][:5]
+
+    # run with all the ksips
+    walker.run_recipe(recipe, save_recipe_file=False)
+
+    # check that the output dataset is saved to the output dir
+    # filenames have been appended with a suffix
+    output_files = [os.path.join(outputdir, "CGI_L2a_200_0200001001001100001_20270101T120000_{0:03d}.fits".format(i)) for i in range(len(l1_dataset))]
+    output_dataset = data.Dataset(output_files)
+    assert len(output_dataset) == len(l1_dataset) # check the same number of files
+
+    assert 'non-linearity' not in output_dataset[0].ext_hdr['HISTORY'][-2].lower()
+
+    corgidrp.skip_missing_cal_steps = old_setting
+    corgidrp.caldb_filepath = old_caldb_filepath
+
 if __name__ == "__main__":#
-    test_saving()
+    test_skip_missing_calib()
 
 
 


### PR DESCRIPTION
## Describe your changes
This should partially address the issues in #128 regarding pipeline install. Now in first load, we check specifically that the config file and the default calibrations sub directory exist (and if not, create them). We also check we've loaded all the cals for the default_calib_dir (where DetectorParams file lives) when we import caldb (in case someone completely deleted or wiped their caldb). 

Adds two new pipeline settings (Both default to False currently):
 * `corgidrp.jit_calib_id`: identifies the calibration file at the execution of that particular step rather than the creation of the recipe.
 * `corgidrp.skip_missing_cal_steps`: skips step functions in which we have zero suitable calibration files in the caldb.

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
