### PR TITLE
Updating Filename Conventions when files are combined 

### DIFF
--- a/corgidrp/combine.py
+++ b/corgidrp/combine.py
@@ -94,8 +94,12 @@ def combine_subexposures(input_dataset, num_frames_per_group=None, collapse="mea
         dq_hdr = input_dataset[num_frames_per_group*i].dq_hdr.copy()
         hdulist = input_dataset[num_frames_per_group*i].hdu_list.copy()
         new_image = data.Image(data_collapse, pri_hdr=pri_hdr, ext_hdr=ext_hdr, err=err_collapse, dq=dq_collapse, err_hdr=err_hdr, 
-                                dq_hdr=dq_hdr, input_hdulist=hdulist)   
-        new_image.filename = input_dataset[num_frames_per_group*i].filename
+                                dq_hdr=dq_hdr, input_hdulist=hdulist)
+                                
+        # always take the last filename in the group for the combined frame
+        last_idx_in_group = num_frames_per_group*(i+1) - 1
+        new_image.filename = input_dataset[last_idx_in_group].filename   
+
         new_image._record_parent_filenames(input_dataset[num_frames_per_group*i:num_frames_per_group*(i+1)])   
         new_dataset.append(new_image)
     new_dataset = data.Dataset(new_dataset)

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -359,6 +359,9 @@ def do_psf_subtraction(input_dataset, reference_star_dataset=None,
     frame = data.Image(pyklip_data,
                         pri_hdr=pri_hdr, ext_hdr=ext_hdr, 
                         err=err, dq=dq)
+    # NOTE: product of psfsubtraction should take: CGI_<Last science target VisitID>_<Last science target TimeUTC>_L<>.fits
+    # upgrade to L4 should be done by a serpate receipe
+    frame.filename = sci_dataset.frames[-1].filename
     
     dataset_out = data.Dataset([frame])
 

--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -3046,3 +3046,25 @@ def create_psfsub_dataset(n_sci,n_ref,roll_angles,darkhole_scifiles=None,darkhol
             ref_dataset.save(filedir=outdir, filenames=['mock_psfsub_L2b_ref_input_dataset.fits'])
 
     return sci_dataset,ref_dataset
+
+def format_FTIMEUTC(FTIMEUTC_str):
+    """
+    Convert FTIMEUTC (ISO 8601 format) to the required yyyymmddThhmmsss format.
+    
+    Args:
+        FTIMEUTC_str (str): FTIMEUTC string in ISO 8601 format (e.g., '2025-03-18T22:46:46.352490+00:00')
+
+    Returns:
+        str: Formatted TimeUTC string in 'yyyymmddThhmmsss' format.
+    """
+    # Parse the ISO 8601 string into a datetime object
+    dt = datetime.datetime.fromisoformat(FTIMEUTC_str.replace("Z", "+00:00"))
+
+    # Round microseconds to the nearest 0.1 second
+    rounded_microseconds = round(dt.microsecond / 100000) * 100000
+    dt = dt.replace(microsecond=rounded_microseconds)
+
+    # Format into yyyymmddThhmmsss
+    formatted_time = dt.strftime('%Y%m%dT%H%M%S') + str(dt.microsecond // 100000)
+
+    return formatted_time

--- a/corgidrp/photon_counting.py
+++ b/corgidrp/photon_counting.py
@@ -59,7 +59,6 @@ def photon_count(e_image, thresh):
 
     return pc_image
 
-
 def get_pc_mean(input_dataset, pc_master_dark=None, T_factor=None, pc_ecount_max=None, niter=2, mask_filepath=None, safemode=True, inputmode='illuminated'):
     """Take a stack of images, frames of the same exposure 
     time, k gain, read noise, and EM gain, and return the mean expected value per 
@@ -284,7 +283,8 @@ def get_pc_mean(input_dataset, pc_master_dark=None, T_factor=None, pc_ecount_max
     if val[0] != "DARK":  
         new_image = data.Image(combined_pc_mean, pri_hdr=pri_hdr, ext_hdr=ext_hdr, err=combined_err, dq=combined_dq, err_hdr=err_hdr, 
                             dq_hdr=dq_hdr, input_hdulist=hdulist) 
-        new_image.filename = dataset[0].filename.split('.')[0]+'_pc'+filename_end+'.fits'
+        # NOTE - assuming input L2a dataset already has the same file format
+        new_image.filename = dataset[-1].filename.replace("L2a", "L2b") 
         new_image.ext_hdr['PCTHRESH'] = thresh
         new_image._record_parent_filenames(input_dataset) 
         pc_ill_dataset = data.Dataset([new_image])

--- a/corgidrp/photon_counting.py
+++ b/corgidrp/photon_counting.py
@@ -284,7 +284,7 @@ def get_pc_mean(input_dataset, pc_master_dark=None, T_factor=None, pc_ecount_max
         new_image = data.Image(combined_pc_mean, pri_hdr=pri_hdr, ext_hdr=ext_hdr, err=combined_err, dq=combined_dq, err_hdr=err_hdr, 
                             dq_hdr=dq_hdr, input_hdulist=hdulist) 
         # NOTE - assuming input L2a dataset already has the same file format
-        new_image.filename = dataset[-1].filename.replace("L2a", "L2b") 
+        new_image.filename = dataset[-1].filename
         new_image.ext_hdr['PCTHRESH'] = thresh
         new_image._record_parent_filenames(input_dataset) 
         pc_ill_dataset = data.Dataset([new_image])

--- a/tests/test_photon_counting.py
+++ b/tests/test_photon_counting.py
@@ -74,14 +74,7 @@ def test_pc():
     # now process illuminated frames and subtract the PC dark
     pc_dataset_err = get_pc_mean(dataset_err, pc_master_dark=pc_dark)
 
-    # If first frame does not start with "CGI", skip the name test
-    first_frame = pc_dataset_err.frames[0].filename
-
-    if not first_frame.startswith("CGI"):
-        pytest.skip("Skipping test: first frame does not start with 'CGI'. Currently working under the assumption that we have correctly named the input dataset")
-
-    # Proceed to check if 'L2b' is present; assuming function was already tested
-    assert 'L2b' in first_frame, f"Expected 'L2b' in {first_frame}, but it was not found."
+    assert pc_dataset_err.frames[-1].filename.strip() == dataset_err[-1].filename.strip()
 
     history = ''
     for line in pc_dataset_err.frames[0].ext_hdr["HISTORY"]:

--- a/tests/test_photon_counting.py
+++ b/tests/test_photon_counting.py
@@ -76,6 +76,7 @@ def test_pc():
 
     # If first frame does not start with "CGI", skip the name test
     first_frame = pc_dataset_err.frames[0].filename
+
     if not first_frame.startswith("CGI"):
         pytest.skip("Skipping test: first frame does not start with 'CGI'. Currently working under the assumption that we have correctly named the input dataset")
 

--- a/tests/test_photon_counting.py
+++ b/tests/test_photon_counting.py
@@ -73,8 +73,15 @@ def test_pc():
     assert pc_dark.ext_hdr['PC_STAT'] == 'photon-counted master dark'
     # now process illuminated frames and subtract the PC dark
     pc_dataset_err = get_pc_mean(dataset_err, pc_master_dark=pc_dark)
-    assert pc_dataset_err.frames[0].filename[-7:] == 'pc.fits'
-    assert pc_dataset_err.frames[0].filepath[-7:] == 'pc.fits'
+
+    # If first frame does not start with "CGI", skip the name test
+    first_frame = pc_dataset_err.frames[0].filename
+    if not first_frame.startswith("CGI"):
+        pytest.skip("Skipping test: first frame does not start with 'CGI'. Currently working under the assumption that we have correctly named the input dataset")
+
+    # Proceed to check if 'L2b' is present; assuming function was already tested
+    assert 'L2b' in first_frame, f"Expected 'L2b' in {first_frame}, but it was not found."
+
     history = ''
     for line in pc_dataset_err.frames[0].ext_hdr["HISTORY"]:
         history += line

--- a/tests/test_photon_counting.py
+++ b/tests/test_photon_counting.py
@@ -135,9 +135,7 @@ def test_pc():
     copy_pc = pc_dataset_err.all_data.copy()
     # mask out all the irrelevant pixels:
     copy_pc[0,22:40,23:49] = np.nan
-    # didn't dark-subtract this time:
-    assert pc_dataset_err.frames[0].filename.endswith('pc_no_ds.fits')
-    assert pc_dataset_err.frames[0].filepath.endswith('pc_no_ds.fits')
+    # didn't dark-subtract this time
     history = ''
     for line in pc_dataset_err.frames[0].ext_hdr["HISTORY"]:
         history += line


### PR DESCRIPTION
## Describe your changes 
- Removed 2 asserts from test_photoncounting.py function regarding the name changes. Added a test to check when filename starts with "CGI_"
- Added a line in `do_psfsubtraction.py` after constructing image object from pykilpdata. Frame created will take file name from last frame from `sci_dataset`. 
- Fixed the file name convention in combined.py: now after combined_subexposure, the combined frame will always take the filename from the last frame of the group. 
`combine ['1', '2', '3', '4'] by group of 2 -> dataset[0].filename = '2' dataset[1].filename = '4'`


## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
#334 

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed