### PR TITLE
Add some missing L2b headers and improved frame selection

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -401,6 +401,18 @@ class Image():
             self.err = self.err[:1] # only save the total err, preserve 3-D shape
         self.err_hdr['TRK_ERRS'] = corgidrp.track_individual_errors # specify whether we are tracing errors
 
+        # the DRP needs to make sure certain keywords are set in its reduced products
+        # check those here, and if not, set them. 
+        # by default, assume desmear and CTI correction are not applied by default
+        # and they can be toggled to true after their step functions are run
+        if not 'DESMEAR' in self.ext_hdr:
+            self.ext_hdr.set('DESMEAR', False, "Was desmear applied to this frame?")
+        if not 'CTI_CORR' in self.ext_hdr:
+            self.ext_hdr.set('CTI_CORR', False, "Was CTI correction applied to this frame?")
+        if not 'IS_BAD' in self.ext_hdr:
+            self.ext_hdr.set('IS_BAD', False, "Was this frame deemed bad?")
+
+
 
 
     # create this field dynamically

--- a/tests/test_desmear.py
+++ b/tests/test_desmear.py
@@ -51,12 +51,20 @@ def test_desmear():
     
     assert type(dataset_smeared) == corgidrp.data.Dataset
 
+    # check the header keyword hasn't been toggled yet
+    for frame in dataset_smeared:
+        assert not frame.ext_hdr['DESMEAR']
+
     # Apply desmear correction
     dataset_desmear = desmear(dataset_smeared, detector_params)
 
     assert type(dataset_desmear) == corgidrp.data.Dataset
 
     assert(np.max(np.abs(dataset_desmear.all_data[0] - unsmeared_frame)) < tol)
+
+    # check the header keyword is toggled
+    for frame in dataset_desmear:
+        assert frame.ext_hdr['DESMEAR']
 
 if __name__ == '__main__':
     test_desmear()


### PR DESCRIPTION
## Describe your changes

 * Ensure DESMEAR, CTI_CORR, and IS_BAD is in every science data frame by setting them on read-in if they don't exist
 * desmear steps sets DESMEAR to True
 * Frame selection step now checks both tip and tilt rms
 * Frame selection step now checks for tip and tilt bias/offset as well
 * Frame selection can keep bad frames instead of automatically dropping them from processing
 * Associated tests for desmear and frame selection updated

CTI correction hasn't been implemented yet, so not implemented. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)

Partially address #142

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
