### PR TITLE
frame combination step function and test

### DIFF
--- a/corgidrp/combine.py
+++ b/corgidrp/combine.py
@@ -1,0 +1,79 @@
+"""
+Module to support frame combination
+"""
+import numpy as np
+import corgidrp.data as data
+
+
+def combine_images(data_subset, err_subset, dq_subset, collapse="lower"):
+    """
+    Combines several images
+
+    Args:
+        data_subset (np.array): 3-D array of N 2-D images
+        err_subset (np.array): 4-D array of N 2-D error maps
+        dq_subset (np.array): 3-D array of N 2-D DQ maps
+    """
+    tot_frames = data_subset.shape[0]
+    # mask bad pixels
+    bad = np.where(dq_subset > 0)
+    data_subset[bad] = np.nan
+    err_subset[bad[0],:,bad[1],bad[2]] = np.nan
+    # track the number of good values that go into the combination
+    n_samples = np.ones(data_subset.shape)
+    n_samples[bad] = 0
+    n_samples = np.sum(n_samples, axis=0)
+    if collapse.lower() == "mean":
+        data_collapse = np.nanmean(data_subset, axis=0) * tot_frames
+        err_collapse = np.sqrt(np.nanmean(err_subset**2, axis=0)) * tot_frames/np.sqrt(n_samples) # not sure if this is correct, but good enough for now
+    elif collapse.lower() == "median":
+        data_collapse = np.nanmedian(data_subset, axis=0) * tot_frames
+        err_collapse = np.sqrt(np.nanmean(err_subset**2, axis=0)) * tot_frames/np.sqrt(n_samples) * np.sqrt(np.pi/2) # inflate median error
+    # dq collpase: keep all flags on
+    dq_collapse = np.bitwise_or.reduce(dq_subset, axis=0)
+    # except those pixels that have been replaced 
+    dq_collapse[np.where((dq_collapse > 0) & (~np.isnan(data_collapse)))] = 0
+
+    return data_collapse, err_collapse, dq_collapse
+
+
+
+def combine_subexposures(input_dataset, num_frames_per_group, collapse="mean"):
+    """
+    Combines a sequence of exposures assuming a constant nubmer of frames per group
+    The length of the dataset must be divisible by the number of frames per group
+    
+    Args:
+        input_dataset (corgidrp.data.Dataset): input data. 
+        num_frames_per_group (int): number of subexposures per group
+        collapse (str): "mean" or "median". Regardless, the images are scaled by num_frames_per_group to ~conserve photons
+    """
+    if len(input_dataset) % num_frames_per_group != 0:
+        raise ValueError("Input dataset of lenght {0} cannot be grouped in sets of {1}".format(len(input_dataset, num_frames_per_group)))
+    
+    if collapse.lower() not in ["mean", "median"]:
+        raise ValueError("combine_subexposures can only collapse with mean or median")
+
+    num_groups = len(input_dataset) // num_frames_per_group
+    new_dataset = []
+    for i in range(num_groups):
+        data_subset = np.copy(input_dataset.all_data[num_frames_per_group*i:num_frames_per_group*(i+1)])
+        err_subset = np.copy(input_dataset.all_err[num_frames_per_group*i:num_frames_per_group*(i+1)])
+        dq_subset = input_dataset.all_dq[num_frames_per_group*i:num_frames_per_group*(i+1)]
+
+        data_collapse, err_collapse, dq_collapse = combine_images(data_subset, err_subset, dq_subset, collapse=collapse)
+
+        # grab the headers from the first frame in this sub sequence
+        pri_hdr = input_dataset[num_frames_per_group*i].pri_hdr.copy()
+        ext_hdr = input_dataset[num_frames_per_group*i].ext_hdr.copy()
+        err_hdr = input_dataset[num_frames_per_group*i].err_hdr.copy()
+        dq_hdr = input_dataset[num_frames_per_group*i].err_hdr.copy()
+        new_image = data.Image(data_collapse, pri_hdr=pri_hdr, ext_hdr=ext_hdr, err=err_collapse, dq=dq_collapse, err_hdr=err_hdr, 
+                                dq_hdr=dq_hdr, input_hdulist=input_dataset[num_frames_per_group*i].hdu_list)   
+        new_image.filename = input_dataset[num_frames_per_group*i].filename
+        new_image._record_parent_filenames(input_dataset[num_frames_per_group*i:num_frames_per_group*(i+1)])   
+        new_dataset.append(new_image)
+    new_dataset = data.Dataset(new_dataset)
+    new_dataset.update_after_processing_step("Combine_subexposures: combined every {0} frames by {1}".format(num_frames_per_group, collapse))
+
+    return new_dataset

