### PR TITLE
Added threhold to correct_nonlinearity function to flag pixels in the DQ

### DIFF
--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -293,6 +293,7 @@ def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
         input_dataset (corgidrp.data.Dataset): a dataset of Images that need non-linearity correction (L2a-level).
         non_lin_correction (corgidrp.data.NonLinearityCorrection): a NonLinearityCorrection calibration file to model the non-linearity.
         threshold (float): threshold for flagging pixels in the DQ array, value above this threshold will be flagged in the DQ map as too nonlinear. By default it is set to infinity, user can change it to a different value.
+    
     Returns:
         linearized_dataset (corgidrp.data.Dataset): A non-linearity corrected version of the input dataset
     """

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -287,7 +287,7 @@ def detect_cosmic_rays(input_dataset, detector_params, k_gain = None, sat_thresh
 
 def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
     """
-    Perform non-linearity correction of a dataset using the corresponding non-linearity correction
+    Perform non-linearity correction of a dataset using the corresponding non-linearity correction. Now we check for non-linear pixel and flag them in the DQ. 
 
     Args:
         input_dataset (corgidrp.data.Dataset): a dataset of Images that need non-linearity correction (L2a-level)

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -290,9 +290,9 @@ def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
     Perform non-linearity correction of a dataset using the corresponding non-linearity correction. We check for non-linear pixel and flag them in the DQ. 
 
     Args:
-        input_dataset (corgidrp.data.Dataset): a dataset of Images that need non-linearity correction (L2a-level)
-        non_lin_correction (corgidrp.data.NonLinearityCorrection): a NonLinearityCorrection calibration file to model the non-linearity
-        threshold (float): threshold for flagging pixels in the DQ array, value above this threshold will be flagged in the DQ map as too nonlinear. By default it is set to infinity, user can change it to a different value 
+        input_dataset (corgidrp.data.Dataset): a dataset of Images that need non-linearity correction (L2a-level).
+        non_lin_correction (corgidrp.data.NonLinearityCorrection): a NonLinearityCorrection calibration file to model the non-linearity.
+        threshold (float): threshold for flagging pixels in the DQ array, value above this threshold will be flagged in the DQ map as too nonlinear. By default it is set to infinity, user can change it to a different value.
     Returns:
         corgidrp.data.Dataset: a non-linearity corrected version of the input dataset
     """

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -287,13 +287,13 @@ def detect_cosmic_rays(input_dataset, detector_params, k_gain = None, sat_thresh
 
 def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
     """
-    Perform non-linearity correction of a dataset using the corresponding non-linearity correction. Now we check for non-linear pixel and flag them in the DQ. 
+    Perform non-linearity correction of a dataset using the corresponding non-linearity correction. We check for non-linear pixel and flag them in the DQ. 
 
     Args:
         input_dataset (corgidrp.data.Dataset): a dataset of Images that need non-linearity correction (L2a-level)
         non_lin_correction (corgidrp.data.NonLinearityCorrection): a NonLinearityCorrection calibration file to model the non-linearity
-        threshold (float): threshold for flagging pixels in the DQ array. By default it is set to infinity, user can change it to a different value
-
+        threshold (float): threshold for flagging pixels in the DQ array, value above this threshold will be flagged in the DQ map as too nonlinear. 
+                           By default it is set to infinity, user can change it to a different value 
     Returns:
         corgidrp.data.Dataset: a non-linearity corrected version of the input dataset
     """

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -292,7 +292,8 @@ def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
     Args:
         input_dataset (corgidrp.data.Dataset): a dataset of Images that need non-linearity correction (L2a-level)
         non_lin_correction (corgidrp.data.NonLinearityCorrection): a NonLinearityCorrection calibration file to model the non-linearity
-        threshold (float): threshold for flagging pixels in the DQ array. By default it is set to infinity, user can change it to a different value. 
+        threshold (float): threshold for flagging pixels in the DQ array. By default it is set to infinity, user can change it to a different value
+        
     Returns:
         corgidrp.data.Dataset: a non-linearity corrected version of the input dataset
     """

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -292,8 +292,7 @@ def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
     Args:
         input_dataset (corgidrp.data.Dataset): a dataset of Images that need non-linearity correction (L2a-level)
         non_lin_correction (corgidrp.data.NonLinearityCorrection): a NonLinearityCorrection calibration file to model the non-linearity
-        threshold (float): threshold for flagging pixels in the DQ array, value above this threshold will be flagged in the DQ map as too nonlinear. 
-                           By default it is set to infinity, user can change it to a different value 
+        threshold (float): threshold for flagging pixels in the DQ array, value above this threshold will be flagged in the DQ map as too nonlinear. By default it is set to infinity, user can change it to a different value 
     Returns:
         corgidrp.data.Dataset: a non-linearity corrected version of the input dataset
     """

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -295,7 +295,7 @@ def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
         threshold (float): threshold for flagging pixels in the DQ array, value above this threshold will be flagged in the DQ map as too nonlinear. By default it is set to infinity, user can change it to a different value.
     
     Returns:
-        linearized_dataset (corgidrp.data.Dataset): A non-linearity corrected version of the input dataset
+        (corgidrp.data.Dataset): A non-linearity corrected version of the input dataset
     """
     #Copy the dataset to start
     linearized_dataset = input_dataset.copy()

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -294,7 +294,8 @@ def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
         non_lin_correction (corgidrp.data.NonLinearityCorrection): a NonLinearityCorrection calibration file to model the non-linearity.
         threshold (float): threshold for flagging pixels in the DQ array, value above this threshold will be flagged in the DQ map as too nonlinear. By default it is set to infinity, user can change it to a different value.
     Returns:
-        corgidrp.data.Dataset: a non-linearity corrected version of the input dataset
+        corgidrp.data.Dataset: 
+            A non-linearity corrected version of the input dataset
     """
     #Copy the dataset to start
     linearized_dataset = input_dataset.copy()

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -294,8 +294,7 @@ def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
         non_lin_correction (corgidrp.data.NonLinearityCorrection): a NonLinearityCorrection calibration file to model the non-linearity.
         threshold (float): threshold for flagging pixels in the DQ array, value above this threshold will be flagged in the DQ map as too nonlinear. By default it is set to infinity, user can change it to a different value.
     Returns:
-        corgidrp.data.Dataset: 
-            A non-linearity corrected version of the input dataset
+        linearized_dataset (corgidrp.data.Dataset): A non-linearity corrected version of the input dataset
     """
     #Copy the dataset to start
     linearized_dataset = input_dataset.copy()

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -293,7 +293,7 @@ def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
         input_dataset (corgidrp.data.Dataset): a dataset of Images that need non-linearity correction (L2a-level)
         non_lin_correction (corgidrp.data.NonLinearityCorrection): a NonLinearityCorrection calibration file to model the non-linearity
         threshold (float): threshold for flagging pixels in the DQ array. By default it is set to infinity, user can change it to a different value
-        
+
     Returns:
         corgidrp.data.Dataset: a non-linearity corrected version of the input dataset
     """
@@ -318,8 +318,9 @@ def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
                 em_gain = linearized_dataset[i].ext_hdr["EMGAIN_C"]
 
         # Flag pixels in the DQ array if they exceed the threshold
-        # Select dq = 4 for pixels that exceed the threshold, can be changed
-        linearized_dataset[i].dq[linearized_cube[i] > threshold] = 4
+        non_linear_flag = 64
+        current_value = linearized_dataset[i].dq[linearized_cube[i] > threshold]
+        linearized_dataset[i].dq[linearized_cube[i] > threshold] = np.bitwise_or(current_value, non_linear_flag)
         linearized_cube[i] *= get_relgains(linearized_cube[i], em_gain, non_lin_correction)
     
     if non_lin_correction is not None:

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -285,14 +285,14 @@ def detect_cosmic_rays(input_dataset, detector_params, k_gain = None, sat_thresh
 
     return crmasked_dataset
 
-def correct_nonlinearity(input_dataset, non_lin_correction):
+def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
     """
     Perform non-linearity correction of a dataset using the corresponding non-linearity correction
 
     Args:
         input_dataset (corgidrp.data.Dataset): a dataset of Images that need non-linearity correction (L2a-level)
         non_lin_correction (corgidrp.data.NonLinearityCorrection): a NonLinearityCorrection calibration file to model the non-linearity
