### PR TITLE
Make sure to set the DQ when dividing by a zero in a flat-field 

### DIFF
--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -133,7 +133,7 @@ def flat_division(input_dataset, flat_field):
     where_zero = np.where(flat_field.data == 0)
     flatdiv_dq = copy.deepcopy(flatdiv_dataset.all_dq)
     for i in range(len(flatdiv_dataset)):
-       flatdiv_dq[i].dq[where_zero] = np.bitwise_or(flatdiv_dataset[i].dq[where_zero], 4)
+       flatdiv_dq[i][where_zero] = np.bitwise_or(flatdiv_dataset[i].dq[where_zero], 4)
 
     # propagate the error of the master flat frame
     if hasattr(flat_field, "err"):

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -1,5 +1,6 @@
 # A file that holds the functions that transmogrify l2a data to l2b data
 import numpy as np
+import copy
 import corgidrp.data as data
 from corgidrp.darks import build_synthesized_dark
 from corgidrp.detector import detector_areas
@@ -128,6 +129,12 @@ def flat_division(input_dataset, flat_field):
     #Divide by the master flat
     flatdiv_cube = flatdiv_dataset.all_data /  flat_field.data
 
+    #Find where the flat_field is 0 and set a DQ flag: 
+    where_zero = np.where(flat_field.data == 0)
+    flatdiv_dq = copy.deepcopy(flatdiv_dataset.all_dq)
+    for i in range(len(flatdiv_dataset)):
+       flatdiv_dq[i].dq[where_zero] = np.bitwise_or(flatdiv_dataset[i].dq[where_zero], 4)
+
     # propagate the error of the master flat frame
     if hasattr(flat_field, "err"):
         flatdiv_dataset.rescale_error(1/flat_field.data, "FlatField")
@@ -138,7 +145,7 @@ def flat_division(input_dataset, flat_field):
     history_msg = "Flat calibration done using Flat field {0}".format(flat_field.filename)
 
     # update the output dataset with this new flat calibrated data and update the history
-    flatdiv_dataset.update_after_processing_step(history_msg,new_all_data=flatdiv_cube)
+    flatdiv_dataset.update_after_processing_step(history_msg,new_all_data=flatdiv_cube, new_all_dq = flatdiv_dq)
 
     return flatdiv_dataset
 

--- a/tests/test_flat_div.py
+++ b/tests/test_flat_div.py
@@ -77,9 +77,25 @@ def test_flat_div():
     print("Error estimated:",err_estimated)
     assert(err_flatdiv == pytest.approx(err_estimated, abs = 1e-2))
     
-    print(flatdivided_dataset[0].ext_hdr)
+    # print(flatdivided_dataset[0].ext_hdr)
     corgidrp.track_individual_errors = old_err_tracking
     
+
+    ### Check to make sure DQ gets set when flatfield zero. ###
+
+    ## Injected some 0s. 
+    pixel_list = [[110,120],[50,50], [100,100]]
+    for pixel in pixel_list:
+        flatfield.data[pixel[0],pixel[1]] = 0.
+    
+    ## Perform flat division
+    flatdivided_dataset_w_zeros = l2a_to_l2b.flat_division(simflat_dataset, flatfield)
+
+    ## Check that all the pixels that were zeroed out have the DQ flag set to 4. 
+    for pixel in pixel_list:
+        for i in range(len(simdata_filenames)):
+            assert np.bitwise_and(flatdivided_dataset_w_zeros.all_dq[i,pixel[0],pixel[1]],4)
+
     
 if __name__ == "__main__":
     test_flat_div()


### PR DESCRIPTION
## Describe your changes

If a different flatfield is used for flat field division than was used to create the bad pixel map and the new one has 0s in it, we might introduce infs when we divide. This fix makes sure that the DQ gets set when this happens. 


## Type of change

Please delete options that are not relevant (and this line).
- Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