--- a/corgidrp/combine.py
+++ b/corgidrp/combine.py
@@ -7,12 +7,18 @@ import corgidrp.data as data
 
 def combine_images(data_subset, err_subset, dq_subset, collapse="lower"):
     """
-    Combines several images
+    Combines several images together
 
     Args:
         data_subset (np.array): 3-D array of N 2-D images
         err_subset (np.array): 4-D array of N 2-D error maps
         dq_subset (np.array): 3-D array of N 2-D DQ maps
+        collapse (str): "mean" or "median". Regardless, the images are scaled by num_frames_per_group to ~conserve photons
+
+    Returns:
+        np.array: 2-D array of combined images
+        np.array: 3-D array of combined error map
+        np.array: 2-D array of combined DQ maps
     """
     tot_frames = data_subset.shape[0]
     # mask bad pixels
@@ -47,6 +53,9 @@ def combine_subexposures(input_dataset, num_frames_per_group, collapse="mean"):
         input_dataset (corgidrp.data.Dataset): input data. 
         num_frames_per_group (int): number of subexposures per group
         collapse (str): "mean" or "median". Regardless, the images are scaled by num_frames_per_group to ~conserve photons
+
+    Returns:
+        corgidrp.data.Dataset: dataset after combination of every "num_frames_per_group" frames together
     """
     if len(input_dataset) % num_frames_per_group != 0:
         raise ValueError("Input dataset of lenght {0} cannot be grouped in sets of {1}".format(len(input_dataset, num_frames_per_group)))

--- a/corgidrp/combine.py
+++ b/corgidrp/combine.py
@@ -44,19 +44,22 @@ def combine_images(data_subset, err_subset, dq_subset, collapse="lower"):
 
 
 
-def combine_subexposures(input_dataset, num_frames_per_group, collapse="mean"):
+def combine_subexposures(input_dataset, num_frames_per_group=None, collapse="mean"):
     """
     Combines a sequence of exposures assuming a constant nubmer of frames per group
     The length of the dataset must be divisible by the number of frames per group
     
     Args:
         input_dataset (corgidrp.data.Dataset): input data. 
-        num_frames_per_group (int): number of subexposures per group
+        num_frames_per_group (int): number of subexposures per group. If None, combines all images together
         collapse (str): "mean" or "median". Regardless, the images are scaled by num_frames_per_group to ~conserve photons
 
     Returns:
         corgidrp.data.Dataset: dataset after combination of every "num_frames_per_group" frames together
     """
+    if num_frames_per_group is None:
+        num_frames_per_group = len(input_dataset)
+
     if len(input_dataset) % num_frames_per_group != 0:
         raise ValueError("Input dataset of lenght {0} cannot be grouped in sets of {1}".format(len(input_dataset, num_frames_per_group)))
     

--- a/corgidrp/combine.py
+++ b/corgidrp/combine.py
@@ -5,7 +5,7 @@ import numpy as np
 import corgidrp.data as data
 
 
-def combine_images(data_subset, err_subset, dq_subset, collapse="lower"):
+def combine_images(data_subset, err_subset, dq_subset, collapse, num_frames_scaling):
     """
     Combines several images together
 
@@ -13,7 +13,8 @@ def combine_images(data_subset, err_subset, dq_subset, collapse="lower"):
         data_subset (np.array): 3-D array of N 2-D images
         err_subset (np.array): 4-D array of N 2-D error maps
         dq_subset (np.array): 3-D array of N 2-D DQ maps
-        collapse (str): "mean" or "median". Regardless, the images are scaled by num_frames_per_group to ~conserve photons
+        collapse (str): "mean" or "median". 
+        num_frames_scaling (bool): Multiply by number of frames in sequence in order to ~conserve photons
 
     Returns:
         np.array: 2-D array of combined images
@@ -30,11 +31,16 @@ def combine_images(data_subset, err_subset, dq_subset, collapse="lower"):
     n_samples[bad] = 0
     n_samples = np.sum(n_samples, axis=0)
     if collapse.lower() == "mean":