-
+        threshold (float): threshold for flagging pixels in the DQ array. By default it is set to infinity, user can change it to a different value. 
     Returns:
         corgidrp.data.Dataset: a non-linearity corrected version of the input dataset
     """
@@ -301,6 +301,7 @@ def correct_nonlinearity(input_dataset, non_lin_correction):
 
     #Apply the non-linearity correction to the data
     linearized_cube = linearized_dataset.all_data
+
     #Check to see if EM gain is in the header, if not, raise an error
     if "EMGAIN_C" not in linearized_dataset[0].ext_hdr.keys():
         raise ValueError("EM gain not found in header of input dataset. Non-linearity correction requires EM gain to be in header.")
@@ -314,6 +315,10 @@ def correct_nonlinearity(input_dataset, non_lin_correction):
                 em_gain = linearized_dataset[i].ext_hdr["EMGAIN_A"]
             else: # otherwise use commanded EM gain
                 em_gain = linearized_dataset[i].ext_hdr["EMGAIN_C"]
+
+        # Flag pixels in the DQ array if they exceed the threshold
+        # Select dq = 4 for pixels that exceed the threshold, can be changed
+        linearized_dataset[i].dq[linearized_cube[i] > threshold] = 4
         linearized_cube[i] *= get_relgains(linearized_cube[i], em_gain, non_lin_correction)
     
     if non_lin_correction is not None:

--- a/tests/test_non_linearity_correction.py
+++ b/tests/test_non_linearity_correction.py
@@ -168,7 +168,10 @@ def test_non_linearity_correction():
     pickled_nonlin = pickle.loads(pickled)
     assert np.all((non_linearity_correction.data == pickled_nonlin.data) | np.isnan(non_linearity_correction.data))
 
-    linear_dataset = l1_to_l2a.correct_nonlinearity(nonlinear_dataset, non_linearity_correction)
+    # check if flagging non-linearity works
+    non_linear_flag = 64
+    linear_dataset = l1_to_l2a.correct_nonlinearity(nonlinear_dataset, non_linearity_correction,threshold=-np.inf)
+    assert np.all(linear_dataset.all_dq >= non_linear_flag) # all pixels should be flagged
 
     #The data was generated with a ramp in the x-direction going from 10 to 65536
     expected_ramp = np.linspace(800,65536,1024)

--- a/tests/test_non_linearity_correction.py
+++ b/tests/test_non_linearity_correction.py
@@ -182,7 +182,7 @@ def test_non_linearity_correction():
     assert flagged_dataset.all_dq[0,0,0] >= non_linear_flag # flagged_dataset.all_data[0,0,0] should be flagged
     flagged_dataset.all_dq[0,0,0] = 0 # reset the flag
 
-    assert np.all(flagged_dataset.all_dq <= non_linear_flag) # all other pixels should not be flagged 
+    assert np.all(flagged_dataset.all_dq < non_linear_flag) # all other pixels should not be flagged 
 
     linear_dataset = l1_to_l2a.correct_nonlinearity(nonlinear_dataset, non_linearity_correction)
 

--- a/tests/test_non_linearity_correction.py
+++ b/tests/test_non_linearity_correction.py
@@ -168,10 +168,20 @@ def test_non_linearity_correction():
     pickled_nonlin = pickle.loads(pickled)
     assert np.all((non_linearity_correction.data == pickled_nonlin.data) | np.isnan(non_linearity_correction.data))
 
-    # check if flagging non-linearity works
+    # set up values for testing flags and the value of the flag
     non_linear_flag = 64
-    linear_dataset = l1_to_l2a.correct_nonlinearity(nonlinear_dataset, non_linearity_correction,threshold=-np.inf)
-    assert np.all(linear_dataset.all_dq >= non_linear_flag) # all pixels should be flagged
+    non_linear_pixel_value = 1e12
+
+    # seperate dataset to test flagging
+    flagged_dataset = nonlinear_dataset.copy()
+
+    # Inject a non-linear pixel and check that if it is flagged
+    flagged_dataset.all_data[0,0,0] = non_linear_pixel_value
+    flagged_dataset = l1_to_l2a.correct_nonlinearity(flagged_dataset, non_linearity_correction,threshold=non_linear_pixel_value-1)
+
+    assert flagged_dataset.all_dq[0,0,0] >= non_linear_flag # all pixels should be flagged
+
+    linear_dataset = l1_to_l2a.correct_nonlinearity(nonlinear_dataset, non_linearity_correction)
 
     #The data was generated with a ramp in the x-direction going from 10 to 65536
     expected_ramp = np.linspace(800,65536,1024)
@@ -184,7 +194,7 @@ def test_non_linearity_correction():
     #We are happy if the relative correction is less than 1% [TBC]
     assert np.all(relative_correction < 1e-2)
 
-    
+
     #Let's test that this returns the same thing as the II&T pipeline
     linear_data_iit = nonlinear_dataset.all_data*get_relgains(nonlinear_dataset.all_data,emgain,input_non_linearity_path)
 

--- a/tests/test_non_linearity_correction.py
+++ b/tests/test_non_linearity_correction.py
@@ -179,7 +179,10 @@ def test_non_linearity_correction():
     flagged_dataset.all_data[0,0,0] = non_linear_pixel_value
     flagged_dataset = l1_to_l2a.correct_nonlinearity(flagged_dataset, non_linearity_correction,threshold=non_linear_pixel_value-1)
 
-    assert flagged_dataset.all_dq[0,0,0] >= non_linear_flag # all pixels should be flagged
+    assert flagged_dataset.all_dq[0,0,0] >= non_linear_flag # flagged_dataset.all_data[0,0,0] should be flagged
+    flagged_dataset.all_dq[0,0,0] = 0 # reset the flag
+
+    assert np.all(flagged_dataset.all_dq <= non_linear_flag) # all other pixels should not be flagged 
 
     linear_dataset = l1_to_l2a.correct_nonlinearity(nonlinear_dataset, non_linearity_correction)
 


### PR DESCRIPTION
## Describe your changes
Added threhold to correct_nonlinearity function to flag pixels in the DQ. Threshold is set to np.inf for now, so it should not change any value in the DQ. 

## Type of change
- New feature (non-breaking change which adds functionality)
 
Please note that the current pytest function `test_non_linearity_correction()` in `test_non_linearity_correction.py` does not include the test to flag pixels in the DQ 

## Reference any relevant issues (don't forget the #)
#66 

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed