### PR TITLE
accommodation of EMGAIN_M, EMGAIN_A, and CMDGAIN in that order of priority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ tests/e2e_tests/*/*.json
 # Output figures
 figures/
 tests/figures/
+tests/test_data/simastrom/guesses.csv

--- a/corgidrp/calibrate_kgain.py
+++ b/corgidrp/calibrate_kgain.py
@@ -858,8 +858,11 @@ def kgain_dataset_2_list(dataset):
                 if record_gain:
                     try: # if EM gain measured directly from frame TODO change hdr name if necessary
                         gains.append(frame.ext_hdr['EMGAIN_M'])
-                    except: # use commanded gain otherwise
-                        gains.append(frame.ext_hdr['CMDGAIN'])
+                    except:
+                        try: # use applied EM gain if available
+                            gains.append(frame.ext_hdr['EMGAIN_A'])
+                        except: # use commanded gain otherwise
+                            gains.append(frame.ext_hdr['CMDGAIN'])
                     record_gain = False
                 
         # Calibration data may have different subsets
@@ -890,12 +893,10 @@ def kgain_dataset_2_list(dataset):
         raise Exception('DATETIMEs cannot be duplicated')
     # There can only be an EM gain in the data used to calibrate K-gain
     if len(set(em_gains)) != 1:
-        raise Exception('There can only be one commanded gain when calibrating K-Gain')
+        raise Exception('There can only be one commanded EM gain when calibrating K-Gain')
     if np.any(np.array(gains) < 1):
         raise Exception('Actual EM gains must be greater than or equal to 1')
     # When measuring k_gain, there can only be one gain for all exposure times
-    actual_gain = gains[0]
-    if len(set(gains)) != 1:
-        raise Exception('Actual EM gain for K-gain calibration frames must be the same for all exposure times.')
-
+    actual_gain = np.mean(gains) # not actually used in k gain calibration since frames already gain-divided
+    
     return stack, mean_frame_stack, actual_gain

--- a/corgidrp/calibrate_nonlin.py
+++ b/corgidrp/calibrate_nonlin.py
@@ -881,8 +881,11 @@ def nonlin_dataset_2_stack(dataset):
                 if record_gain:
                     try: # if EM gain measured directly from frame TODO change hdr name if necessary
                         gains.append(frame.ext_hdr['EMGAIN_M'])
-                    except: # use commanded gain otherwise
-                        gains.append(frame.ext_hdr['CMDGAIN'])
+                    except:
+                        try: # use applied EM gain if available
+                            gains.append(frame.ext_hdr['EMGAIN_A'])
+                        except: # use commanded gain otherwise
+                            gains.append(frame.ext_hdr['CMDGAIN'])
                     record_gain = False
         # First layer (array of unique EM values)
         stack.append(np.stack(sub_stack))
@@ -896,7 +899,7 @@ def nonlin_dataset_2_stack(dataset):
         raise Exception('Substacks must have at least one element')
     # Every EM gain must be greater than or equal to 1
     if np.any(np.array(split[1]) < 1):
-        raise Exception('Commanded EM gains must be greater than or equal to 1') 
+        raise Exception('Each set of frames categorized by commanded EM gains must be have 1 or more frames')
     if np.any(np.array(gains) < 1):
         raise Exception('Actual EM gains must be greater than or equal to 1')
 

--- a/corgidrp/darks.py
+++ b/corgidrp/darks.py
@@ -461,8 +461,11 @@ def calibrate_darks_lsq(dataset, detector_params, detector_regions=None):
                             'same number of frames and frame shape.')
         try: # if EM gain measured directly from frame TODO change hdr name if necessary
             EMgain_arr = np.append(EMgain_arr, datasets[i].frames[0].ext_hdr['EMGAIN_M'])
-        except: # use commanded gain otherwise TODO change hdr name if necessary
-            EMgain_arr = np.append(EMgain_arr, datasets[i].frames[0].ext_hdr['CMDGAIN'])
+        except:
+            try: # use applied EM gain if available
+                EMgain_arr = np.append(EMgain_arr, datasets[i].frames[0].ext_hdr['EMGAIN_A'])
+            except: # use commanded gain otherwise
+                EMgain_arr = np.append(EMgain_arr, datasets[i].frames[0].ext_hdr['CMDGAIN'])
         exptime = datasets[i].frames[0].ext_hdr['EXPTIME']
         cmdgain = datasets[i].frames[0].ext_hdr['CMDGAIN']
         kgain = datasets[i].frames[0].ext_hdr['KGAIN']
@@ -792,10 +795,13 @@ def build_synthesized_dark(dataset, noisemaps, detector_regions=None, full_frame
         _, unique_vals = dataset.split_dataset(exthdr_keywords=['EXPTIME', 'CMDGAIN', 'KGAIN'])
         if len(unique_vals) > 1:
             raise Exception('Input dataset should contain frames of the same exposure time, commanded EM gain, and k gain.')
-        try:
+        try: # use measured EM gain if available TODO change hdr name if necessary
             g = dataset.frames[0].ext_hdr['EMGAIN_M']
         except:
-            g = dataset.frames[0].ext_hdr['CMDGAIN']
+            try: # use applied EM gain if available
+                g = dataset.frames[0].ext_hdr['EMGAIN_A']
+            except: # otherwise, use commanded EM gain
+                g = dataset.frames[0].ext_hdr['CMDGAIN']
         t = dataset.frames[0].ext_hdr['EXPTIME']
 
         rows = detector_regions['SCI']['frame_rows']
@@ -838,7 +844,7 @@ def build_synthesized_dark(dataset, noisemaps, detector_regions=None, full_frame
         exthdr['NAXIS1'] = Fd.shape[0]
         exthdr['NAXIS2'] = Fd.shape[1]
         exthdr['DATATYPE'] = 'Dark'
-        exthdr['CMDGAIN'] = g
+        exthdr['CMDGAIN'] = g # reconciling measured vs applied vs commanded not important for synthesized product; this is simply the user-specified gain
         exthdr['EXPTIME'] = t
         # wipe clean so that the proper documenting occurs for dark
         exthdr.pop('DRPNFILE')

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -617,7 +617,7 @@ class Dark(Image):
                 self._record_parent_filenames(input_dataset)
 
             # add to history
-            self.ext_hdr['HISTORY'] = "Dark with exptime = {0} s and EM gain = {1} created from {2} frames".format(self.ext_hdr['EXPTIME'], self.ext_hdr['CMDGAIN'], self.ext_hdr['DRPNFILE'])
+            self.ext_hdr['HISTORY'] = "Dark with exptime = {0} s and commanded EM gain = {1} created from {2} frames".format(self.ext_hdr['EXPTIME'], self.ext_hdr['CMDGAIN'], self.ext_hdr['DRPNFILE'])
 
             # give it a default filename using the first input file as the base
             # strip off everything starting at .fits

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -186,7 +186,17 @@ def detect_cosmic_rays(input_dataset, detector_params, sat_thresh=0.7,
 
     # Calculate the full well capacity for every frame in the dataset
     kgain = np.array([detector_params.params['kgain'] for frame in crmasked_dataset])
-    emgain_arr = np.array([frame.ext_hdr['CMDGAIN'] for frame in crmasked_dataset])
+    emgain_list = []
+    for frame in crmasked_dataset:
+        try: # use measured gain if available TODO change hdr name if necessary
+            emgain = frame.ext_hdr['EMGAIN_M']
+        except:
+            try: # use applied EM gain if available
+                emgain = frame.ext_hdr['EMGAIN_A']
+            except: # otherwise use commanded EM gain
+                emgain = frame.ext_hdr['CMDGAIN']
+        emgain_list.append(emgain)
+    emgain_arr = np.array(emgain_list)
     fwcpp_e_arr = np.array([detector_params.params['fwc_pp'] for frame in crmasked_dataset])
     fwcem_e_arr = np.array([detector_params.params['fwc_em'] for frame in crmasked_dataset])
 
@@ -257,9 +267,14 @@ def correct_nonlinearity(input_dataset, non_lin_correction):
     if "CMDGAIN" not in linearized_dataset[0].ext_hdr.keys():
         raise ValueError("EM gain not found in header of input dataset. Non-linearity correction requires EM gain to be in header.")
 
-    em_gain = linearized_dataset[0].ext_hdr["CMDGAIN"] #NOTE THIS REQUIRES THAT THE EM GAIN IS MEASURED ALREADY
-
     for i in range(linearized_cube.shape[0]):
+        try: # use measured gain if available TODO change hdr name if necessary
+            em_gain = linearized_dataset[i].ext_hdr["EMGAIN_M"]
+        except:
+            try: # use applied EM gain if available
+                em_gain = linearized_dataset[i].ext_hdr["EMGAIN_A"]
+            except: # otherwise use commanded EM gain
+                em_gain = linearized_dataset[i].ext_hdr["CMDGAIN"]
         linearized_cube[i] *= get_relgains(linearized_cube[i], em_gain, non_lin_correction)
 
     history_msg = "Data corrected for non-linearity with {0}".format(non_lin_correction.filename)

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -18,7 +18,13 @@ def add_photon_noise(input_dataset):
     phot_noise_dataset = input_dataset.copy() # necessary at all?
 
     for i, frame in enumerate(phot_noise_dataset.frames):
-        em_gain = phot_noise_dataset[i].ext_hdr["CMDGAIN"]
+        try: # use measured gain if available TODO change hdr name if necessary
+            em_gain = phot_noise_dataset[i].ext_hdr["EMGAIN_M"]
+        except:
+            try: # use EM applied EM gain if available
+                em_gain = phot_noise_dataset[i].ext_hdr["EMGAIN_A"]
+            except: # otherwise use commanded EM gain
+                em_gain = phot_noise_dataset[i].ext_hdr["CMDGAIN"]
         phot_err = np.sqrt(frame.data)
         #add excess noise in case of em_gain
         if em_gain > 1:
@@ -232,7 +238,7 @@ def convert_to_electrons(input_dataset, k_gain):
 def em_gain_division(input_dataset):
     """
 
-    Convert the data from detected EM electrons to detected electrons by dividing the commanded em_gain.
+    Convert the data from detected EM electrons to detected electrons by dividing by the EM gain.
     Update the change in units in the header [detected electrons].
 
     Args:
@@ -247,21 +253,24 @@ def em_gain_division(input_dataset):
     emgain_cube = emgain_dataset.all_data
     emgain_error = emgain_dataset.all_err
 
-    unique = True
-    emgain = emgain_dataset[0].ext_hdr["CMDGAIN"]
     for i in range(len(emgain_dataset)):
-        if emgain != emgain_dataset[i].ext_hdr["CMDGAIN"]:
-            unique = False
-            emgain = emgain_dataset[i].ext_hdr["CMDGAIN"]
+        try: # use measured gain if available TODO change hdr name if necessary
+            emgain = emgain_dataset[i].ext_hdr["EMGAIN_M"]
+        except:
+            try: # use EM applied EM gain if available
+                emgain = emgain_dataset[i].ext_hdr["EMGAIN_A"]
+            except: # otherwise use commanded EM gain
+                emgain = emgain_dataset[i].ext_hdr["CMDGAIN"]
         emgain_cube[i] /= emgain
         emgain_error[i] /= emgain
 
-    if unique:
-        history_msg = "data divided by em_gain {0}".format(str(emgain))
+    dataset_list, _ = emgain_dataset.split_dataset(exthdr_keywords=['CMDGAIN'])
+    if len(dataset_list) > 1:
+        history_msg = "data divided by EM gain for dataset with frames with different commanded EM gains"
     else:
-        history_msg = "data divided by non-unique em_gain"
+        history_msg = "data divided by EM gain for dataset with frames with the same commanded EM gain"
 
-    # update the output dataset with this em_gain divided data and update the history
+    # update the output dataset with this EM gain divided data and update the history
     emgain_dataset.update_after_processing_step(history_msg, new_all_data=emgain_cube, new_all_err=emgain_error, header_entries = {"BUNIT":"detected electrons"})
 
     return emgain_dataset

--- a/tests/test_emgain_div.py
+++ b/tests/test_emgain_div.py
@@ -15,7 +15,7 @@ def test_emgain_div():
     
     ###### perform em_gain division
     gain_dataset = l2a_to_l2b.em_gain_division(dataset)
-    assert("em_gain" in str(gain_dataset[0].ext_hdr["HISTORY"]))
+    assert("same" in str(gain_dataset[0].ext_hdr["HISTORY"]))
 
     emgain = gain_dataset[0].ext_hdr['CMDGAIN']
     
@@ -31,7 +31,7 @@ def test_emgain_div():
     emgain1 = 100
     dataset[1].ext_hdr['CMDGAIN'] = emgain1
     gain_dataset = l2a_to_l2b.em_gain_division(dataset)
-    assert("non-unique" in str(gain_dataset[0].ext_hdr["HISTORY"]))
+    assert("different" in str(gain_dataset[0].ext_hdr["HISTORY"]))
     assert np.mean(gain_dataset.all_data[0]) == pytest.approx(np.mean(dataset.all_data[0])/emgain, abs=1e-3)
     assert np.mean(gain_dataset.all_data[1]) == pytest.approx(np.mean(dataset.all_data[1])/emgain1, abs=1e-3)
     assert np.mean(gain_dataset.all_err[0]) == pytest.approx(np.mean(dataset.all_err[0])/emgain, abs=1e-3)


### PR DESCRIPTION
## Describe your changes
Where absolute EM gain is desired, this PR tries to retrieve the header key measured EM gain (EMGAIN_M), and if applied EM gain (EMGAIN_A) if that fails, and commanded EM gain (CMDGAIN) if that fails. For sorting by EM gain, commanded EM gain or applied EM gain is used instead of measured EM gain (since measured EM gain will vary frame to frame even if the commanded EM gain is the same for them all).
(same changes as in deleted emgain_a branch but w/o whitespace differences)

## Type of change
New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
#108 

## Checklist before requesting a review
- [ X] I have linted my code
- [ X] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ X] I have verified that all docstrings are properly formatted and added new documentation, as needed