-        data_collapse = np.nanmean(data_subset, axis=0) * tot_frames
-        err_collapse = np.sqrt(np.nanmean(err_subset**2, axis=0)) * tot_frames/np.sqrt(n_samples) # not sure if this is correct, but good enough for now
+        data_collapse = np.nanmean(data_subset, axis=0)
+        err_collapse = np.sqrt(np.nanmean(err_subset**2, axis=0)) /np.sqrt(n_samples) # not sure if this is correct, but good enough for now
     elif collapse.lower() == "median":
-        data_collapse = np.nanmedian(data_subset, axis=0) * tot_frames
-        err_collapse = np.sqrt(np.nanmean(err_subset**2, axis=0)) * tot_frames/np.sqrt(n_samples) * np.sqrt(np.pi/2) # inflate median error
+        data_collapse = np.nanmedian(data_subset, axis=0)
+        err_collapse = np.sqrt(np.nanmean(err_subset**2, axis=0)) /np.sqrt(n_samples) * np.sqrt(np.pi/2) # inflate median error
+    if num_frames_scaling:
+        # scale up by the number of frames
+        data_collapse *= tot_frames
+        err_collapse *= tot_frames
+    
     # dq collpase: keep all flags on
     dq_collapse = np.bitwise_or.reduce(dq_subset, axis=0)
     # except those pixels that have been replaced 
@@ -44,15 +50,20 @@ def combine_images(data_subset, err_subset, dq_subset, collapse="lower"):
 
 
 
-def combine_subexposures(input_dataset, num_frames_per_group=None, collapse="mean"):
+def combine_subexposures(input_dataset, num_frames_per_group=None, collapse="mean", num_frames_scaling=True):
     """
-    Combines a sequence of exposures assuming a constant nubmer of frames per group
-    The length of the dataset must be divisible by the number of frames per group
+    Combines a sequence of exposures assuming a constant nubmer of frames per group. 
+    The length of the dataset must be divisible by the number of frames per group.
+    
+    The combination is done with either the mean or median, but the collapsed image can be scaled 
+    in order to ~conserve the total number of photons in the input dataset (this essentially turns a
+    median into a sum)
     
     Args:
         input_dataset (corgidrp.data.Dataset): input data. 
         num_frames_per_group (int): number of subexposures per group. If None, combines all images together
-        collapse (str): "mean" or "median". Regardless, the images are scaled by num_frames_per_group to ~conserve photons
+        collapse (str): "mean" or "median". (default: mean) 
+        num_frames_scaling (bool): Multiply by number of frames in sequence in order to ~conserve photons (default: True)
 
     Returns:
         corgidrp.data.Dataset: dataset after combination of every "num_frames_per_group" frames together
@@ -73,15 +84,17 @@ def combine_subexposures(input_dataset, num_frames_per_group=None, collapse="mea
         err_subset = np.copy(input_dataset.all_err[num_frames_per_group*i:num_frames_per_group*(i+1)])
         dq_subset = input_dataset.all_dq[num_frames_per_group*i:num_frames_per_group*(i+1)]
 
-        data_collapse, err_collapse, dq_collapse = combine_images(data_subset, err_subset, dq_subset, collapse=collapse)
+        data_collapse, err_collapse, dq_collapse = combine_images(data_subset, err_subset, dq_subset, collapse=collapse, 
+                                                                  num_frames_scaling=num_frames_scaling)
 
         # grab the headers from the first frame in this sub sequence
         pri_hdr = input_dataset[num_frames_per_group*i].pri_hdr.copy()
         ext_hdr = input_dataset[num_frames_per_group*i].ext_hdr.copy()
         err_hdr = input_dataset[num_frames_per_group*i].err_hdr.copy()
         dq_hdr = input_dataset[num_frames_per_group*i].err_hdr.copy()
+        hdulist = input_dataset[num_frames_per_group*i].hdu_list.copy()
         new_image = data.Image(data_collapse, pri_hdr=pri_hdr, ext_hdr=ext_hdr, err=err_collapse, dq=dq_collapse, err_hdr=err_hdr, 
-                                dq_hdr=dq_hdr, input_hdulist=input_dataset[num_frames_per_group*i].hdu_list)   
+                                dq_hdr=dq_hdr, input_hdulist=hdulist)   
         new_image.filename = input_dataset[num_frames_per_group*i].filename
         new_image._record_parent_filenames(input_dataset[num_frames_per_group*i:num_frames_per_group*(i+1)])   
         new_dataset.append(new_image)

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -457,14 +457,25 @@ class Image():
         """
         Record what input dataset was used to create this Image.
         This assumes many Images were used to make this single Image.
+        Also tracks images that were used to make the images that make this image.
         Record is stored in the ext header.
 
         Args:
             input_dataset (corgidrp.data.Dataset): the input dataset that were combined together to make this image
         """
-        self.ext_hdr.set('DRPNFILE', len(input_dataset), "# of files used to create this processed frame")
-        for i, img in enumerate(input_dataset):
-            self.ext_hdr.set('FILE{0}'.format(i), img.filename, "File #{0} filename used to create this frame".format(i))
+
+        parent_filenames = set()
+        # go through filenames and also check each frames parents
+        for img in input_dataset:
+            parent_filenames.add(img.filename)
+            # also check if this frame has parent frames. keep trakc of them too
+            if 'DRPNFILE' in img.ext_hdr:
+                for j in range(img.ext_hdr['DRPNFILE']):
+                    parent_filenames.add(img.ext_hdr['FILE{0}'.format(j)])
+        
+        for i, filename in enumerate(parent_filenames):
+            self.ext_hdr.set('FILE{0}'.format(i), filename, "File #{0} filename used to create this frame".format(i))
+        self.ext_hdr.set('DRPNFILE', len(parent_filenames), "# of files used to create this processed frame")
 
     def copy(self, copy_data=True):
         """

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -1,0 +1,128 @@
+import os
+import pytest
+import numpy as np
+import astropy.io.fits as fits
+import corgidrp.data as data
+import corgidrp.mocks as mocks
+import corgidrp.combine as combine
+
+img1 = np.ones([100, 100])
+err1 = np.ones([100, 100])
+dq = np.zeros([100, 100], dtype = int)
+prhd, exthd = mocks.create_default_headers()
+errhd = fits.Header()
+errhd["CASE"] = "test"
+dqhd = fits.Header()
+dqhd["CASE"] = "test"
+
+
+def test_mean_combine_subexposures():
+    """
+    Test mean combine of subexposures
+    """
+
+    image1 = data.Image(img1, err=err1, dq=dq, pri_hdr = prhd, ext_hdr = exthd)
+    image1.filename = "1.fits"
+    image2 = image1.copy()
+    image2.filename = "2.fits"
+    image3 = image1.copy()
+    image3.filename = "3.fits"
+    image4 = image1.copy()
+    image4.filename = "4.fits"
+
+    dataset = data.Dataset([image1, image2, image3, image4])
+
+    combined_dataset = combine.combine_subexposures(dataset, 2)
+
+    assert(len(combined_dataset) == 2)
+    assert(np.all(combined_dataset[0].data == 2))
+    assert(np.all(combined_dataset[0].err == pytest.approx(np.sqrt(2))))
+    assert(np.all(combined_dataset[0].dq == 0))
+
+    assert combined_dataset[0].ext_hdr['DRPNFILE'] == 2
+    assert combined_dataset[0].ext_hdr['FILE0'] in ["2.fits", "1.fits"]
+    assert combined_dataset[0].ext_hdr['FILE1'] in ["2.fits", "1.fits"]
+
+    assert combined_dataset[1].ext_hdr['DRPNFILE'] == 2
+    assert combined_dataset[1].ext_hdr['FILE0'] in ["3.fits", "4.fits"]
+    assert combined_dataset[1].ext_hdr['FILE1'] in ["3.fits", "4.fits"]
+
+    # combine again
+    combined_dataset_2 = combine.combine_subexposures(combined_dataset, 2)
+     
+    assert(len(combined_dataset_2) == 1)
+    assert(np.all(combined_dataset_2[0].data == 4))
+    assert(np.all(combined_dataset_2[0].err == pytest.approx(2)))
+    assert(np.all(combined_dataset_2[0].dq == 0))
+
+    assert combined_dataset_2[0].ext_hdr['DRPNFILE'] == 4
+    assert combined_dataset_2[0].ext_hdr['FILE0'] in ["2.fits", "1.fits", "3.fits", "4.fits"]
+    assert combined_dataset_2[0].ext_hdr['FILE1'] in ["2.fits", "1.fits", "3.fits", "4.fits"]
+    assert combined_dataset_2[0].ext_hdr['FILE2'] in ["2.fits", "1.fits", "3.fits", "4.fits"]
+    assert combined_dataset_2[0].ext_hdr['FILE3'] in ["2.fits", "1.fits", "3.fits", "4.fits"]
+
+
+def test_mean_combine_subexposures_with_bad():
+    """
+    Test mean combine of subexposures with bad pixels
+    """
+    # use copies since we are going to modify their values
+    image1 = data.Image(np.copy(img1), err=np.copy(err1), dq=np.copy(dq), 
+                        pri_hdr = prhd, ext_hdr = exthd)
+    image1.filename = "1.fits"
+    image2 = image1.copy()
+    image2.filename = "2.fits"
+    image3 = image1.copy()
+    image3.filename = "3.fits"
+    image4 = image1.copy()
+    image4.filename = "4.fits"
+
+    # (0,0) has one bad frame
+    image1.dq[0][0] = 1
+    # (0,1) has both pixels bad
+    image1.dq[0][1] = 1
+    image2.dq[0][1] = 1
+
+    dataset = data.Dataset([image1, image2, image3, image4])
+
+    combined_dataset = combine.combine_subexposures(dataset, 2)
+
+    assert(len(combined_dataset) == 2)
+    # the pixel with one bad pixel should have same value but higher error
+    assert combined_dataset[0].data[0][0] == 2
+    assert combined_dataset[0].err[0][0][0] == pytest.approx(2)
+    # compare against a pixel without any bad pixels
+    assert combined_dataset[1].data[0][0] == 2
+    assert combined_dataset[1].err[0][0][0] == pytest.approx(np.sqrt(2))
+
+    # the pixel with two bad pixels should be nan
+    assert np.isnan(combined_dataset[0].data[0][1])
+    assert np.isnan(combined_dataset[0].err[0][0][1])
+    assert combined_dataset[0].dq[0][1] == 1
+
+def test_median_combine_subexposures():
+    """
+    Test median combine of subexposures
+    """
+
+    image1 = data.Image(img1, err=err1, dq=dq, pri_hdr = prhd, ext_hdr = exthd)
+    image1.filename = "1.fits"
+    image2 = image1.copy()
+    image2.filename = "2.fits"
+    image3 = image1.copy()
+    image3.filename = "3.fits"
+    image4 = image1.copy()
+    image4.filename = "4.fits"
+
+    dataset = data.Dataset([image1, image2, image3, image4])
+
+    combined_dataset = combine.combine_subexposures(dataset, 2, collapse="median")
+
+    assert(len(combined_dataset) == 2)
+    assert(np.all(combined_dataset[0].data == 2))
+    assert(np.all(combined_dataset[0].err == pytest.approx(np.sqrt(np.pi))))
+    assert(np.all(combined_dataset[0].dq == 0))
+
+
+if __name__ == "__main__":
+    test_mean_combine_subexposures()

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -102,7 +102,7 @@ def test_mean_combine_subexposures_with_bad():
 
 def test_median_combine_subexposures():
     """
-    Test median combine of subexposures
+    Test median combine of subexposures. And tests defualt case wihere num_frames_per_group isn't specified. 
     """
 
     image1 = data.Image(img1, err=err1, dq=dq, pri_hdr = prhd, ext_hdr = exthd)
@@ -116,11 +116,11 @@ def test_median_combine_subexposures():
 
     dataset = data.Dataset([image1, image2, image3, image4])
 
-    combined_dataset = combine.combine_subexposures(dataset, 2, collapse="median")
+    combined_dataset = combine.combine_subexposures(dataset, collapse="median")
 
-    assert(len(combined_dataset) == 2)
-    assert(np.all(combined_dataset[0].data == 2))
-    assert(np.all(combined_dataset[0].err == pytest.approx(np.sqrt(np.pi))))
+    assert(len(combined_dataset) == 1)
+    assert(np.all(combined_dataset[0].data == 4))
+    assert(np.all(combined_dataset[0].err == pytest.approx(np.sqrt(2*np.pi))))
     assert(np.all(combined_dataset[0].dq == 0))
 
 


### PR DESCRIPTION
## Describe your changes

New step function to combine subsets of frames together. Made currently for the intent of the flat field e2e to combine subexposures of a raster scan. I started a new combine.py since I anticipate we want to combine frames in different frames (e.g., collapse via keywords, sigma clipping, etc). 

I also updated the recording of parent filenames to include grand-parents. This way, a file (E.g., flat field) would record its parents, but also the frames that were combined together from its parents. In the current logic, great grand parents of arbitrary depth are also tracked. 

## Type of change

Please delete options that are not relevant (and this line).

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
