### PR TITLE
Nonlin filename

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -789,11 +789,9 @@ class NonLinearityCalibration(Image):
             # add to history
             self.ext_hdr['HISTORY'] = "Non Linearity Calibration file created"
 
-            # give it a default filename using the first input file as the base
-            # strip off everything starting at .fits
-            orig_input_filename = input_dataset[0].filename.split(".fits")[0]
-            self.filename = "{0}_NonLinearityCalibration.fits".format(orig_input_filename)
-
+            # Follow filename convention as of R3.0.2
+            self.filedir = '.'
+            self.filename = re.sub('_L[0-9].', '_NLN_CAL', input_dataset[-1].filename)
 
         # double check that this is actually a NonLinearityCalibration file that got read in
         # since if only a filepath was passed in, any file could have been read in

--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -1431,6 +1431,8 @@ def make_fluxmap_image(f_map, bias, kgain, rn, emgain, time, coeffs, nonlin_flag
     dq = np.zeros([1200,2200], dtype = np.uint16)
     image = Image(frame, pri_hdr = prhd, ext_hdr = exthd, err = err,
         dq = dq)
+    # Use a an expected filename
+    image.filename = 'CGI_0200001001001001001_20250415T0305102_L2b.fits'
     return image
 
 def create_astrom_data(field_path, filedir=None, image_shape=(1024, 1024), target=(80.553428801, -69.514096821), offset=(0,0), subfield_radius=0.03, platescale=21.8, rotation=45, add_gauss_noise=True, 

--- a/tests/e2e_tests/nonlin_e2e.py
+++ b/tests/e2e_tests/nonlin_e2e.py
@@ -116,7 +116,7 @@ def test_nonlin_cal_e2e(
     # Compare results
     print('Comparing the results with TVAC')
     # NL from CORGIDRP
-    possible_nonlin_files = glob.glob(os.path.join(e2eoutput_path, '*_NonLinearityCalibration.fits'))
+    possible_nonlin_files = glob.glob(os.path.join(e2eoutput_path, '*_NLN_CAL.fits'))
     nonlin_drp_filepath = max(possible_nonlin_files, key=os.path.getmtime) # get the one most recently modified
     nonlin_drp_filename = nonlin_drp_filepath.split(os.path.sep)[-1]
 

--- a/tests/test_nonlin_cal.py
+++ b/tests/test_nonlin_cal.py
@@ -203,9 +203,12 @@ def test_expected_results_nom_sub():
     assert np.equal(nonlin_out.data[norm_ind+1,0], norm_val)
 
     # Test filename follows convention (as of R3.0.2)
-    nonlin_out.save(filedir=corgidrp.default_cal_dir)
+    datadir = os.path.join(os.path.dirname(__file__), "simdata")
+    if not os.path.exists(datadir):
+        os.mkdir(datadir)
+    nonlin_out.save(filedir=datadir)
     nln_cal_filename = dataset_nl[-1].filename.replace("_L2b", "_NLN_CAL")
-    nln_cal_filepath = os.path.join(corgidrp.default_cal_dir, nln_cal_filename)
+    nln_cal_filepath = os.path.join(datadir, nln_cal_filename)
     if os.path.exists(nln_cal_filepath) is False:
         raise IOError(f'NonLinearity calibration file {nln_cal_filepath} does not exist.')
     # Load the calibration file to check it has the same data contents

--- a/tests/test_nonlin_cal.py
+++ b/tests/test_nonlin_cal.py
@@ -149,7 +149,6 @@ def setup_module():
     min_write = 800
     max_write = 10000
 
-
 def teardown_module():
     """
     Runs at the end. Deletes variables
@@ -201,6 +200,13 @@ def test_expected_results_nom_sub():
     assert np.equal(nonlin_out.data[norm_ind+1,-1], 1)
     # check that norm_val is correct
     assert np.equal(nonlin_out.data[norm_ind+1,0], norm_val)
+
+    # Test filename follows convention (as of R3.0.2)
+    nln_cal_filename = dataset_nl[-1].filename.replace("_L2b", "_NLN_CAL")
+    nln_cal_filepath = os.path.join(corgidrp.default_cal_dir,ct_cal_filename)
+    breakpoint()
+    if os.path.exists(nln_cal_filepath) is False:
+        raise IOError(f'NonLinearity calibration file {nln_cal_filepath} does not exist.')
 
 def test_expected_results_time_sub():
     """Outputs are as expected for the provided frames with datetime values for


### PR DESCRIPTION
## Describe your changes

I added the current filename convention for non-linearity: _NLN_CAL to both the unit test and the e2e test.

## Reference any relevant issues (don't forget the #)

https://github.com/roman-corgi/corgidrp/issues/356

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [x] I have filled out the Unit Test Definition Table on confluence, as needed