### PR TITLE
Bug fix/going back to uint8 badpixelmap

### DIFF
--- a/corgidrp/bad_pixel_calibration.py
+++ b/corgidrp/bad_pixel_calibration.py
@@ -33,12 +33,12 @@ def create_bad_pixel_map(dataset, master_dark, master_flat, dthresh = 5., ffrac 
 
     #Calculate the hot and warm bad pixel maps
     hot_warm_pixels_bool = detect_hot_warm_pixels_from_dark(dark_data, dthresh)
-    hot_warm_pixels = np.zeros_like(dark_data,dtype=np.uint64)
+    hot_warm_pixels = np.zeros_like(dark_data,dtype=np.uint8)
     hot_warm_pixels[hot_warm_pixels_bool] = 8 
 
     #Calculate the cold and dead pixels
     dead_pixels_bool = detect_dead_pixels_from_flat(flat_data, ffrac, fwidth)
-    dead_pixels = np.zeros_like(dark_data,dtype=np.uint64) 
+    dead_pixels = np.zeros_like(dark_data,dtype=np.uint8) 
     dead_pixels[dead_pixels_bool] = 4
 
     #Combined the two maps 

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -1836,8 +1836,9 @@ def unpackbits_64uint(arr, axis):
     Returns:
         _type_: np.ndarray of bits
     """
-    n = np.array(arr).view("u1")
-    return np.unpackbits(n, axis=axis, bitorder='little')
+    arr = arr.astype('>u8')
+    n = arr.view('u1')
+    return np.unpackbits(n, axis=axis, bitorder='big')
 
 def packbits_64uint(arr, axis):
     """
@@ -1850,4 +1851,4 @@ def packbits_64uint(arr, axis):
     Returns:
         _type_: np.ndarray of 64-bit unsigned integers
     """
-    return np.packbits(arr, axis=axis, bitorder='little').view(np.uint64)
+    return np.packbits(arr, axis=axis, bitorder='big').view('>u8')

--- a/tests/test_badpixelmap.py
+++ b/tests/test_badpixelmap.py
@@ -72,15 +72,10 @@ def test_badpixelmap():
     ###### make the badpixel map (input the flat_dataset just as a dummy):
     badpixelmap = create_bad_pixel_map(flat_dataset, dark_frame,flat_frame, dthresh=6) # you have integer in here
     
-    current_value = badpixelmap.data[0,0]
-    badpixelmap.data[0,0] = 256 # a value to test uint64
-
     # Use np.unpackbits to unpack the bits - big endien integer to binary
-    badpixelmap_bits = data.unpackbits_64uint(arr=badpixelmap.data[:, :, np.newaxis], axis=2)  # unit64 to binary
-    badpixelmap_repacked = data.packbits_64uint(badpixelmap_bits, axis=2).reshape(badpixelmap.data.shape)
+    badpixelmap_bits = np.unpackbits(badpixelmap.data[:, :, np.newaxis], axis=2, bitorder='big')  # unit64 to binary
+    badpixelmap_repacked = np.packbits(badpixelmap_bits, axis=2, bitorder='big').reshape(badpixelmap.data.shape)
     assert np.array_equal(badpixelmap_repacked, badpixelmap.data)    # check if the repacked data is the same as the original
-
-    badpixelmap.data[0,0] = current_value
 
     # Checking that everywhere there's a badpixel is in one of the two lists
     bp_locations = np.argwhere(badpixelmap.data)


### PR DESCRIPTION
## Describe your changes
1. Change the definition of hot pixel and bad pixel used in badpixelmap back to `uint8`. 
2. Enforce the endianness to 'big' to make sure it aligns with the bit definition. 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [ ] I have linted my code
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed