### PR TITLE
Header updates and enforcing cal products to have DATALVL = CAL

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -654,6 +654,9 @@ class Dark(Image):
             if input_dataset is not None:
                 orig_input_filename = input_dataset[-1].filename.split(".fits")[0]
                 self.filename = "{0}_DRK_CAL.fits".format(orig_input_filename)
+
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
         
         if 'PC_STAT' not in self.ext_hdr:
             self.ext_hdr['PC_STAT'] = 'analog master dark'
@@ -700,6 +703,8 @@ class FlatField(Image):
             # give it a default filename using the last input file as the base
             self.filename = re.sub('_L[0-9].', '_FLT_CAL', input_dataset[-1].filename)
 
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
 
         # double check that this is actually a masterflat file that got read in
         # since if only a filepath was passed in, any file could have been read in
@@ -794,6 +799,9 @@ class NonLinearityCalibration(Image):
             orig_input_filename = input_dataset[0].filename.split(".fits")[0]
             self.filename = "{0}_NonLinearityCalibration.fits".format(orig_input_filename)
 
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
+
 
         # double check that this is actually a NonLinearityCalibration file that got read in
         # since if only a filepath was passed in, any file could have been read in
@@ -881,6 +889,9 @@ class KGain(Image):
             # add to history
             self.ext_hdr['HISTORY'] = "KGain Calibration file created"
 
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
+
         # double check that this is actually a KGain file that got read in
         # since if only a filepath was passed in, any file could have been read in
         if 'DATATYPE' not in self.ext_hdr:
@@ -964,8 +975,9 @@ class BadPixelMap(Image):
             else:
                 # not created from a flat
                 self.filename = re.sub('_L[0-9].', '_BPM_CAL', input_dataset[-1].filename)
-
-
+            
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
 
         # double check that this is actually a bad pixel map that got read in
         # since if only a filepath was passed in, any file could have been read in
@@ -1034,6 +1046,9 @@ class DetectorNoiseMaps(Image):
             # give it a default filename
             orig_input_filename = self.ext_hdr['FILE0'].split(".fits")[0]
             self.filename = "{0}_DetectorNoiseMaps.fits".format(orig_input_filename)
+
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
 
         if err_hdr is not None:
             self.err_hdr['BUNIT'] = 'Detected Electrons'
@@ -1137,6 +1152,9 @@ class DetectorParams(Image):
             ext_hdr['OPMODE'] = ""
             ext_hdr['EMGAIN_C'] = 1.0
             ext_hdr['EXCAMT'] = 40.0
+
+            # Enforce data level = CAL?
+            self.ext_hdr['DATALVL']    = 'CAL'
 
             # write default values to headers
             for key, value in self.default_values.items():
@@ -1255,6 +1273,9 @@ class AstrometricCalibration(Image):
             # give a default filename
             self.filename = "AstrometricCalibration.fits"
 
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
+
         # check that this is actually an AstrometricCalibration file that was read in
         if 'DATATYPE' not in self.ext_hdr or self.ext_hdr['DATATYPE'] != 'AstrometricCalibration':
             raise ValueError("File that was loaded was not an AstrometricCalibration file.")    
@@ -1301,6 +1322,8 @@ class TrapCalibration(Image):
             orig_input_filename = input_dataset[0].filename.split(".fits")[0]
             self.filename = "{0}_trapcal.fits".format(orig_input_filename)
 
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
 
         # double check that this is actually a dark file that got read in
         # since if only a filepath was passed in, any file could have been read in
@@ -1389,6 +1412,9 @@ class FluxcalFactor(Image):
             self.err_hdr['BUNIT'] = 'erg/(s * cm^2 * AA)/(electron/s)'
             # add to history
             self.ext_hdr['HISTORY'] = "Flux calibration file created"
+
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
 
             # use the start date for the filename by default
             self.filedir = "."
@@ -1484,6 +1510,9 @@ class FpamFsamCal(Image):
             # use the start date for the filename by default
             self.filedir = '.'
             self.filename = "FpamFsamCal_{0}.fits".format(self.ext_hdr['SCTSRT'])
+
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
 
 class CoreThroughputCalibration(Image):
     """
@@ -1589,6 +1618,9 @@ class CoreThroughputCalibration(Image):
             # input dataset by _CTP_CAL.fits
             self.filedir = '.'
             self.filename = re.sub('_L[0-9].', '_CTP_CAL', input_dataset[-1].filename)
+
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
 
         # double check that this is actually a NonLinearityCalibration file that got read in
         # since if only a filepath was passed in, any file could have been read in
@@ -2432,6 +2464,9 @@ class NDFilterSweetSpotDataset(Image):
                 self.filename = f"{base_name}_ndfsweet.fits"
             else:
                 self.filename = "NDFilterSweetSpotDataset.fits"
+
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
 
         # 4. If reading from a file, verify that the header indicates the correct DATATYPE.
         if 'DATATYPE' not in self.ext_hdr or self.ext_hdr['DATATYPE'] != 'NDFilterSweetSpotDataset':

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -1154,7 +1154,7 @@ class DetectorParams(Image):
             ext_hdr['EXCAMT'] = 40.0
 
             # Enforce data level = CAL?
-            self.ext_hdr['DATALVL']    = 'CAL'
+            ext_hdr['DATALVL']    = 'CAL'
 
             # write default values to headers
             for key, value in self.default_values.items():

--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -271,6 +271,8 @@ def create_default_L1_headers(arrtype="SCI"):
     exthdr['DPAM_V']      = 0.0             # DPAM absolute position of the V-axis (µm)
     exthdr['DPAMSP_H']    = 0.0             # DPAM set point H (µm)
     exthdr['DPAMSP_V']    = 0.0             # DPAM set point V (µm)
+    exthdr['EACQ_ROW']    = 0               # Desired row for EXCAM star acquisition method
+    exthdr['EQCQ_COL']    = 0               # Desired column for EXCAM star acquisition method
     exthdr['DATETIME']    = dt_str          # Time of preceding 1Hz HK packet (TAI)
     exthdr['FTIMEUTC']    = dt_str           # Frame time in UTC
     exthdr['DATALVL']    = 'L1'            # Data level (e.g., 'L1', 'L2a', 'L2b')
@@ -450,6 +452,8 @@ def create_default_L1_TrapPump_headers(arrtype="SCI"):
     exthdr['DPAM_V']      = 0.0             # DPAM absolute position of the V-axis (µm)
     exthdr['DPAMSP_H']    = 0.0             # DPAM set point H (µm)
     exthdr['DPAMSP_V']    = 0.0             # DPAM set point V (µm)
+    exthdr['EACQ_ROW']    = 0               # Desired row for EXCAM star acquisition method
+    exthdr['EQCQ_COL']    = 0               # Desired column for EXCAM star acquisition method
     exthdr['TPINJCYC']    = 0               # Number of cycles for TPUMP injection
     exthdr['TPOSCCYC']    = 0               # Number of cycles for charge oscillation (TPUMP)
     exthdr['TPTAU']       = 0               # Length of one step in a trap pumping scheme (microseconds)
@@ -601,7 +605,7 @@ def create_default_calibration_product_headers():
     '''
     # TO DO: update when this has been more defined
     prihdr, exthdr = create_default_L1_headers()
-    exthdr['DATALVL']    = 'Calibration Product'
+    exthdr['DATALVL']    = 'CAL'
     exthdr['DATATYPE']    = 'Image'              # What type of calibration product, just do image for now, mock codes will update
 
     return prihdr, exthdr


### PR DESCRIPTION
## Describe your changes
Updates L1 mock headers to include EACQ_ROW and EACQ_COL and updates classes for calibration products to have DATALVL = CAL

## Type of change

Please delete options that are not relevant (and this line).

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
#245 #357 

## Checklist before requesting a review
- [ ] I have linted my code
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed