### PR TITLE
Bug Fix: Walker can't automatically identify NoiseMap datasets

### DIFF
--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -197,7 +197,7 @@ def guess_template(dataset):
             recipe_filename = "l1_to_l2a_nonlin.json"
         elif image.pri_hdr['OBSTYPE'] == "KGAIN":
             recipe_filename = "l1_to_kgain.json"
-        elif image.pri_hdr['OBSTYPE'] == "DARKS":
+        elif image.pri_hdr['OBSTYPE'] == "DARK":
             recipe_filename = "l1_to_l2a_noisemap.json"
         elif image.pri_hdr['OBSTYPE'] == "MNFRAME":
             # Disambiguate between NONLIN and KGAIN
@@ -213,7 +213,7 @@ def guess_template(dataset):
         else:
             recipe_filename = "l1_to_l2b.json"
     elif image.ext_hdr['DATA_LEVEL'] == "L2a":
-        if image.pri_hdr['OBSTYPE'] == "DARKS":
+        if image.pri_hdr['OBSTYPE'] == "DARK":
             recipe_filename = "l2a_to_l2a_noisemap.json"
         else:
             raise NotImplementedError()

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -197,6 +197,8 @@ def guess_template(dataset):
             recipe_filename = "l1_to_l2a_nonlin.json"
         elif image.pri_hdr['OBSTYPE'] == "KGAIN":
             recipe_filename = "l1_to_kgain.json"
+        elif image.pri_hdr['OBSTYPE'] == "DARKS":
+            recipe_filename = "l1_to_l2a_noisemap.json"
         elif image.pri_hdr['OBSTYPE'] == "MNFRAME":
             # Disambiguate between NONLIN and KGAIN
             for data in dataset:
@@ -210,6 +212,11 @@ def guess_template(dataset):
                     raise ValueError(f"Define recipe for {data.pri_hdr['OBSTYPE']}")
         else:
             recipe_filename = "l1_to_l2b.json"
+    elif image.ext_hdr['DATA_LEVEL'] == "L2a":
+        if image.pri_hdr['OBSTYPE'] == "DARKS":
+            recipe_filename = "l2a_to_l2a_noisemap.json"
+        else:
+            raise NotImplementedError()
     else:
         raise NotImplementedError()
 

--- a/tests/e2e_tests/noisemap_cal_e2e.py
+++ b/tests/e2e_tests/noisemap_cal_e2e.py
@@ -12,8 +12,30 @@ import corgidrp.walker as walker
 import corgidrp.caldb as caldb
 import corgidrp.detector as detector
 from glob import glob
+from astropy.io import fits
 
 thisfile_dir = os.path.dirname(__file__) # this file's folder
+
+def set_obstype_for_darks(
+    list_of_fits,
+    ):
+    """ Adds proper values to OBSTYPE for the NoiseMap calibration: DARKS
+    (data used to calibrate the dark noise sources).
+
+    This function is unnecessary with future data because data will have
+    the proper values in OBSTYPE. 
+
+    Args:
+    list_of_fits (list): list of FITS files that need to be updated.
+
+    """
+    # Folder with files
+    for file in list_of_fits:
+        fits_file = fits.open(file)
+        prihdr = fits_file[0].header
+        prihdr['OBSTYPE'] = 'DARKS'
+        # Update FITS file
+        fits_file.writeto(file, overwrite=True)
 
 @pytest.mark.e2e
 def test_noisemap_calibration_from_l1(tvacdata_path, e2eoutput_path):
@@ -80,7 +102,9 @@ def test_noisemap_calibration_from_l1(tvacdata_path, e2eoutput_path):
     ####### Run the walker on some test_data
 
     template = "l1_to_l2a_noisemap.json"
-    walker.walk_corgidrp(l1_data_filelist, "", noisemap_outputdir,template=template)
+    # Update OBSTYPE for each file to "DARKS"
+    set_obstype_for_darks(l1_data_filelist)
+    walker.walk_corgidrp(l1_data_filelist, "", noisemap_outputdir,template=None)
 
 
     # clean up by removing entry
@@ -194,7 +218,9 @@ def test_noisemap_calibration_from_l2a(tvacdata_path, e2eoutput_path):
     ####### Run the walker on some test_data
 
     template = "l2a_to_l2a_noisemap.json"
-    walker.walk_corgidrp(l2a_data_filelist, "", noisemap_outputdir,template=template)
+    # Update OBSTYPE to "DARKS"
+    set_obstype_for_darks(l2a_data_filelist)
+    walker.walk_corgidrp(l2a_data_filelist, "", noisemap_outputdir,template=None)
 
 
     # clean up by removing entry

--- a/tests/e2e_tests/noisemap_cal_e2e.py
+++ b/tests/e2e_tests/noisemap_cal_e2e.py
@@ -33,7 +33,7 @@ def set_obstype_for_darks(
     for file in list_of_fits:
         fits_file = fits.open(file)
         prihdr = fits_file[0].header
-        prihdr['OBSTYPE'] = 'DARKS'
+        prihdr['OBSTYPE'] = 'DARK'
         # Update FITS file
         fits_file.writeto(file, overwrite=True)
 


### PR DESCRIPTION
## Changes
Walker can now automatically identify NoiseMap datasets. E2E test to generate NoiseMaps from dark files (L1 or L2a) runs successfully without specifying a recipe template explicitly.
- Modified `walker.py` to check if L1 or L2a data has been passed in with the OBSTYPE "DARK," assuming this is the keyword that will be used for NoiseMap data (chosen from list of OBSTYPE keywords [here](https://collaboration.ipac.caltech.edu/display/romancoronagraph/EXCAM+image+headers+CTC+release+R.3.2))
- Modified `tests/e2e_tests/noisemap_cal_e2e.py`:
  - Removed template filename from the walker call for generating noisemaps from L1 or L2a dark files.
  - Added a function `set_obstype_for_darks()` to overwrite the OBSTYPE of the input files for the test to "DARK".

## Type of change: 
Bug fix (non-breaking change which fixes an issue) for Issue #220 

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
