### PR TITLE
Bug Fix: Crop Function Checks for Correct Header Keyword

### DIFF
--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -28,8 +28,6 @@ def make_test_dataset(shape=[100,100],centxy=None):
     exthdr['STARLOCY'] = cent[0]
     exthdr['MASKLOCX'] = cent[1]
     exthdr['MASKLOCY'] = cent[0]
-    exthdr['CRPIX1'] = cent[1] + 1
-    exthdr['CRPIX2'] = cent[0] + 1
     prihdr['LSAMNAME'] = 'NFOV'
     
     if len(shape) == 2:

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -80,7 +80,7 @@ def test_2d_square_offcenter_crop():
         raise Exception("Unexpected result for 2D square offcenter crop test.")
 
 def test_2d_rect_offcenter_crop():
-    """ Test cropping off-center non-square data.
+    """ Tests cropping off-center non-square data.
     """
     test_dataset = make_test_dataset(shape=[100,40],centxy=[24.5,49.5])
     cropped_test_dataset = crop(test_dataset,sizexy=[20,10],centerxy=None)
@@ -89,7 +89,7 @@ def test_2d_rect_offcenter_crop():
         raise Exception("Unexpected result for 2D rect offcenter crop test.")
 
 def test_3d_rect_offcenter_crop():
-    """ Test cropping 3D off-center non-square data.
+    """ Tests cropping 3D off-center non-square data.
     """
     test_dataset = make_test_dataset(shape=[3,100,40],centxy=[24.5,49.5])
     cropped_test_dataset = crop(test_dataset,sizexy=[20,10],centerxy=None)
@@ -100,7 +100,8 @@ def test_3d_rect_offcenter_crop():
         raise Exception("Unexpected result for 2D rect offcenter crop test.")
 
 def test_edge_of_detector():
-    """ Test cropping right at the edge of the data array.
+    """ Tests that trying to crop a region right at the edge of the 
+    detector succeeds.
     """
     test_dataset = make_test_dataset(shape=[100,100],centxy=[94.5,94.5])
     cropped_test_dataset = crop(test_dataset,sizexy=10,centerxy=None)
@@ -109,7 +110,7 @@ def test_edge_of_detector():
         raise Exception("Unexpected result for edge of FOV crop test.")
 
 def test_outside_detector_edge():
-    """ Test cropping over the edge of the data array.
+    """ Tests that trying to crop a region outside the detector fails.
     """
 
     test_dataset = make_test_dataset(shape=[100,100],centxy=[95.5,95.5])
@@ -118,7 +119,8 @@ def test_outside_detector_edge():
         _ = crop(test_dataset,sizexy=10,centerxy=None)
 
 def test_nonhalfinteger_centxy():
-    """ Test trying to center the crop not on a pixel intersection.
+    """ Tests that trying to crop data to a center that is not at the intersection 
+    of 4 pixels results in centering on the nearest pixel intersection.
     """
     test_dataset = make_test_dataset(shape=[100,100],centxy=[49.5,49.5])
     cropped_test_dataset = crop(test_dataset,sizexy=10,centerxy=[49.7,49.7])
@@ -127,7 +129,8 @@ def test_nonhalfinteger_centxy():
         raise Exception("Unexpected result for non half-integer crop test.")
 
 def test_header_updates_2d():
-    """ Test that the header values are updated correctly.
+    """ Tests that cropping works, and updates header values related to 
+    pixel positions and data shapes correctly, for 3D data.
     """
     
     test_dataset = make_test_dataset(shape=[100,100],centxy=[49.5,49.5])
@@ -164,7 +167,8 @@ def test_header_updates_2d():
         raise Exception("Frame dq header kw NAXIS2 not updated correctly.")
     
 def test_header_updates_3d():
-    """ Test that the header values are updated correctly.
+    """ Tests that cropping works, and updates header values related to pixel 
+    positions and data shapes correctly, for 3D data.
     """
     
     test_dataset = make_test_dataset(shape=[3,100,100],centxy=[49.5,49.5])
@@ -207,13 +211,21 @@ def test_header_updates_3d():
         raise Exception("Frame err header kw NAXIS3 not updated correctly.")
     
 def test_non_nfov_input():
-    """ Test cropping to the center of a square using the header keywords "STARLOCX/Y".
+    """ Crop function is not configured for non-NFOV observations and should
+    fail if the Lyot stop is not in the narrow FOV position, unless the desired
+    image size is provided manually.
     """
 
     test_dataset = make_test_dataset(shape=[100,100],centxy=[50.5,50.5])
     for frame in test_dataset:
         frame.pri_hdr['LSAMNAME'] = 'WFOV'
 
+    try:
+        _ = crop(test_dataset,sizexy=20,centerxy=None)
+    except:
+        raise ValueError('Cropping a non-NFOV observation failed even though sizexy was provided')
+    
+    
     with pytest.raises(UserWarning):
         _ = crop(test_dataset,sizexy=None,centerxy=None)
 
@@ -222,6 +234,7 @@ if __name__ == "__main__":
     test_2d_square_center_crop()
     test_2d_square_offcenter_crop()
     test_2d_rect_offcenter_crop()
+    test_3d_rect_offcenter_crop()
     test_edge_of_detector()
     test_outside_detector_edge()
     test_nonhalfinteger_centxy()

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -30,7 +30,7 @@ def make_test_dataset(shape=[100,100],centxy=None):
     exthdr['MASKLOCY'] = cent[0]
     exthdr['CRPIX1'] = cent[1] + 1
     exthdr['CRPIX2'] = cent[0] + 1
-    prihdr['MODE'] = 'HLC'
+    prihdr['LSAMNAME'] = 'NFOV'
     
     if len(shape) == 2:
         test_arr[int(cent[0]-0.5):int(cent[0]+1.5),int(cent[1]-0.5):int(cent[1]+1.5)] = 1
@@ -101,8 +101,7 @@ def test_3d_rect_offcenter_crop():
     if not cropped_test_dataset[0].data == pytest.approx(goal_rect_arr3d):
         raise Exception("Unexpected result for 2D rect offcenter crop test.")
 
-
-def test_edge_of_FOV():
+def test_edge_of_detector():
     """ Test cropping right at the edge of the data array.
     """
     test_dataset = make_test_dataset(shape=[100,100],centxy=[94.5,94.5])
@@ -111,7 +110,7 @@ def test_edge_of_FOV():
     if not cropped_test_dataset[0].data == pytest.approx(goal_arr):
         raise Exception("Unexpected result for edge of FOV crop test.")
 
-def test_outside_FOV():
+def test_outside_detector_edge():
     """ Test cropping over the edge of the data array.
     """
 
@@ -209,12 +208,25 @@ def test_header_updates_3d():
     if not cropped_test_dataset[0].err_hdr["NAXIS3"] == 3:
         raise Exception("Frame err header kw NAXIS3 not updated correctly.")
     
+def test_non_nfov_input():
+    """ Test cropping to the center of a square using the header keywords "STARLOCX/Y".
+    """
+
+    test_dataset = make_test_dataset(shape=[100,100],centxy=[50.5,50.5])
+    for frame in test_dataset:
+        frame.pri_hdr['LSAMNAME'] = 'WFOV'
+
+    with pytest.raises(UserWarning):
+        _ = crop(test_dataset,sizexy=None,centerxy=None)
+
+
 if __name__ == "__main__":
     test_2d_square_center_crop()
     test_2d_square_offcenter_crop()
     test_2d_rect_offcenter_crop()
-    test_edge_of_FOV()
-    test_outside_FOV()
+    test_edge_of_detector()
+    test_outside_detector_edge()
     test_nonhalfinteger_centxy()
     test_header_updates_2d()
     test_header_updates_3d()
+    test_non_nfov_input()


### PR DESCRIPTION
## Describe your changes
The crop function previously assumed the imaging mode would be encoded in a header keyword like "MODE," however this has been updated to instead check the known PAM (precision alignment mechanism) keywords associated with the relevant imaging mode. In this case, all we really care about is the size of the useful field of view to determine the default region to crop to, so we look for the keyword "LSAMNAME" which encodes which Lyot stop is used. Currently only the LSAMNAME position "NFOV" is configured, which is the primary mode, and a separate issue exists to include additional modes later. 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
Fix for Issue #288: Crop function checks for wrong keyword 

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [x] I have filled out the Unit Test Definition Table on confluence, as needed