### PR TITLE
walker breaks up L1, L2a, L2b, L3, and L4 data processing

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -688,6 +688,7 @@ class FlatField(Image):
                 # error check. this is required in this case
                 raise ValueError("This appears to be a master flat. The dataset of input files needs to be passed in to the input_dataset keyword to record history of this flat")
             self.ext_hdr['DATATYPE'] = 'FlatField' # corgidrp specific keyword for saving to disk
+            self.ext_hdr['BUNIT'] = "None" # flat field is dimentionless
 
             # log all the data that went into making this flat
             self._record_parent_filenames(input_dataset)

--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -556,8 +556,6 @@ def create_default_L3_headers(arrtype="SCI"):
     exthdr['CDELT2'] = 0
     exthdr['CRVAL1'] = 0
     exthdr['CRVAL2'] = 0
-    exthdr['STARLOCX'] = 512
-    exthdr['STARLOCY'] = 512
     exthdr['DATALVL']    = 'L3'           # Data level (e.g., 'L1', 'L2a', 'L2b')
 
     return prihdr, exthdr
@@ -579,7 +577,9 @@ def create_default_L4_headers(arrtype="SCI"):
     """
     # TO DO: Update this once L4 headers have been finalized
     prihdr, exthdr = create_default_L3_headers(arrtype)
-
+    
+    exthdr['STARLOCX'] = 512
+    exthdr['STARLOCY'] = 512
     exthdr['DATALVL']    = 'L4'           # Data level (e.g., 'L1', 'L2a', 'L2b')
 
     return prihdr, exthdr

--- a/corgidrp/recipe_templates/l2a_to_l2b.json
+++ b/corgidrp/recipe_templates/l2a_to_l2b.json
@@ -1,0 +1,65 @@
+{
+    "name" : "l2a_to_l2b",
+    "template" : true,
+    "drpconfig" : {
+        "track_individual_errors" : false
+    },
+    "inputs" : [],
+    "outputdir" : "",
+    "steps" : [
+        {
+            "name" : "frame_select"
+        },
+        {
+            "name" : "convert_to_electrons",
+            "calibs" : {
+                "KGain" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "em_gain_division"
+        },
+        {
+            "name" : "add_photon_noise"
+        },
+        {
+            "name" : "dark_subtraction",
+            "calibs" : {
+                "DetectorNoiseMaps" : "AUTOMATIC"
+            },
+            "keywords" : {
+                "outputdir" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "desmear",
+            "calibs" : {
+                "DetectorParams" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "cti_correction",
+            "calibs" : {
+                "TrapCalibration" : "AUTOMATIC,OPTIONAL"
+            }
+        },
+        {
+            "name" : "flat_division",
+            "calibs" : {
+                "FlatField" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "correct_bad_pixels",
+            "calibs" : {
+                "BadPixelMap" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "update_to_l2b"
+        },
+        {
+            "name" : "save"
+        }
+    ]
+}

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -237,6 +237,8 @@ def guess_template(dataset):
         str or list: the best template filename or a list of multiple template filenames
     """
     image = dataset[0] # first image for convenience
+
+    # L1 -> L2a data processing
     if image.ext_hdr['DATALVL'] == "L1":
         if 'VISTYPE' not in image.pri_hdr:
             # this is probably IIT test data. Do generic processing
@@ -260,10 +262,8 @@ def guess_template(dataset):
         elif image.pri_hdr['VISTYPE'] == "PUPILIMG":
             recipe_filename = ["l1_to_l2a_nonlin.json", "l1_to_kgain.json"]
         else:
-            if image.ext_hdr['ISPC']:
-                recipe_filename = "l1_to_l2b_pc.json" 
-            else:  
-                recipe_filename = "l1_to_l2b.json"    
+            recipe_filename = "l1_to_l2a_basic.json"  # science data and all else (including photon counting)
+    # L2a -> L2b data processing
     elif image.ext_hdr['DATALVL'] == "L2a":
         if image.pri_hdr['VISTYPE'] == "DARK":
             _, unique_vals = dataset.split_dataset(exthdr_keywords=['EXPTIME', 'EMGAIN_C', 'KGAINPAR'])
@@ -277,12 +277,18 @@ def guess_template(dataset):
             if image.ext_hdr['ISPC']:
                 recipe_filename = "l2a_to_l2b_pc.json"
             else:
-                recipe_filename = "l2a_to_l2b.json"
+                recipe_filename = "l2a_to_l2b.json"  # science data and all else
+    # L2b -> L3 data processing
     elif image.ext_hdr['DATALVL'] == "L2b":
         if image.pri_hdr['VISTYPE'] == "ABSFLXFT" or image.pri_hdr['VISTYPE'] == "ABSFLXBT":
             recipe_filename = "l2b_to_fluxcal_factor.json"
+        else:
+            recipe_filename = "l2b_to_l3.json"
+    # L3 -> L4 data processing
+    elif image.ext_hdr['DATALVL'] == "L3":
+        recipe_filename = "l3_to_l4.json"
     else:
-        raise NotImplementedError()
+        raise NotImplementedError("Cannot automatically guess the input dataset with 'DATALVL' = {0}".format(image.ext_hdr['DATALVL']))
 
     return recipe_filename
 

--- a/tests/e2e_tests/l1_to_l2b_e2e.py
+++ b/tests/e2e_tests/l1_to_l2b_e2e.py
@@ -30,6 +30,7 @@ def fix_headers_for_tvac(
         prihdr = fits_file[0].header
         exthdr = fits_file[1].header
         # Adjust VISTYPE
+        prihdr['VISTYPE'] = "TDEMO"
         prihdr['OBSNUM'] = prihdr['OBSID']
         exthdr['EMGAIN_C'] = exthdr['CMDGAIN']
         exthdr['EMGAIN_A'] = -1
@@ -48,11 +49,19 @@ def fix_headers_for_tvac(
 def test_l1_to_l2b(tvacdata_path, e2eoutput_path):
     # figure out paths, assuming everything is located in the same relative location
     l1_datadir = os.path.join(tvacdata_path, "TV-36_Coronagraphic_Data", "L1")
+    l2a_datadir = os.path.join(tvacdata_path, "TV-36_Coronagraphic_Data", "L2a")
     l2b_datadir = os.path.join(tvacdata_path, "TV-36_Coronagraphic_Data", "L2b")
     processed_cal_path = os.path.join(tvacdata_path, "TV-36_Coronagraphic_Data", "Cals")
 
     # make output directory if needed
-    l2b_outputdir = os.path.join(e2eoutput_path, "l1_to_l2b_output")
+    test_outputdir = os.path.join(e2eoutput_path, "l1_to_l2b_output")
+    if not os.path.exists(test_outputdir):
+        os.mkdir(test_outputdir)
+    # separate L2a and L2b outputdirs
+    l2a_outputdir = os.path.join(test_outputdir, "l2a")
+    if not os.path.exists(l2a_outputdir):
+        os.mkdir(l2a_outputdir)
+    l2b_outputdir = os.path.join(test_outputdir, "l2b")
     if not os.path.exists(l2b_outputdir):
         os.mkdir(l2b_outputdir)
 
@@ -68,6 +77,7 @@ def test_l1_to_l2b(tvacdata_path, e2eoutput_path):
 
     l1_data_filelist = [os.path.join(l1_datadir, "{0}.fits".format(i)) for i in [90499, 90500]] # just grab the first two files
     mock_cal_filelist = [os.path.join(l1_datadir, "{0}.fits".format(i)) for i in [90526, 90527]] # grab the last two real data to mock the calibration 
+    tvac_l2a_filelist = [os.path.join(l2a_datadir, "{0}.fits".format(i)) for i in [90528, 90530]] # just grab the first two files
     tvac_l2b_filelist = [os.path.join(l2b_datadir, "{0}.fits".format(i)) for i in [90529, 90531]] # just grab the first two files
 
     # modify TVAC headers for produciton
@@ -89,14 +99,14 @@ def test_l1_to_l2b(tvacdata_path, e2eoutput_path):
     nonlin_dat = np.genfromtxt(nonlin_path, delimiter=",")
     nonlinear_cal = data.NonLinearityCalibration(nonlin_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr,
                                                 input_dataset=mock_input_dataset)
-    nonlinear_cal.save(filedir=l2b_outputdir, filename="mock_nonlinearcal.fits" )
+    nonlinear_cal.save(filedir=test_outputdir, filename="mock_nonlinearcal.fits" )
     this_caldb.create_entry(nonlinear_cal)
 
     # KGain
     kgain_val = 8.7
     kgain = data.KGain(np.array([[kgain_val]]), pri_hdr=pri_hdr, ext_hdr=ext_hdr, 
                     input_dataset=mock_input_dataset)
-    kgain.save(filedir=l2b_outputdir, filename="mock_kgain.fits")
+    kgain.save(filedir=test_outputdir, filename="mock_kgain.fits")
     this_caldb.create_entry(kgain)
 
     # NoiseMap
@@ -119,26 +129,31 @@ def test_l1_to_l2b(tvacdata_path, e2eoutput_path):
     noise_map = data.DetectorNoiseMaps(noise_map_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr,
                                     input_dataset=mock_input_dataset, err=noise_map_noise,
                                     dq = noise_map_dq, err_hdr=err_hdr)
-    noise_map.save(filedir=l2b_outputdir, filename="mock_detnoisemaps.fits")
+    noise_map.save(filedir=test_outputdir, filename="mock_detnoisemaps.fits")
     this_caldb.create_entry(noise_map)
 
     ## Flat field
     with fits.open(flat_path) as hdulist:
         flat_dat = hdulist[0].data
     flat = data.FlatField(flat_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=mock_input_dataset)
-    flat.save(filedir=l2b_outputdir, filename="mock_flat.fits")
+    flat.save(filedir=test_outputdir, filename="mock_flat.fits")
     this_caldb.create_entry(flat)
 
     # bad pixel map
     with fits.open(bp_path) as hdulist:
         bp_dat = hdulist[0].data
     bp_map = data.BadPixelMap(bp_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=mock_input_dataset)
-    bp_map.save(filedir=l2b_outputdir, filename="mock_bpmap.fits")
+    bp_map.save(filedir=test_outputdir, filename="mock_bpmap.fits")
     this_caldb.create_entry(bp_map)
 
     ####### Run the walker on some test_data
 
-    walker.walk_corgidrp(l1_data_filelist, "", l2b_outputdir)
+    # l1 -> l2a processing
+    walker.walk_corgidrp(l1_data_filelist, "", l2a_outputdir)
+
+    # l2a -> l2b processing
+    new_l2a_filenames = [os.path.join(l2a_outputdir, "{0}.fits".format(i)) for i in [90499, 90500]]
+    walker.walk_corgidrp(new_l2a_filenames, "", l2b_outputdir)
 
 
     # clean up by removing entry
@@ -149,6 +164,18 @@ def test_l1_to_l2b(tvacdata_path, e2eoutput_path):
     this_caldb.remove_entry(bp_map)
 
     ##### Check against TVAC data
+    # l2a data
+    for new_filename, tvac_filename in zip(new_l2a_filenames, tvac_l2a_filelist):
+        img = data.Image(new_filename)
+
+        with fits.open(tvac_filename) as hdulist:
+            tvac_dat = hdulist[1].data
+        
+        diff = img.data - tvac_dat
+
+        assert np.all(np.abs(diff) < 1e-5)
+
+    # l2b data
     new_l2b_filenames = [os.path.join(l2b_outputdir, "{0}.fits".format(i)) for i in [90499, 90500]]
 
     for new_filename, tvac_filename in zip(new_l2b_filenames, tvac_l2b_filelist):

--- a/tests/e2e_tests/l2b_to_l4_e2e.py
+++ b/tests/e2e_tests/l2b_to_l4_e2e.py
@@ -198,7 +198,7 @@ def test_l2b_to_l3(tvacdata_path, e2eoutput_path):
     #####################################
 
     l2b_data_filelist = sorted(glob.glob(os.path.join(e2e_data_path, "*.fits")))
-    walker.walk_corgidrp(l2b_data_filelist, "", e2eoutput_path, template="l2b_to_l3.json")
+    walker.walk_corgidrp(l2b_data_filelist, "", e2eoutput_path)
 
     #Read in an L3 file
     l3_filename = glob.glob(os.path.join(e2eoutput_path, "*L3_.fits"))[0]
@@ -322,7 +322,7 @@ def test_l3_to_l4(e2eoutput_path):
 
     l3_data_filelist = sorted(glob.glob(os.path.join(e2eintput_path, "*L3_.fits")))
 
-    walker.walk_corgidrp(l3_data_filelist, "", e2eoutput_path_l4, template="l3_to_l4.json")
+    walker.walk_corgidrp(l3_data_filelist, "", e2eoutput_path_l4)
 
     ########################################################################
     #### Read in the psf_subtracted images and test for source detection ###

--- a/tests/test_data_levels.py
+++ b/tests/test_data_levels.py
@@ -18,28 +18,28 @@ def test_l1_to_l4():
     """
     l1_dataset = mocks.create_prescan_files(arrtype="SCI", numfiles=2)
     # edit filenames
-    fname_template = "CGI_L1_100_0200001001001100001_20270101T120000_{0:03d}.fits"
+    fname_template = "CGI_0000011222333OOO111_20250101T12{0:02d}00_L1_.fits"
     for i, image in enumerate(l1_dataset):
         image.filename = fname_template.format(i)
 
     l2a_dataset = l1_to_l2a.update_to_l2a(l1_dataset)
 
-    for frame in l2a_dataset:
+    for i,frame in enumerate(l2a_dataset):
         assert frame.ext_hdr['DATALVL'] == "L2a"
-        assert "L2a" in frame.filename
+        assert frame.filename == "CGI_0000011222333OOO111_20250101T12{0:02d}00_L2a.fits".format(i)
     
 
     l2b_dataset = l2a_to_l2b.update_to_l2b(l2a_dataset)
 
-    for frame in l2b_dataset:
+    for i,frame in enumerate(l2b_dataset):
         assert frame.ext_hdr['DATALVL'] == "L2b"
-        assert "L2b" in frame.filename
+        assert frame.filename == "CGI_0000011222333OOO111_20250101T12{0:02d}00_L2b.fits".format(i)
 
     l3_dataset = l2b_to_l3.update_to_l3(l2b_dataset)
 
-    for frame in l3_dataset:
+    for i,frame in enumerate(l3_dataset):
         assert frame.ext_hdr['DATALVL'] == "L3"
-        assert "L3" in frame.filename
+        assert frame.filename == "CGI_0000011222333OOO111_20250101T12{0:02d}00_L3_.fits".format(i)
 
     #Create dummy dataset to pass in to update_to_l4 (which needs filenames)
     pri_hdr, ext_hdr = mocks.create_default_L3_headers()
@@ -48,9 +48,9 @@ def test_l1_to_l4():
 
     l4_dataset = l3_to_l4.update_to_l4(l3_dataset, test, test)
 
-    for frame in l4_dataset:
+    for i,frame in enumerate(l4_dataset):
         assert frame.ext_hdr['DATALVL'] == "L4"
-        assert "L4" in frame.filename
+        assert frame.filename == "CGI_0000011222333OOO111_20250101T12{0:02d}00_L4_.fits".format(i)
 
 def test_l1_to_l2a_bad():
     """

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -191,7 +191,7 @@ def test_auto_template_identification():
     ### Finally, test the recipe identification
     recipe = walker.autogen_recipe(filelist, outputdir)
 
-    assert recipe['name'] == 'l1_to_l2b'
+    assert recipe['name'] == 'l1_to_l2a_basic'
     assert recipe['template'] == False
 
     # now cleanup
@@ -315,7 +315,10 @@ def test_skip_missing_calib():
 
 
     ### Test that we are skipping the steps without calibrations
-    recipe = walker.autogen_recipe(filelist, outputdir)
+    # use l1 to l2b recipe
+    template_filepath = os.path.join(os.path.dirname(walker.__file__), "recipe_templates", "l1_to_l2b.json")
+    template_recipe = json.load(open(template_filepath, "r"))
+    recipe = walker.autogen_recipe(filelist, outputdir, template=template_recipe)
 
     assert recipe['name'] == 'l1_to_l2b'
     assert recipe['template'] == False


### PR DESCRIPTION
## Describe your changes
 * Walker now does L1 -> L2a, and L2a -> L2b separately (need to call twice to get to L2b)
 * Add automatic detection of L2b->L3 and L3 -> L4 to walker
 * Update one header keyword in Flatfield that I forgot
 * Remove STARLOCX and STARLOCY for mocks of L3 headers
 * Check tests for L2a and L2b filename format
 * [x] Update L2a data type docs
 * [x] Update L2b data type docs

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
Closes #322 and #336

## Checklist before requesting a review
- [ ] I have linted my code
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed