### PR TITLE
Add cleanup for test ops to fix testing bug

### DIFF
--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -81,5 +81,8 @@ def test_ops_produces_expected_file():
     for output_file in output_filelist:
         assert os.path.exists(output_file), f"Expected output file {output_file} does not exist."
 
+    ### Clean up
+    mycaldb.remove_entry(new_nonlinearity)
+
 if __name__ == "__main__":#
     test_ops_produces_expected_file()


### PR DESCRIPTION
## Describe your changes

caldb had nonlin from test ops that, if run immediately before e2e tests, would cause the e2e tests to fail. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
