### PR TITLE
accommodation of EMGAIN_M, EMGAIN_A, and CMDGAIN in that order of priority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ tests/e2e_tests/*/*.json
 # Output figures
 figures/
 tests/figures/
+tests/test_data/simastrom/guesses.csv

--- a/corgidrp/calibrate_kgain.py
+++ b/corgidrp/calibrate_kgain.py
@@ -79,21 +79,21 @@ class CalKgainException(Exception):
     """Exception class for calibrate_kgain."""
 
 ################### function defs #####################
-    
+
 def ptc_bin2(frame_in, mean_frame, binwidth, max_DN):
-    """ 
-    frame_in is a bias-corrected frame trimmed to the ROI. mean_frame is 
-    the scaled high SNR mean frame made from the >=30 frames of uniform 
-    exposure time, binwidth is an integer equal to the width of each bin, 
-    max_DN is an integer equal to the maximum DN value to be included in 
+    """
+    frame_in is a bias-corrected frame trimmed to the ROI. mean_frame is
+    the scaled high SNR mean frame made from the >=30 frames of uniform
+    exposure time, binwidth is an integer equal to the width of each bin,
+    max_DN is an integer equal to the maximum DN value to be included in
     the bins.
-       
+
     Args:
       frame_in (np.array): bias corrected frame
       mean_frame (np.array): mean frame of uniform exposure time
       binwidth (int): width of each bin
       max_DN (int): maximum DN value
-      
+
     Returns:
       np.array: mean array
       np.array: mean array
@@ -101,29 +101,29 @@ def ptc_bin2(frame_in, mean_frame, binwidth, max_DN):
     # calculate the size of output arrays
     rows, cols = frame_in.shape
     out_rows, out_cols = rows // binwidth, cols // binwidth
-      
+
     local_mean_array = np.zeros((out_rows, out_cols))
     local_noise_array = np.zeros((out_rows, out_cols))
-        
+
     # Define the bin edges
     row_bins = np.arange(1, rows + 1, binwidth)
     col_bins = np.arange(1, cols + 1, binwidth)
-        
+
     tot_bins = len(row_bins) * len(col_bins)
     DN_bin = max_DN / tot_bins
-        
+
     # Flatten the arrays for easier indexing
     mean_flat = mean_frame.flatten()
     frame_in_flat = frame_in.flatten()
-        
+
     DN_val = 0
     for m in range(len(row_bins) - 1):
         for n in range(len(col_bins) - 1):
             DN_val += DN_bin
-                
+
             # Create masks based on DN values
             mean_idx = (mean_flat >= DN_val) & (mean_flat < (DN_val + DN_bin))
-                
+
             # Ensure that there is at least one element to calculate mean and std
             if np.any(mean_idx):
                 local_mean_array[m, n] = np.nanmean(frame_in_flat[mean_idx])
@@ -131,55 +131,55 @@ def ptc_bin2(frame_in, mean_frame, binwidth, max_DN):
             else:
                 local_mean_array[m, n] = 0
                 local_noise_array[m, n] = 0
-        
+
     return local_mean_array, local_noise_array
 
 def diff2std(diff_frame, detector_regions=None):
     """
-    calculate the standard deviation of the frame difference, 
+    calculate the standard deviation of the frame difference,
     diff_frame within the ROI row and column boundaries.
-    
+
     Args:
       diff_frame (np.array): frame diffference
       detector_regions (dict): a dictionary of detector geometry properties.
         Keys should be as found in detector_areas in detector.py.  Defaults to
-        that dictionary. 
-      
+        that dictionary.
+
     Returns:
       np.array: standard deviation of frame difference
     """
-        
+
     selected_area = slice_section(diff_frame, 'SCI', 'prescan_reliable',
         detector_regions)
     std_value = np.std(selected_area.reshape(-1), ddof=1)
     # dividing by sqrt(2) since we want std of one frame
     return std_value / np.sqrt(2)
-    
+
 def gauss(x, A, mean, sigma):
     """
     Gauss function. Called by sgaussfit.
-    
+
     Args:
       x (np.array): input array
       A (float): amplitude
       mean (float): mean value
       sigma (float): sigma
-    
+
     Returns:
       np.array: Gauss function
     """
     return A * np.exp(-0.5 * ((x - mean) ** 2) / (sigma ** 2))
-    
+
 def sgaussfit(xdata, ydata, gaussinp):
     """
-    Find fitting parameters to Gauss function. Called by Single_peakfit. 
+    Find fitting parameters to Gauss function. Called by Single_peakfit.
     gaussinp is an array containing initial values of A, mean, sigma.
-    
+
     Args:
       xdata (np.array): input x array
       ydata (np.array): input y array
       gaussinp (np.array): initial guess array
-    
+
     Returns:
       np.array: fit parameters
       np.array: fit parameters
@@ -187,16 +187,16 @@ def sgaussfit(xdata, ydata, gaussinp):
     popt, pcov = curve_fit(gauss, xdata, ydata, p0=gaussinp)
     sse = np.sum((ydata - gauss(xdata, *popt)) ** 2)
     return popt, lambda params: (sse, gauss(xdata, *params))
-    
+
 def Single_peakfit(xdata, ydata):
     """
-    Fit Gauss function to x, y data. Returns mean and sigma. Only sigma 
+    Fit Gauss function to x, y data. Returns mean and sigma. Only sigma
     is used in main code call.
-    
+
     Args:
       xdata (np.array): x data
       ydata (np.array): y data
-    
+
     Returns:
       float: sigma
     """
@@ -204,24 +204,24 @@ def Single_peakfit(xdata, ydata):
     mustart = xdata[np.argmax(ydata)]
     sigmastart = 10
     sgaussinp = [astart, mustart, sigmastart]
-    
+
     estimates, model = sgaussfit(xdata, ydata, sgaussinp)
     a1, mu1, sigma = estimates
 
     return sigma
-    
+
 def histc_roi(frame, rn_bins, detector_regions=None):
     """
-    Histogram of pixel values of frame within the ROI and bins defined in 
+    Histogram of pixel values of frame within the ROI and bins defined in
     rn_bins. Returns the counts in each bin.
-    
+
     Args:
       frame (np.array): frame
       rn_bins (int): histogram bins
       detector_regions (dict): a dictionary of detector geometry properties.
         Keys should be as found in detector_areas in detector.py.  Defaults to
-        that dictionary.      
-    
+        that dictionary.
+
     Returns:
       np.array: counts in each bin
     """
@@ -229,16 +229,16 @@ def histc_roi(frame, rn_bins, detector_regions=None):
         detector_regions)
     data_reshaped = selected_area.ravel()
     counts, _ = np.histogram(data_reshaped, bins=rn_bins)
-      
+
     return counts
-    
+
 def calculate_mode(arr):
     """
     calculates histogram of an array
-    
+
     Args:
       arr (np.array): input array
-    
+
     Returns:
       np.array: bin center values
       np.array: bin center counts
@@ -252,19 +252,19 @@ def calculate_mode(arr):
 def sigma_clip(data, sigma=2.5, max_iters=6):
     """
     Perform sigma-clipping on the data.
-      
+
     Args:
        data (np.array): The input data to be sigma-clipped.
        sigma (float): The number of standard deviations to use for clipping.
        max_iters (int): The maximum number of iterations to perform.
-    
+
     Returns:
       np.ndarray: The sigma-clipped data.
       np.ndarray: A boolean mask where True indicates a clipped value.
     """
     data = np.asarray(data)
     clipped_data = data.copy()
-      
+
     for i in range(max_iters):
         mean = np.mean(clipped_data)
         std = np.std(clipped_data)
@@ -272,19 +272,19 @@ def sigma_clip(data, sigma=2.5, max_iters=6):
         if not np.any(mask):
             break
         clipped_data = clipped_data[~mask]
-        
+
     return clipped_data, mask
-    
+
 ######################### start of main code #############################
 
-def calibrate_kgain(dataset_kgain, 
+def calibrate_kgain(dataset_kgain,
                     n_cal=10, n_mean=30, min_val=800, max_val=3000, binwidth=68,
                     make_plot=True,plot_outdir='figures', show_plot=False,
                     logspace_start=-1, logspace_stop=4, logspace_num=200,
                     verbose=False, detector_regions=None):
     """
     Given an array of frame stacks for various exposure times, each sub-stack
-    having at least 5 illuminated pupil L1 SCI-size frames having the same 
+    having at least 5 illuminated pupil L1 SCI-size frames having the same
     exposure time. The frames are bias-subtracted, and in addition, if EM gain
     is >1 for the input data for calibrate_kgain, EM gain division is also needed.
     It also creates a mean pupil array from a separate stack of
@@ -292,15 +292,15 @@ def calibrate_kgain(dataset_kgain,
     of each stack and statistics (mean and std dev) are calculated for bins from
     the frames in it. kgain (e-/DN) is calculated from the means and variances
     within the defined minimum and maximum mean values. A photon transfer curve
-    is plotted from the std dev and mean values from the bins. 
-    
+    is plotted from the std dev and mean values from the bins.
+
     Args:
       dataset_kgain (corgidrp.Dataset): Dataset with a set of of EXCAM illuminated
         pupil L1 SCI frames (counts in DN) having a range of exp times.
         datset_cal contains a set of subset of frames, and all subsets must have
         the same number of frames, which is a minimum of 5. The frames in a subset
-        must all have the same exposure time. There must be at least 10 subsets 
-        (More than 20 sub-stacks recommended. The mean signal in the pupil region should 
+        must all have the same exposure time. There must be at least 10 subsets
+        (More than 20 sub-stacks recommended. The mean signal in the pupil region should
         span from about 100 to about 10000 DN.
         In addition, dataset_kgain contains a set of at least 30 frames used to
         build a mean frame. All the frames must have the same exposure time,
@@ -312,23 +312,23 @@ def calibrate_kgain(dataset_kgain,
         calculating variances (since the pupil illumination is not perfectly uniform).
         All data must be obtained under the same positioning of the pupil
         relative to the detector. These frames are identified with the kewyord
-        'OBSTYPE'='MNFRAME' (TBD). 
+        'OBSTYPE'='MNFRAME' (TBD).
       n_cal (int):
         Minimum number of sub-stacks used to calibrate K-Gain. The default value
         is 10.
       n_mean (int):
         Minimum number of frames used to generate the mean frame. The default value
         is 30.
-      min_val (int): 
-        Minimum value (in DN) of mean values from sub-stacks to use in calculating 
-        kgain. (> 400 recommended)  
+      min_val (int):
+        Minimum value (in DN) of mean values from sub-stacks to use in calculating
+        kgain. (> 400 recommended)
       max_val (int):
-        Maximum value (in DN) of mean values from sub-stacks to use in calculating 
-        kgain. Choose value that avoids large deviations from linearity at high 
+        Maximum value (in DN) of mean values from sub-stacks to use in calculating
+        kgain. Choose value that avoids large deviations from linearity at high
         counts. (< 6,000 recommended)
       binwidth (int):
-        (Optional) Width of each bin for calculating std devs and means from each 
-        sub-stack in dataset_kgain. Maximum value of binwidth is 800. Notice that small 
+        (Optional) Width of each bin for calculating std devs and means from each
+        sub-stack in dataset_kgain. Maximum value of binwidth is 800. Notice that small
         values increase computation time.
         (minimum 10; binwidth between 65 and 75 recommended)
       make_plot (bool): (Optional) generate and store plots. Default is True.
@@ -339,11 +339,11 @@ def calibrate_kgain(dataset_kgain,
       logspace_stop (int): log plot max value in np.logspace.
       logspace_num (int): Number of elements in np.logspace.
       verbose (bool): (Optional) display various diagnostic print messages.
-        Default is False. 
+        Default is False.
       detector_regions (dict): a dictionary of detector geometry properties.
         Keys should be as found in detector_areas in detector.py.  Defaults to
         that dictionary.
-    
+
     Returns:
       corgidrp.data.KGain: kgain estimate from the least-squares fit to the photon
         transfer curve (in e-/DN). The expected value of kgain for EXCAM with
@@ -387,7 +387,7 @@ def calibrate_kgain(dataset_kgain,
             tmp = tmp[idx]
         except:
             pass
-    if idx != 2:    
+    if idx != 2:
         raise CalKgainException('mean_frame_list must be 3-D (i.e., a stack of '
                 '2-D sub-stacks')
     if len(mean_frame_list) < n_mean:
@@ -412,7 +412,7 @@ def calibrate_kgain(dataset_kgain,
         raise TypeError('logplot2 is not a number')
     if not isinstance(logspace_num, (float, int)):
         raise TypeError('logplot3 is not a number')
-    
+
     # get relevant constants
     rowroi1 = kgain_params['rowroi1']
     rowroi2 = kgain_params['rowroi2']
@@ -432,35 +432,35 @@ def calibrate_kgain(dataset_kgain,
             os.mkdir(plot_outdir)
             if verbose:
                 print('Output directory for figures created in ', os.getcwd())
-    
+
     # NOTE: binwidth must be <= rowroi and colroi
     rowroi = slice(rowroi1,rowroi2)
     colroi = slice(colroi1,colroi2)
-    
+
     averages = []
     deviations = []
     read_noise = []
     deviations_shot = []
     #mean_signals = []
-    
+
     rn_bins = np.array(range(rn_bins1, rn_bins2))
     bin_locs = rn_bins[0:-1]
 
     max_DN = max_DN_val; # maximum DN value to be included in PTC
     nrow = len(cal_list[0][0])
     ncol = len(cal_list[0][0][0])
-    
+
     # prepare "good mean frame"
     good_mean_frame = np.zeros((nrow, ncol))
     nFrames2 = len(mean_frame_list)
     for mean_frame_count in range(nFrames2):
         good_mean_frame += mean_frame_list[mean_frame_count]
-    
+
     good_mean_frame = good_mean_frame / nFrames2
-    
+
     # Slice the good_mean_frame array
     frame_slice = good_mean_frame[rowroi, colroi]
-    
+
     # If requested, create a figure and plot the sliced frame
     if make_plot:
         fname = 'kgain_mean_frame'
@@ -475,89 +475,89 @@ def calibrate_kgain(dataset_kgain,
         if show_plot:
             plt.show()
         plt.close()
-    
+
     nFrames = len(cal_list[0]) # number of frames in an exposure set
     nSets = len(cal_list) # number of exposure sets
-    
+
     # Start with specific offset indices for list comprehension in jj loop
     index_offsets = [2, 3, 1, 4, 5]
-    
+
     # Start with specific index pairs for list comprehension in jj loop
     index_pairs = [(0, 1), (0, 2), (1, 2), (2, 3), (3, 4)]
     # if nFrames>5, then append additional terms to index_pairs
     if nFrames > 5:
         # append offsets
         index_offsets += [i for i in range(4, nFrames - 1)]
-        
+
         # append index pairs (i, i + 1) for i from 4 to len(frames) - 2
         index_pairs += [(i, i + 1) for i in range(4, nFrames - 1)]
-    
+
     for jj in range(nSets):
         if verbose:
             print(jj)
-        
+
         # multi-frame analysis method
         frames = [cal_list[jj][nFrames - offset] for offset in index_offsets]
         # Calculate frame differences
         frames_diff = [frames[j] - frames[k] for j, k in index_pairs]
         # calculate read noise with std from prescan
-        rn_std = [diff2std(frames_diff[x], detector_regions) for x 
+        rn_std = [diff2std(frames_diff[x], detector_regions) for x
             in range(len(frames_diff))]
-        
-        counts_diff = [histc_roi(frames_diff[x], rn_bins, detector_regions) for x 
+
+        counts_diff = [histc_roi(frames_diff[x], rn_bins, detector_regions) for x
             in range(len(frames_diff))]
-        
+
         # calculate read noise from prescan with Gaussian fit
-        rn_gauss = [Single_peakfit(bin_locs,counts_diff[x])/np.sqrt(2) for x 
+        rn_gauss = [Single_peakfit(bin_locs,counts_diff[x])/np.sqrt(2) for x
             in range(len(frames_diff))]
-        
+
         # split each frame up into bins, take std and mean of each region
         mean_frames_mean_curr0 = np.mean(frames, axis=0)
         mean_frames_mean_curr = np.mean(mean_frames_mean_curr0[rowroi,colroi])
-        
+
         # Calculate the means
         mean_good_mean_frame_roi = np.mean(good_mean_frame[rowroi,colroi])
-    
+
         # Compute the scaling factor
         scaling_factor = mean_frames_mean_curr / mean_good_mean_frame_roi
-    
+
         # Apply the scaling to the selected ROI in good_mean_frame
         good_mean_frame_scaled = scaling_factor * good_mean_frame[rowroi,colroi]
-        
+
         # calculate means and stdevs using good_mean_frame_scaled logical indexing
-        local_mean_arrays = [ptc_bin2(frame[rowroi, colroi], 
-                            good_mean_frame_scaled, 
+        local_mean_arrays = [ptc_bin2(frame[rowroi, colroi],
+                            good_mean_frame_scaled,
                             binwidth, max_DN)[0] for frame in frames]
-        
-        local_noise_arrays = [ptc_bin2(frame[rowroi, colroi], 
-                            good_mean_frame_scaled, 
+
+        local_noise_arrays = [ptc_bin2(frame[rowroi, colroi],
+                            good_mean_frame_scaled,
                             binwidth, max_DN)[1] for frame in frames_diff]
         std_diffs = local_noise_arrays / np.sqrt(2)
-        
+
         averages0 = [array.reshape(-1, 1) for array in local_mean_arrays]
         averages.extend(averages0)
         deviations0 = [array.reshape(-1, 1) for array in std_diffs]
         deviations.extend(deviations0)
-        
+
         added_deviations_shot_arr = [
-                np.sqrt(np.square(np.reshape(std_diffs[x], 
+                np.sqrt(np.square(np.reshape(std_diffs[x],
                 newshape=(-1, 1))) - complex(rn_std[x])**2)
                 for x in range(len(rn_std))
                 ]
-        
+
         deviations_shot.extend(added_deviations_shot_arr)
 
         read_noise.extend(rn_std)
-        
+
     averages = np.concatenate([arr.flatten() for arr in averages])
     deviations = np.concatenate([arr.flatten() for arr in deviations])
     deviations_shot = np.concatenate([arr.flatten() for arr in deviations_shot])
     averages_deviations_vector = np.column_stack((averages, np.abs(deviations_shot)))
-    
+
     # Generate linearly spaced bins
     signal_bins = np.linspace(np.min(averages), np.max(averages), signal_bins_N)
     signal_bins = np.insert(signal_bins, 0, 0)  # Insert 0 at the beginning
-    
+
     # Initialize containers for the results
     binned_averages_compiled = []
     binned_averages_error = []
@@ -568,12 +568,12 @@ def calibrate_kgain(dataset_kgain,
     # Loop through each bin, excluding the first which is just 0
     for b in range(1, len(signal_bins)):
         average_bool = (averages_deviations_vector[:, 0] > signal_bins[b-1]) & (averages_deviations_vector[:, 0] < signal_bins[b])
-    
+
         # Filter data within the current bin
         current_binned_averages = averages_deviations_vector[:, 0][average_bool]
         current_binned_deviations = averages_deviations_vector[:, 1][average_bool]
         current_binned_total_deviations = deviations[average_bool]
-    
+
         # Compute statistics if there are data points within the bin
         if current_binned_averages.size > 0:
             binned_averages_compiled.append(np.mean(current_binned_averages))
@@ -593,35 +593,35 @@ def calibrate_kgain(dataset_kgain,
     compiled_binned_averages = np.array(binned_averages_compiled)
     compiled_binned_shot_deviations = np.array(binned_shot_deviations_compiled)
     compiled_binned_total_deviations = np.array(binned_total_deviations)
-    
+
     compiled_binned_deviations_error = np.array(binned_deviations_error)
-    
+
     # define bounds for linearity fit
     # lower bound indices should include as many data points as possible
     # upper bound indices should avoid nonlin region
     lower_bound = np.min(np.where(compiled_binned_averages > min_val)[0])
     upper_bound = np.max(np.where(compiled_binned_averages < max_val)[0])
-    
+
     # Logarithmic transformation of specific array segments
     logged_averages = np.log10(compiled_binned_averages[lower_bound:upper_bound])
     logged_deviations = np.log10(compiled_binned_shot_deviations[lower_bound:upper_bound])
-    
+
     # Find indices of NaN's
     nan_dev = np.isnan(logged_deviations)
     nan_avg = np.isnan(logged_averages)
-    
+
     # Filter out NaN's from the data
     logged_deviations = logged_deviations[~nan_dev & ~nan_avg]
     logged_averages = logged_averages[~nan_dev & ~nan_avg]
-    
+
     # Calculate the error factor
     logged_deviations_error_factor = compiled_binned_deviations_error / compiled_binned_shot_deviations
     logged_deviations_error_factor = logged_deviations_error_factor[lower_bound:upper_bound]
     logged_deviations_error_factor = logged_deviations_error_factor[~nan_dev & ~nan_avg]
-    
+
     # Calculate the logged deviations error
     logged_deviations_error = logged_deviations_error_factor * logged_deviations
-    
+
     # Create a mask for non-NaN values
     non_nan_mask = ~np.isnan(logged_deviations_error)
 
@@ -629,11 +629,11 @@ def calibrate_kgain(dataset_kgain,
     y_err = logged_deviations_error[non_nan_mask]
     x_vals = logged_averages[non_nan_mask]
     y_vals = logged_deviations[non_nan_mask]
-    
+
     # make array of kgain values from variance and mean values
     # equation: k_gain = mean / signal variance
     kgain_arr = 10**(x_vals)/(10**y_vals)**2
-    
+
     if make_plot:
         fname = 'kgain_histogram'
         plt.figure()
@@ -646,7 +646,7 @@ def calibrate_kgain(dataset_kgain,
         if show_plot:
             plt.show()
         plt.close()
-    
+
     if make_plot:
         fname = 'kgain_vs_mean'
         plt.figure()
@@ -664,7 +664,7 @@ def calibrate_kgain(dataset_kgain,
         if show_plot:
             plt.show()
         plt.close()
-    
+
     kgain_clipped, _ = sigma_clip(kgain_arr)
     mode_kgain,_ = calculate_mode(kgain_clipped)
 
@@ -683,50 +683,50 @@ def calibrate_kgain(dataset_kgain,
         if show_plot:
             plt.show()
         plt.close()
-    
+
     # parameter for plot
     parm1 = -0.5*np.log10(kgain)
-    
+
     # Gaussian read noise value in DN
     mean_rn_gauss_DN = np.mean(rn_gauss)
     mean_rn_gauss_e = mean_rn_gauss_DN * kgain
-    
+
     mean_rn_std_DN = np.mean(read_noise)
     mean_rn_std_e = mean_rn_std_DN * kgain
-    
+
     # If requested, plotting
     if make_plot:
         fname = 'kgain_ptc'
         # Create log-spaced averages for plotting
         full_range_averages = np.logspace(logspace_start, logspace_stop, logspace_num)
-        
+
         plt.figure(num=3, figsize=(20, 10))
-        
+
         # Main data plots
-        plt.plot(compiled_binned_averages, compiled_binned_total_deviations, 
+        plt.plot(compiled_binned_averages, compiled_binned_total_deviations,
                  label='Shot Noise + Read Noise')
         # Assuming `lower_bound` is 6
-        plt.plot(compiled_binned_averages, 
+        plt.plot(compiled_binned_averages,
                  compiled_binned_shot_deviations, label='Shot Noise')
-        plt.errorbar(10**logged_averages, 10**logged_deviations, 
-                     yerr=10**(logged_deviations_error), color='gray', 
+        plt.errorbar(10**logged_averages, 10**logged_deviations,
+                     yerr=10**(logged_deviations_error), color='gray',
                      label='Fitted Points')
-        
+
         # Extra lines
-        plt.plot(10**full_range_averages, 
-                 10**(full_range_averages * 0.50 + parm1), 
+        plt.plot(10**full_range_averages,
+                 10**(full_range_averages * 0.50 + parm1),
                  'k-', label='Forced 0.50 Gradient')
-        
+
         # Reference lines and text annotations
         plt.axhline(y=mean_rn_std_DN, color='k', linestyle='--')
         plt.axvline(x=95000, color='k', linestyle='--')
         plt.text(2, 1.5, f'Fitted k gain = {np.round(kgain,1)} e/DN', fontsize=15)
-        plt.text(2, 10, 
-                 f'Read noise (Gaussian fit) = {np.round(mean_rn_gauss_DN,1)} DN = {mean_rn_gauss_e} e', 
+        plt.text(2, 10,
+                 f'Read noise (Gaussian fit) = {np.round(mean_rn_gauss_DN,1)} DN = {mean_rn_gauss_e} e',
                  fontsize=15)
-        plt.text(2, 8, f'Read noise (Std) = {np.round(mean_rn_std_DN,1)} DN = {np.round(mean_rn_std_e,1)} e', 
+        plt.text(2, 8, f'Read noise (Std) = {np.round(mean_rn_std_DN,1)} DN = {np.round(mean_rn_std_e,1)} e',
                  fontsize=15)
-        
+
         # Scaling and labeling
         plt.xscale('log')
         plt.yscale('log')
@@ -734,29 +734,29 @@ def calibrate_kgain(dataset_kgain,
         plt.ylabel('Noise (DN)')
         plt.title('PTC curve fit')
         plt.grid(True)
-        
+
         # Setting axis limits
         plt.xlim([1, 20000])
         plt.ylim([1, 1000])
-        
+
         # Legend and aesthetics
         plt.legend(loc='upper left')
-        
+
         plt.gca().tick_params(axis='both', which='major', labelsize=18)
-        
+
         # Adjust figure position
         plt.gcf().set_dpi(100)
         plt.gcf().set_size_inches(20, 10)
-        
+
         plt.savefig(f'{plot_outdir}/{fname}')
         if verbose:
             print(f'Figure {fname} stored in {plot_outdir}')
         if show_plot:
             plt.show()
         plt.close()
-    
+
     # prepare PTC array
-    ptc_list = [compiled_binned_averages, 
+    ptc_list = [compiled_binned_averages,
              compiled_binned_shot_deviations]
     ptc = np.column_stack(ptc_list)
 
@@ -764,20 +764,20 @@ def calibrate_kgain(dataset_kgain,
     exthd = dataset_kgain.frames[0].ext_hdr
     # Read noise and error
     exthd['RN'] = mean_rn_gauss_e
-    
+
     # rn err depends on spread of data that determines rn and the error in kgain,
     # so use error propagation to find error in (rn in DN)*kgain
     kgain_err = np.std(kgain_clipped)
     rn_err_DN = np.std(rn_gauss)
     rn_err_e = np.sqrt((kgain*rn_err_DN)**2 + (mean_rn_gauss_DN*kgain_err)**2)
     exthd['RN_ERR'] = rn_err_e
-    
+
     # Update history
     exthd['HISTORY'] = f"Kgain and read noise derived from a set of frames on {exthd['DATETIME']}"
     gain_value = np.array([[kgain]])
 
     kgain = data.KGain(gain_value, err = np.array([[np.std(kgain_clipped)]]), ptc = ptc, pri_hdr = prhd, ext_hdr = exthd, input_dataset=dataset_kgain)
-    
+
     return kgain
 
 def kgain_dataset_2_list(dataset):
@@ -817,7 +817,7 @@ def kgain_dataset_2_list(dataset):
     # Size of each sub stack
     len_sstack = []
     # Record measured gain of each substack of calibration frames
-    gains = []    
+    gains = []
     for idx_set, data_set in enumerate(split[0]):
         # Second layer (array of different exposure times)
         sub_stack = []
@@ -858,10 +858,13 @@ def kgain_dataset_2_list(dataset):
                 if record_gain:
                     try: # if EM gain measured directly from frame TODO change hdr name if necessary
                         gains.append(frame.ext_hdr['EMGAIN_M'])
-                    except: # use commanded gain otherwise
-                        gains.append(frame.ext_hdr['CMDGAIN'])
+                    except:
+                        try: # use applied EM gain if available
+                            gains.append(frame.ext_hdr['EMGAIN_A'])
+                        except: # use commanded gain otherwise
+                            gains.append(frame.ext_hdr['CMDGAIN'])
                     record_gain = False
-                
+
         # Calibration data may have different subsets
         if len(sub_stack) != 0:
             stack.append(np.stack(sub_stack))
@@ -884,18 +887,16 @@ def kgain_dataset_2_list(dataset):
             for rep in range(len(sub)//len_sub):
                 stack_cp.append(sub[idx_0:idx_0+len_sub])
                 idx_0 += len_sub
-    stack = stack_cp        
+    stack = stack_cp
     # All elements of datetimes must be unique
     if len(datetimes) != len(set(datetimes)):
         raise Exception('DATETIMEs cannot be duplicated')
     # There can only be an EM gain in the data used to calibrate K-gain
     if len(set(em_gains)) != 1:
-        raise Exception('There can only be one commanded gain when calibrating K-Gain')
+        raise Exception('There can only be one commanded EM gain when calibrating K-Gain')
     if np.any(np.array(gains) < 1):
         raise Exception('Actual EM gains must be greater than or equal to 1')
     # When measuring k_gain, there can only be one gain for all exposure times
-    actual_gain = gains[0]
-    if len(set(gains)) != 1:
-        raise Exception('Actual EM gain for K-gain calibration frames must be the same for all exposure times.')
+    actual_gain = np.mean(gains) # not actually used in k gain calibration since frames already gain-divided
 
     return stack, mean_frame_stack, actual_gain

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -250,7 +250,7 @@ class Image():
         dq (np.array): 2-D data quality, 0: good. Other values track different causes for bad pixels and other pixel-level effects in accordance with the DRP implementation document.x
         err_hdr (astropy.io.fits.Header): the error extension header
         dq_hdr (astropy.io.fits.Header): the data quality extension header
-        hdu_list (astropy.io.fits.HDUList): an astropy HDUList object that contains any other extension types. 
+        hdu_list (astropy.io.fits.HDUList): an astropy HDUList object that contains any other extension types.
 
     Attributes:
         data (np.array): 2-D data for this Image
@@ -269,7 +269,7 @@ class Image():
         if isinstance(data_or_filepath, str):
             # a filepath is passed in
             with fits.open(data_or_filepath) as hdulist:
-                
+
                 #Pop out the primary header
                 self.pri_hdr = hdulist.pop(0).header
                 #Pop out the image extension
@@ -302,7 +302,7 @@ class Image():
                     if np.shape(self.data) != np.shape(dq):
                         raise ValueError("The shape of dq is {0} while we are expecting shape {1}".format(dq.shape, self.data.shape))
                     self.dq = dq
-                
+
                 elif "DQ" in self.hdu_names:
                     dq_hdu = hdulist.pop("DQ")
                     self.dq = dq_hdu.data
@@ -313,7 +313,7 @@ class Image():
 
                 if input_hdulist is not None:
                     self.hdu_list = input_hdulist
-                else: 
+                else:
                     #After the data, err and dqs are popped out, the rest of the hdulist is stored in hdu_list
                     self.hdu_list = hdulist
 
@@ -361,25 +361,25 @@ class Image():
             #The default hdu extensions
             self.hdu_names = ["ERR", "DQ"]
 
-            #Take the input hdulist or make a blank one. 
+            #Take the input hdulist or make a blank one.
             if input_hdulist is not None:
                 self.hdu_list = input_hdulist
-                #Keep track of the names 
+                #Keep track of the names
                 for hdu in input_hdulist:
                     self.hdu_names.append(hdu.name)
-            else: 
+            else:
                 self.hdu_list = fits.HDUList()
 
-            
-            
+
+
             #A list of extensions
-            
+
 
             # record when this file was created and with which version of the pipeline
             self.ext_hdr.set('DRPVERSN', corgidrp.__version__, "corgidrp version that produced this file")
             self.ext_hdr.set('DRPCTIME', time.Time.now().isot, "When this file was saved")
 
-        
+
         # we assume that if the err_hdr and dq_hdr is given as parameter they supersede eventual existing err_hdr and dq_hdr
         if err_hdr is not None:
             self.err_hdr = err_hdr
@@ -476,7 +476,7 @@ class Image():
             new_err = self.err
             new_dq = self.dq
             new_hdulist = self.hdu_list
-        new_img = Image(new_data, pri_hdr=self.pri_hdr.copy(), ext_hdr=self.ext_hdr.copy(), err = new_err, dq = new_dq, 
+        new_img = Image(new_data, pri_hdr=self.pri_hdr.copy(), ext_hdr=self.ext_hdr.copy(), err = new_err, dq = new_dq,
                         input_hdulist = new_hdulist, err_hdr = self.err_hdr.copy(), dq_hdr = self.dq_hdr.copy())
 
         # annoying, but we got to manually update some parameters. Need to keep track of which ones to update
@@ -582,7 +582,7 @@ class Image():
 
         if name in self.hdu_names:
             raise ValueError("Extension name already exists in HDU list")
-        else: 
+        else:
             self.hdu_list.append(new_hdu)
 
 
@@ -617,7 +617,7 @@ class Dark(Image):
                 self._record_parent_filenames(input_dataset)
 
             # add to history
-            self.ext_hdr['HISTORY'] = "Dark with exptime = {0} s and EM gain = {1} created from {2} frames".format(self.ext_hdr['EXPTIME'], self.ext_hdr['CMDGAIN'], self.ext_hdr['DRPNFILE'])
+            self.ext_hdr['HISTORY'] = "Dark with exptime = {0} s and commanded EM gain = {1} created from {2} frames".format(self.ext_hdr['EXPTIME'], self.ext_hdr['CMDGAIN'], self.ext_hdr['DRPNFILE'])
 
             # give it a default filename using the first input file as the base
             # strip off everything starting at .fits
@@ -813,16 +813,16 @@ class KGain(Image):
         if self.data.shape != (1,1):
             raise ValueError('The KGain calibration data should be just one float value')
 
-        self._kgain = self.data[0,0] 
+        self._kgain = self.data[0,0]
         self._kgain_error = self.err[0,0]
-        
+
         if isinstance(data_or_filepath, str):
             # a filepath is passed in
             with fits.open(data_or_filepath) as hdulist:
                 self.ptc_hdr = hdulist[3].header
                 # ptc data is in FITS extension
                 self.ptc = hdulist[3].data
-        
+
         else:
             if ptc is not None:
                 self.ptc = ptc
@@ -832,7 +832,7 @@ class KGain(Image):
                 self.ptc_hdr = ptc_hdr
             else:
                 self.ptc_hdr = fits.Header()
-        
+
         self.ptc_hdr["EXTNAME"] = "PTC"
         # additional bookkeeping for a calibration file
         # if this is a new calibration file, we need to bookkeep it in the header
@@ -867,11 +867,11 @@ class KGain(Image):
     @property
     def value(self):
         return self._kgain
-    
+
     @property
     def error(self):
         return self._kgain_error
-    
+
     def copy(self, copy_data = True):
         """
         Make a copy of this KGain file. including data and headers.
@@ -892,9 +892,9 @@ class KGain(Image):
             new_data = self.data # this is just pointer referencing
             new_ptc = self.ptc
             new_err = np.copy(self.err)
-        
+
         new_kg = KGain(new_data, err = new_err, ptc = new_ptc, pri_hdr=self.pri_hdr.copy(), ext_hdr=self.ext_hdr.copy(), err_hdr = self.err_hdr.copy(), ptc_hdr = self.ptc_hdr.copy())
-        
+
         # annoying, but we got to manually update some parameters. Need to keep track of which ones to update
         new_kg.filename = self.filename
         new_kg.filedir = self.filedir
@@ -902,7 +902,7 @@ class KGain(Image):
         # update DRP version tracking
         self.ext_hdr['DRPVERSN'] =  corgidrp.__version__
         self.ext_hdr['DRPCTIME'] =  time.Time.now().isot
-        
+
         return new_kg
 
 
@@ -1260,13 +1260,13 @@ class DetectorParams(Image):
 
 class AstrometricCalibration(Image):
     """
-    Class for astrometric calibration file. 
-    
+    Class for astrometric calibration file.
+
     Args:
         data_or_filepath (str or np.array); either the filepath to the FITS file to read in OR the 2D image data
         pri_hdr (astropy.io.fits.Header): the primary header (required only if raw 2D data is passed in)
         ext_hdr (astropy.io.fits.Header): the image extension header (required only if raw 2D data is passed in)
-        
+
     Attrs:
         boresight (np.array): the [(RA, Dec)] of the center pixel in ([deg], [deg])
         platescale (float): the platescale value in [mas/pixel]
@@ -1284,7 +1284,7 @@ class AstrometricCalibration(Image):
             self.boresight = self.data[:2]
             self.platescale = self.data[2]
             self.northangle = self.data[3]
-            
+
         # if this is a new astrometric calibration file, bookkeep it in the header
         # we need to check if it is new
         if ext_hdr is not None:
@@ -1297,14 +1297,14 @@ class AstrometricCalibration(Image):
 
             # add to history
             self.ext_hdr['HISTORY'] = "Astrometric Calibration file created"
-            
+
             # give a default filename
             self.filename = "AstrometricCalibration.fits"
 
         # check that this is actually an AstrometricCalibration file that was read in
         if 'DATATYPE' not in self.ext_hdr or self.ext_hdr['DATATYPE'] != 'AstrometricCalibration':
-            raise ValueError("File that was loaded was not an AstrometricCalibration file.")    
-        
+            raise ValueError("File that was loaded was not an AstrometricCalibration file.")
+
 datatypes = { "Image" : Image,
              "Dark" : Dark,
               "NonLinearityCalibration" : NonLinearityCalibration,

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -196,7 +196,7 @@ def detect_cosmic_rays(input_dataset, detector_params, sat_thresh=0.7,
             except: # otherwise use commanded EM gain
                 emgain = frame.ext_hdr['CMDGAIN']
         emgain_list.append(emgain)
-    emgain_arr = np.array(emgain_arr)
+    emgain_arr = np.array(emgain_list)
     fwcpp_e_arr = np.array([detector_params.params['fwc_pp'] for frame in crmasked_dataset])
     fwcem_e_arr = np.array([detector_params.params['fwc_em'] for frame in crmasked_dataset])
 

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -186,7 +186,17 @@ def detect_cosmic_rays(input_dataset, detector_params, sat_thresh=0.7,
 
     # Calculate the full well capacity for every frame in the dataset
     kgain = np.array([detector_params.params['kgain'] for frame in crmasked_dataset])
-    emgain_arr = np.array([frame.ext_hdr['CMDGAIN'] for frame in crmasked_dataset])
+    emgain_list = []
+    for frame in crmasked_dataset:
+        try: # use measured gain if available TODO change hdr name if necessary
+            emgain = frame.ext_hdr['EMGAIN_M']
+        except:
+            try: # use applied EM gain if available
+                emgain = frame.ext_hdr['EMGAIN_A']
+            except: # otherwise use commanded EM gain
+                emgain = frame.ext_hdr['CMDGAIN']
+        emgain_list.append(emgain)
+    emgain_arr = np.array(emgain_arr)
     fwcpp_e_arr = np.array([detector_params.params['fwc_pp'] for frame in crmasked_dataset])
     fwcem_e_arr = np.array([detector_params.params['fwc_em'] for frame in crmasked_dataset])
 
@@ -257,9 +267,14 @@ def correct_nonlinearity(input_dataset, non_lin_correction):
     if "CMDGAIN" not in linearized_dataset[0].ext_hdr.keys():
         raise ValueError("EM gain not found in header of input dataset. Non-linearity correction requires EM gain to be in header.")
 
-    em_gain = linearized_dataset[0].ext_hdr["CMDGAIN"] #NOTE THIS REQUIRES THAT THE EM GAIN IS MEASURED ALREADY
-
     for i in range(linearized_cube.shape[0]):
+        try: # use measured gain if available TODO change hdr name if necessary
+            em_gain = linearized_dataset[i].ext_hdr["EMGAIN_M"]
+        except:
+            try: # use applied EM gain if available
+                em_gain = linearized_dataset[i].ext_hdr["EMGAIN_A"]
+            except: # otherwise use commanded EM gain
+                em_gain = linearized_dataset[i].ext_hdr["CMDGAIN"]
         linearized_cube[i] *= get_relgains(linearized_cube[i], em_gain, non_lin_correction)
 
     history_msg = "Data corrected for non-linearity with {0}".format(non_lin_correction.filename)

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -266,9 +266,9 @@ def em_gain_division(input_dataset):
 
     dataset_list, _ = emgain_dataset.split_dataset(exthdr_keywords=['CMDGAIN'])
     if len(dataset_list) > 1:
-        history_msg = "data divided by non-unique EM gain"
+        history_msg = "data divided by EM gain for dataset with frames with different commanded EM gains"
     else:
-        history_msg = "data divided by EM gain {0}".format(str(emgain))
+        history_msg = "data divided by EM gain for dataset with frames with the same commanded EM gain"
 
     # update the output dataset with this EM gain divided data and update the history
     emgain_dataset.update_after_processing_step(history_msg, new_all_data=emgain_cube, new_all_err=emgain_error, header_entries = {"BUNIT":"detected electrons"})

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -6,7 +6,7 @@ from corgidrp.detector import detector_areas
 
 def add_photon_noise(input_dataset):
     """
-    Propagate the photon/shot noise determined from the image signal to the error map. 
+    Propagate the photon/shot noise determined from the image signal to the error map.
 
     Args:
        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)
@@ -18,15 +18,21 @@ def add_photon_noise(input_dataset):
     phot_noise_dataset = input_dataset.copy() # necessary at all?
 
     for i, frame in enumerate(phot_noise_dataset.frames):
-        em_gain = phot_noise_dataset[i].ext_hdr["CMDGAIN"]
+        try: # use measured gain if available TODO change hdr name if necessary
+            em_gain = phot_noise_dataset[i].ext_hdr["EMGAIN_M"]
+        except:
+            try: # use EM applied EM gain if available
+                em_gain = phot_noise_dataset[i].ext_hdr["EMGAIN_A"]
+            except: # otherwise use commanded EM gain
+                em_gain = phot_noise_dataset[i].ext_hdr["CMDGAIN"]
         phot_err = np.sqrt(frame.data)
         #add excess noise in case of em_gain
         if em_gain > 1:
-            phot_err *= np.sqrt(2)           
+            phot_err *= np.sqrt(2)
         frame.add_error_term(phot_err, "photnoise_error")
-    
-    new_all_err = np.array([frame.err for frame in phot_noise_dataset.frames])        
-    
+
+    new_all_err = np.array([frame.err for frame in phot_noise_dataset.frames])
+
     history_msg = "photon noise propagated to error map"
     # update the output dataset
     phot_noise_dataset.update_after_processing_step(history_msg, new_all_err = new_all_err)
@@ -232,7 +238,7 @@ def convert_to_electrons(input_dataset, k_gain):
 def em_gain_division(input_dataset):
     """
 
-    Convert the data from detected EM electrons to detected electrons by dividing the commanded em_gain.
+    Convert the data from detected EM electrons to detected electrons by dividing by the EM gain.
     Update the change in units in the header [detected electrons].
 
     Args:
@@ -247,21 +253,24 @@ def em_gain_division(input_dataset):
     emgain_cube = emgain_dataset.all_data
     emgain_error = emgain_dataset.all_err
 
-    unique = True
-    emgain = emgain_dataset[0].ext_hdr["CMDGAIN"]
     for i in range(len(emgain_dataset)):
-        if emgain != emgain_dataset[i].ext_hdr["CMDGAIN"]:
-            unique = False
-            emgain = emgain_dataset[i].ext_hdr["CMDGAIN"]
+        try: # use measured gain if available TODO change hdr name if necessary
+            emgain = emgain_dataset[i].ext_hdr["EMGAIN_M"]
+        except:
+            try: # use EM applied EM gain if available
+                emgain = emgain_dataset[i].ext_hdr["EMGAIN_A"]
+            except: # otherwise use commanded EM gain
+                emgain = emgain_dataset[i].ext_hdr["CMDGAIN"]
         emgain_cube[i] /= emgain
         emgain_error[i] /= emgain
 
-    if unique:
-        history_msg = "data divided by em_gain {0}".format(str(emgain))
+    dataset_list, _ = emgain_dataset.split_dataset(exthdr_keywords=['CMDGAIN'])
+    if len(dataset_list) > 1:
+        history_msg = "data divided by non-unique EM gain"
     else:
-        history_msg = "data divided by non-unique em_gain"
+        history_msg = "data divided by EM gain {0}".format(str(emgain))
 
-    # update the output dataset with this em_gain divided data and update the history
+    # update the output dataset with this EM gain divided data and update the history
     emgain_dataset.update_after_processing_step(history_msg, new_all_data=emgain_cube, new_all_err=emgain_error, header_entries = {"BUNIT":"detected electrons"})
 
     return emgain_dataset

--- a/tests/test_emgain_div.py
+++ b/tests/test_emgain_div.py
@@ -5,38 +5,38 @@ from corgidrp.data import Image, Dataset
 import corgidrp.l2a_to_l2b as l2a_to_l2b
 
 def test_emgain_div():
-    data = np.ones([1024,1024]) * 2 
+    data = np.ones([1024,1024]) * 2
     err = np.ones([1,1024,1024]) *0.5
     prhd, exthd = create_default_headers()
     exthd["CMDGAIN"] = 1000
     image1 = Image(data,pri_hdr = prhd, ext_hdr = exthd, err = err)
     image2 = image1.copy()
     dataset=Dataset([image1, image2])
-    
+
     ###### perform em_gain division
     gain_dataset = l2a_to_l2b.em_gain_division(dataset)
-    assert("em_gain" in str(gain_dataset[0].ext_hdr["HISTORY"]))
+    assert("same" in str(gain_dataset[0].ext_hdr["HISTORY"]))
 
     emgain = gain_dataset[0].ext_hdr['CMDGAIN']
-    
+
     # check the level of the dataset
     assert np.mean(gain_dataset.all_data) == pytest.approx(np.mean(dataset.all_data)/emgain, abs=1e-3)
     assert np.mean(gain_dataset.all_err) == pytest.approx(np.mean(dataset.all_err)/emgain, abs=1e-3)
     assert gain_dataset[0].ext_hdr["BUNIT"] == "detected electrons"
     assert gain_dataset[0].err_hdr["BUNIT"] == "detected electrons"
-  
+
     print(gain_dataset[0].ext_hdr)
-    
+
     # check non-unique emgain
     emgain1 = 100
     dataset[1].ext_hdr['CMDGAIN'] = emgain1
     gain_dataset = l2a_to_l2b.em_gain_division(dataset)
-    assert("non-unique" in str(gain_dataset[0].ext_hdr["HISTORY"]))
+    assert("different" in str(gain_dataset[0].ext_hdr["HISTORY"]))
     assert np.mean(gain_dataset.all_data[0]) == pytest.approx(np.mean(dataset.all_data[0])/emgain, abs=1e-3)
     assert np.mean(gain_dataset.all_data[1]) == pytest.approx(np.mean(dataset.all_data[1])/emgain1, abs=1e-3)
     assert np.mean(gain_dataset.all_err[0]) == pytest.approx(np.mean(dataset.all_err[0])/emgain, abs=1e-3)
     assert np.mean(gain_dataset.all_err[1]) == pytest.approx(np.mean(dataset.all_err[1])/emgain1, abs=1e-3)
-    
+
 
 if __name__ == "__main__":
     test_emgain_div()


### PR DESCRIPTION
## Describe your changes
Where absolute EM gain is desired, this PR tries to retrieve the header key measured EM gain (EMGAIN_M), and if applied EM gain (EMGAIN_A) if that fails, and commanded EM gain (CMDGAIN) if that fails.  For sorting by EM gain, commanded EM gain or applied EM gain is used instead of measured EM gain (since measured EM gain will vary frame to frame even if the commanded EM gain is the same for them all).

## Type of change
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
#108 

## Checklist before requesting a review
- [X ] I have linted my code
- [X ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [X ] I have verified that all docstrings are properly formatted and added new documentation, as needed
