### PR TITLE
Enforce DATALVL for Non-linearity calibration

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -795,7 +795,7 @@ class NonLinearityCalibration(Image):
             self.ext_hdr['HISTORY'] = "Non Linearity Calibration file created"
 
             # Enforce data level = CAL
-            self.ext_hdr['DATALVL']    = 'CAL'
+            self.ext_hdr['DATALVL'] = 'CAL'
 
             # Follow filename convention as of R3.0.2
             self.filedir = '.'

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -794,6 +794,9 @@ class NonLinearityCalibration(Image):
             # add to history
             self.ext_hdr['HISTORY'] = "Non Linearity Calibration file created"
 
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
+
             # Follow filename convention as of R3.0.2
             self.filedir = '.'
             self.filename = re.sub('_L[0-9].', '_NLN_CAL', input_dataset[-1].filename)

--- a/tests/test_nonlin_cal.py
+++ b/tests/test_nonlin_cal.py
@@ -172,6 +172,9 @@ def test_expected_results_nom_sub():
     """Outputs are as expected for the provided frames with nominal arrays."""
     nonlin_out = calibrate_nonlin(dataset_nl, n_cal, n_mean, norm_val, min_write,
         max_write)
+
+    # Test its DATALVL is CAL
+    assert nonlin_out.ext_hdr['DATALVL'] == 'CAL'
         
     # Calculate rms of the differences between the assumed nonlinearity and 
     # the nonlinearity determined with calibrate_nonlin


### PR DESCRIPTION
## Describe your changes

Enforcing that DATALVL in the EXT_HDR is 'CAL'. Simple change. UT adds check.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [x] I have filled out the Unit Test Definition Table on confluence, as needed