### PR TITLE
update initialization of caldb and corgidrp

### DIFF
--- a/corgidrp/__init__.py
+++ b/corgidrp/__init__.py
@@ -11,6 +11,7 @@ def create_config_dir():
     """
     Checks if the default .corgidrp directory exists, and if not, it sets it up
     """
+    global config_folder
     homedir = pathlib.Path.home()
     config_folder = os.path.join(homedir, ".corgidrp")
     # replace legacy file with folder if needed
@@ -50,19 +51,32 @@ def create_config_dir():
             config.write(f)
 
         print("corgidrp: Configuration file written to {0}. Please edit if you want things stored in different locations.".format(config_filepath))
+
+
+def update_pipeline_settings():
+    """
+    Loads configuration file to update pipeline settings
+    """
+    global config_filepath
+    global caldb_filepath, default_cal_dir, track_individual_errors, skip_missing_cal_steps, jit_calib_id
+    # borrowed from the kpicdrp caldb
+    # load in default caldbs based on configuration file
+    config_filepath = os.path.join(pathlib.Path.home(), ".corgidrp", "corgidrp.cfg")
+    config = configparser.ConfigParser()
+    config.read(config_filepath)
+
+    _bool_map = {"true" : True, "false" : False}
+
+    ## pipeline settings
+    caldb_filepath = config.get("PATH", "caldb", fallback=None) # path to calibration db
+    default_cal_dir = config.get("PATH", "default_calibs", fallback=None) # path to default calibrations directory
+    track_individual_errors = _bool_map[config.get("DATA", "track_individual_errors", fallback='false').lower()] # save each individual error component separately?
+    skip_missing_cal_steps = _bool_map[config.get("WALKER", "skip_missing_cal_steps", fallback='false').lower()] # skip steps, instead of crashing, when suitable calibration file cannot be found 
+    jit_calib_id = _bool_map[config.get("WALKER", "jit_calib_id", fallback='false').lower()] # AUTOMATIC calibration files identified right before the execution of a step, rather than when recipe is first generated
+
+
 create_config_dir()
-    
-_bool_map = {"true" : True, "false" : False}
+update_pipeline_settings()
 
-# borrowed from the kpicdrp caldb
-# load in default caldbs based on configuration file
-config_filepath = os.path.join(pathlib.Path.home(), ".corgidrp", "corgidrp.cfg")
-config = configparser.ConfigParser()
-config.read(config_filepath)
 
-## pipeline settings
-caldb_filepath = config.get("PATH", "caldb", fallback=None) # path to calibration db
-default_cal_dir = config.get("PATH", "default_calibs", fallback=None) # path to default calibrations directory
-track_individual_errors = _bool_map[config.get("DATA", "track_individual_errors", fallback='false').lower()] # save each individual error component separately?
-skip_missing_cal_steps = _bool_map[config.get("WALKER", "skip_missing_cal_steps", fallback='false').lower()] # skip steps, instead of crashing, when suitable calibration file cannot be found 
-jit_calib_id = _bool_map[config.get("WALKER", "jit_calib_id", fallback='false').lower()] # AUTOMATIC calibration files identified right before the execution of a step, rather than when recipe is first generated
+

--- a/corgidrp/caldb.py
+++ b/corgidrp/caldb.py
@@ -345,17 +345,36 @@ class CalDB:
         for calib_frame in calib_frames:
             self.create_entry(calib_frame, to_disk=to_disk)
 
-### Create set of default calibrations
-# Add default detector_params calibration file if it doesn't exist
-if not os.path.exists(os.path.join(corgidrp.default_cal_dir, "DetectorParams_2023-11-01T00:00:00.000.fits")):
-    default_detparams = data.DetectorParams({}, date_valid=time.Time("2023-11-01 00:00:00", scale='utc'))
-    default_detparams.save(filedir=corgidrp.default_cal_dir)
-# Add default FpamFsamCal calibration file if it doesn't exist
-if not os.path.exists(os.path.join(corgidrp.default_cal_dir, "FpamFsamCal_2024-02-10T00:00:00.000.fits")):
-    fpamfsam_2excam = data.FpamFsamCal([],
-        date_valid=time.Time("2024-02-10 00:00:00", scale='utc'))
-    fpamfsam_2excam.save(filedir=corgidrp.default_cal_dir)
 
-# add default caldb entries
-default_caldb = CalDB()
-default_caldb.scan_dir_for_new_entries(corgidrp.default_cal_dir)
+
+def initialize():
+    """
+    Creates default calibrations and caldb if it doesn't exist
+
+    """
+    global initialized
+
+    ### Create set of default calibrations
+    rescan_needed = False
+    # Add default detector_params calibration file if it doesn't exist
+    if not os.path.exists(os.path.join(corgidrp.default_cal_dir, "DetectorParams_2023-11-01T00:00:00.000.fits")):
+        default_detparams = data.DetectorParams({}, date_valid=time.Time("2023-11-01 00:00:00", scale='utc'))
+        default_detparams.save(filedir=corgidrp.default_cal_dir)
+        rescan_needed = True
+    # Add default FpamFsamCal calibration file if it doesn't exist
+    if not os.path.exists(os.path.join(corgidrp.default_cal_dir, "FpamFsamCal_2024-02-10T00:00:00.000.fits")):
+        fpamfsam_2excam = data.FpamFsamCal([],
+            date_valid=time.Time("2024-02-10 00:00:00", scale='utc'))
+        fpamfsam_2excam.save(filedir=corgidrp.default_cal_dir)
+        rescan_needed = True
+
+    if rescan_needed:
+        # add default caldb entries
+        default_caldb = CalDB()
+        default_caldb.scan_dir_for_new_entries(corgidrp.default_cal_dir)
+
+    # set initialization
+    initialized = True
+
+initialized = False
+initialize()

--- a/corgidrp/ops.py
+++ b/corgidrp/ops.py
@@ -1,4 +1,4 @@
-
+import corgidrp
 import corgidrp.caldb as caldb
 import corgidrp.walker as walker
 import argparse
@@ -6,11 +6,14 @@ import argparse
 
 def step_1_initialize():
     """
-    Initialize the caldb
+    Initialize corgidrp and it's caldb again
 
     Returns: 
         caldb.CalDB: an instance of an initialized caldb object
     """
+    corgidrp.create_config_dir()
+    corgidrp.update_pipeline_settings()
+    caldb.initialize()
     this_caldb = caldb.CalDB()
     return this_caldb
 

--- a/tests/test_caldb.py
+++ b/tests/test_caldb.py
@@ -23,6 +23,12 @@ master_dark = data.Dark(dark_dataset[0].data, dark_dataset[0].pri_hdr, dark_data
 # save master dark to disk to be loaded later
 master_dark.save(filedir=calibdir, filename="mockdark.fits")
 
+def test_caldb_init():
+    """
+    Tests that caldb has been initialized. It has to be if it's being imported.
+    """
+    assert caldb.initialized
+
 
 def test_caldb_create_default():
     """
@@ -166,6 +172,7 @@ def test_caldb_scan():
     os.remove(testcaldb_filepath)
 
 if __name__ == "__main__":
+    test_caldb_init()
     test_get_calib()
     test_caldb_create_default()
     test_caldb_custom_filepath()


### PR DESCRIPTION
## Describe your changes

 * Removes scanning all the time to avoid race condition when creating a multiprocessing process poll
 * ops.py re-initializes corgidrp and caldb to handle ops environment. 

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
Closes #359, 360

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed