### PR TITLE
get_calib can take None as input

### DIFF
--- a/corgidrp/caldb.py
+++ b/corgidrp/caldb.py
@@ -103,6 +103,27 @@ class CalDB:
                     Dictionary of data entry properties keyed by column names
 
         """
+        # return a dummy entry if nothing is passed in
+        if entry is None:
+            time_now = time.Time.now()
+            row_dict = {
+                "Filepath" : "",
+                "Type" : "Sci",
+                "MJD" : time_now.mjd,
+                "EXPTIME" : 0.,
+                "Files Used" : 0,
+                "Date Created" : time_now.mjd,
+                "Hash" : hash(time_now),
+                "DRPVERSN" : "0.0",
+                "OBSID" : 0,
+                "NAXIS1": 0,
+                "NAXIS2" : 0,
+                "OPMODE" : "",
+                "CMDGAIN" : 0.,
+                "EXCAMT" : 0
+            }
+            return list(row_dict.values()), row_dict
+
         filepath = os.path.abspath(entry.filepath)
         if is_calib:
             datatype = labels[entry.__class__]  # get the database str representation
@@ -224,7 +245,8 @@ class CalDB:
         Outputs the best calibration file of the given type for the input sciene frame.
 
         Args:
-            frame (corgidrp.data.Image): an image frame to request a calibratio for
+            frame (corgidrp.data.Image): an image frame to request a calibration for. If None is passed in, looks for the 
+                                         most recently created calibration. 
             dtype (corgidrp.data Class): for example: corgidrp.data.Dark (TODO: document the entire list of options)
             to_disk (bool): True by default, will update DB from disk before matching
 
@@ -247,7 +269,20 @@ class CalDB:
         # downselect to only calibs of this type
         calibdf = self._db[self._db["Type"] == dtype_label]
 
-        if dtype_label in ["Dark"]:
+        # different logic for different cases
+        # each if/else statement returns a single filepath to a good calibration
+        if frame is None:
+            # no frame is passed in, get the most recently created 
+            options = calibdf
+
+            if len(options) == 0:
+                raise ValueError("No valid {0} calibration in caldb located at {1}".format(dtype_label, self.filepath))
+
+            # select the one that was most recently created
+            result_index = options["Date Created"].argmax()
+            calib_filepath = options.iloc[result_index, 0]
+
+        elif dtype_label in ["Dark"]:
             # general selection criteria for 2D image frames. Can use different selection criteria for different dtypes
             options = calibdf.loc[
                 (
@@ -256,19 +291,27 @@ class CalDB:
                     & (calibdf["NAXIS2"] == frame_dict["NAXIS2"])
                 )
             ]
+
+            if len(options) == 0:
+                raise ValueError("No valid Dark with EXPTIME={0} and dimension ({1},{2})"
+                                 .format(frame_dict["EXPTIME"], frame_dict["NAXIS1"], frame_dict["NAXIS2"]))
+
+            # select the one closest in time
+            result_index = np.abs(options["MJD"] - frame_dict["MJD"]).argmin()
+            calib_filepath = options.iloc[result_index, 0]
         else:
             options = calibdf
 
-        if len(options) == 0:
-            raise ValueError("No valid {0} calibration in caldb located at {1}".format(dtype_label, self.filepath))
+            if len(options) == 0:
+                raise ValueError("No valid {0} calibration in caldb located at {1}".format(dtype_label, self.filepath))
 
-        # select the one closest in time
-        result_index = np.abs(options["MJD"] - frame_dict["MJD"]).argmin()
-        calib_filepath = options.iloc[result_index, 0]
+            # select the one closest in time
+            result_index = np.abs(options["MJD"] - frame_dict["MJD"]).argmin()
+            calib_filepath = options.iloc[result_index, 0]
 
         # load the object from disk and return it
         return dtype(calib_filepath)
-
+    
     def scan_dir_for_new_entries(self, filedir, look_in_subfolders=True, to_disk=True):
         """
         Scan a folder and subfolder for calibration files and add them all to the caldb

--- a/tests/test_caldb.py
+++ b/tests/test_caldb.py
@@ -122,6 +122,16 @@ def test_get_calib():
 
     with pytest.raises(ValueError):
         _ = testcaldb.get_calib(dark_dataset[2], data.DetectorNoiseMaps)
+
+    # make a second one dark
+    master_dark_2 = data.Dark(dark_dataset[1].data, dark_dataset[1].pri_hdr, dark_dataset[0].ext_hdr, dark_dataset)
+    # save master dark to disk to be loaded later
+    master_dark_2.save(filedir=calibdir, filename="mockdark2.fits")
+    testcaldb.create_entry(master_dark_2)
+
+    # test that with no input data, we get the most recent dark
+    auto_dark_2 = testcaldb.get_calib(None, data.Dark)
+    assert(auto_dark_2.filepath == master_dark_2.filepath)
         
     # reset everything
     os.remove(testcaldb_filepath)


### PR DESCRIPTION
## Describe your changes

`caldb.get_calib(None, dtype)` now works and returns the latest created calibration of that dtype. The thinking is that we only use this when we are running a recipe with no input data, but want to process newly calibrated calibrations to produce other calibrations (e.g., dark + flat to make bad pixel map).

Does this avoid needing to add a bunch of extra logic to walker.py?

## Type of change

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have linted my code
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
