### PR TITLE
add SED file names in History header

### DIFF
--- a/corgidrp/fluxcal.py
+++ b/corgidrp/fluxcal.py
@@ -45,7 +45,7 @@ def get_calspec_file(star_name):
         star_name (str): 
     
     Returns:
-        str: file path
+        str: file path, fits file name
     """
     if star_name not in calspec_names:
         raise ValueError('{0} is not in list of anticipated standard stars {1}, please check naming'.format(star_name, calspec_names.keys()) )

--- a/corgidrp/fluxcal.py
+++ b/corgidrp/fluxcal.py
@@ -45,7 +45,8 @@ def get_calspec_file(star_name):
         star_name (str): 
     
     Returns:
-        str: file path, fits file name
+        str: file path
+        str: fits file name
     """
     if star_name not in calspec_names:
         raise ValueError('{0} is not in list of anticipated standard stars {1}, please check naming'.format(star_name, calspec_names.keys()) )

--- a/corgidrp/fluxcal.py
+++ b/corgidrp/fluxcal.py
@@ -59,7 +59,7 @@ def get_calspec_file(star_name):
         file_name, headers = urllib.request.urlretrieve(fits_url, filename =  os.path.join(calspec_dir, fits_name))
     except:
         raise Exception("cannot access CALSPEC archive web page and/or download {0}".format(fits_name))
-    return file_name
+    return file_name, fits_name
 
 def get_filter_name(image):
     """
@@ -196,7 +196,7 @@ def calculate_flux_ref(filter_wavelength, calspec_flux, wave_ref):
 
 def calculate_vega_mag(source_flux, filter_file):
     """
-    determine the apparent Vega magnitude of the source with known flux in CALSPEC units (erg/(s * cm^2 *AA)
+    determine the apparent Vega magnitude of the source with known flux in CALSPEC units erg/(s * cm^2 *AA)
     in the used filter band.
     
     Args:
@@ -209,7 +209,7 @@ def calculate_vega_mag(source_flux, filter_file):
     
     wave, filter_trans = read_filter_curve(filter_file)
     # calculate the flux of VEGA and the source star from the user given CALSPEC file binned on the wavelength grid of the filter
-    vega_filepath = get_calspec_file('Vega')
+    vega_filepath = get_calspec_file('Vega')[0]
     vega_sed = read_cal_spec(vega_filepath, wave)
 
     vega_flux = calculate_band_flux(filter_trans, vega_sed, wave)
@@ -474,7 +474,7 @@ def calibrate_fluxcal_aper(dataset_or_image, flux_or_irr = 'flux', phot_kwargs=N
     
     # Read filter and CALSPEC data.
     wave, filter_trans = read_filter_curve(filter_file)
-    calspec_filepath = get_calspec_file(star_name) 
+    calspec_filepath, calspec_filename = get_calspec_file(star_name) 
     flux_ref = read_cal_spec(calspec_filepath, wave)
     
     if flux_or_irr == 'flux':
@@ -511,7 +511,7 @@ def calibrate_fluxcal_aper(dataset_or_image, flux_or_irr = 'flux', phot_kwargs=N
         fluxcal_obj.ext_hdr['LOCBACK'] = back
 
     # Append to or create a HISTORY entry in the header.
-    history_entry = "Flux calibration factor was determined by aperture photometry."
+    history_entry = "Flux calibration factor was determined by aperture photometry using SED file {0}".format(calspec_filename)
     fluxcal_obj.ext_hdr.add_history(history_entry)
 
     return fluxcal_obj
@@ -573,7 +573,7 @@ def calibrate_fluxcal_gauss2d(dataset_or_image, flux_or_irr = 'flux', phot_kwarg
     filter_file = get_filter_name(image)
     
     wave, filter_trans = read_filter_curve(filter_file)
-    calspec_filepath = get_calspec_file(star_name)
+    calspec_filepath, calspec_filename = get_calspec_file(star_name)
     flux_ref = read_cal_spec(calspec_filepath, wave)
     
     if flux_or_irr == 'flux':
@@ -609,7 +609,7 @@ def calibrate_fluxcal_gauss2d(dataset_or_image, flux_or_irr = 'flux', phot_kwarg
         fluxcal_obj.ext_hdr['LOCBACK'] = back
 
     # Append to or create a HISTORY entry in the header.
-    history_entry = "Flux calibration factor was determined by a Gaussian 2D fit photometry."
+    history_entry = "Flux calibration factor was determined by a Gaussian 2D fit photometry using SED file {0}".format(calspec_filename)
     fluxcal_obj.ext_hdr.add_history(history_entry)
     
     return fluxcal_obj

--- a/corgidrp/l4_to_tda.py
+++ b/corgidrp/l4_to_tda.py
@@ -22,7 +22,7 @@ def determine_app_mag(input_data, source_star, scale_factor = 1.):
         input_data (corgidrp.data.Dataset or corgidrp.data.Image): 
             A dataset of Images (L2b-level) or a single Image. Must be all of the same source with same filter.
         source_star (str): either the fits file path of the flux model of the observed source in 
-                           CALSPEC units (erg/(s * cm^2 * AA) and format or the (SIMBAD) name of a CALSPEC star
+                           CALSPEC units erg/(s * cm^2 * AA) and format or the (SIMBAD) name of a CALSPEC star
         scale_factor (float): factor applied to the flux of the calspec standard source, so that you can apply it 
                               if you have a different source with similiar spectral type, but no calspec standard.
                               Defaults to 1.
@@ -58,14 +58,14 @@ def determine_app_mag(input_data, source_star, scale_factor = 1.):
 
     # read the transmission curve from the color filter file
     wave, filter_trans = fluxcal.read_filter_curve(filter_name)
-
+    
     if source_star.split(".")[-1] == "fits":
         source_filepath = source_star
+        source_filename = source_star
     else:
-        source_filepath = fluxcal.get_calspec_file(source_star)
+        source_filepath, source_filename = fluxcal.get_calspec_file(source_star)
     
-    vega_filepath = fluxcal.get_calspec_file('Vega')
-    
+    vega_filepath, vega_filename = fluxcal.get_calspec_file('Vega')
     # calculate the flux of VEGA and the source star from the user given CALSPEC file binned on the wavelength grid of the filter
     vega_sed = fluxcal.read_cal_spec(vega_filepath, wave)
     source_sed = fluxcal.read_cal_spec(source_filepath, wave) * scale_factor
@@ -77,7 +77,7 @@ def determine_app_mag(input_data, source_star, scale_factor = 1.):
     app_mag = -2.5 * np.log10(source_irr/vega_irr)
 
     # write the reference wavelength and the color correction factor to the header (keyword names tbd)
-    history_msg = "the apparent Vega magnitude is calculated and added to the header {0}".format(str(app_mag))
+    history_msg = "the apparent Vega magnitude is calculated and added to the header {0} applying source SED file {1} and VEGA SED file {2}".format(str(app_mag), source_filename, vega_filename)
     # update the header of the output dataset and update the history
     mag_data.update_after_processing_step(history_msg, header_entries = {"APP_MAG": app_mag})
     
@@ -95,7 +95,7 @@ def determine_color_cor(input_dataset, ref_star, source_star):
         ref_star (str): either the fits file path of the known reference flux (usually CALSPEC),
                         or the (SIMBAD) name of a CALSPEC star
         source_star (str): either the fits file path of the flux model of the observed source in 
-                           CALSPEC units (erg/(s * cm^2 * AA) and format or the (SIMBAD) name of a CALSPEC star
+                           CALSPEC units erg/(s * cm^2 * AA) and format or the (SIMBAD) name of a CALSPEC star
     
     Returns:
         corgidrp.data.Dataset: a version of the input dataset with updated header including 
@@ -112,12 +112,14 @@ def determine_color_cor(input_dataset, ref_star, source_star):
     # ref_star/source_star is either the star name or the file path to fits file
     if ref_star.split(".")[-1] == "fits":
         calspec_filepath = ref_star
+        calspec_ref_name = ref_star
     else:
-        calspec_filepath = fluxcal.get_calspec_file(ref_star)
+        calspec_filepath, calspec_ref_name = fluxcal.get_calspec_file(ref_star)
     if source_star.split(".")[-1] == "fits":
         source_filepath = source_star
+        source_filename = source_star
     else:
-        source_filepath = fluxcal.get_calspec_file(source_star)
+        source_filepath, source_filename = fluxcal.get_calspec_file(source_star)
     
     # calculate the flux from the user given CALSPEC file binned on the wavelength grid of the filter
     flux_ref = fluxcal.read_cal_spec(calspec_filepath, wave)
@@ -128,7 +130,7 @@ def determine_color_cor(input_dataset, ref_star, source_star):
     k = fluxcal.compute_color_cor(filter_trans, wave, flux_ref, lambda_ref, source_sed)
     
     # write the reference wavelength and the color correction factor to the header (keyword names tbd)
-    history_msg = "the color correction is calculated and added to the header {0}".format(str(k))
+    history_msg = "the color correction is calculated and added to the header: {0}, source SED file: {1}, reference SED file: {2}".format(str(k), source_filename, calspec_ref_name)
     # update the header of the output dataset and update the history
     color_dataset.update_after_processing_step(history_msg, header_entries = {"LAM_REF": lambda_ref, "COL_COR": k})
     

--- a/corgidrp/nd_filter_calibration.py
+++ b/corgidrp/nd_filter_calibration.py
@@ -113,7 +113,7 @@ def compute_expected_band_irradiance(star_name, filter_name):
     Raises:
         ValueError: If no matching filter curve file is found.
     """
-    calspec_filepath = fluxcal.get_calspec_file(star_name)
+    calspec_filepath = fluxcal.get_calspec_file(star_name)[0]
     datadir = os.path.join(os.path.dirname(fluxcal.__file__), "data", "filter_curves")
     filter_files = [f for f in os.listdir(datadir) if filter_name in f and f.endswith('.csv')]
     if not filter_files:

--- a/tests/test_fluxcal.py
+++ b/tests/test_fluxcal.py
@@ -89,6 +89,7 @@ def test_colorcor():
     calspec_name = 'Vega'
     source_name = 'TYC 4424-1286-1'
     output_dataset = l4_to_tda.determine_color_cor(dataset, calspec_name, source_name)
+    assert "1732526_stisnic_009.fits" in str(output_dataset[0].ext_hdr['HISTORY'])
     assert output_dataset[0].ext_hdr['LAM_REF'] == lambda_piv
     assert output_dataset[0].ext_hdr['COL_COR'] == pytest.approx(1,1e-2) 
     
@@ -96,15 +97,17 @@ def test_calspec_download():
     """
     test the download of a calspec fits file
     """
-    filepath = fluxcal.get_calspec_file('Vega')
+    filepath, filename = fluxcal.get_calspec_file('Vega')
     assert os.path.exists(filepath)
+    assert filename == 'alpha_lyr_stis_011.fits'
     os.remove(filepath)
-    filepath = fluxcal.get_calspec_file('TYC 4424-1286-1')
+    filepath, filename = fluxcal.get_calspec_file('TYC 4424-1286-1')
     assert os.path.exists(filepath)
+    assert filename == '1732526_stisnic_009.fits'
     os.remove(filepath)
     
     with pytest.raises(ValueError):
-        filepath = fluxcal.get_calspec_file('Todesstern')
+        filepath, filename = fluxcal.get_calspec_file('Todesstern')
 
 def test_app_mag():
     """
@@ -120,7 +123,9 @@ def test_app_mag():
     assert output_dataset[0].ext_hdr['APP_MAG'] == pytest.approx(0.+-2.5*np.log10(0.5), 0.03)
     output_dataset = l4_to_tda.determine_app_mag(dataset, '109 Vir')
     assert output_dataset[0].ext_hdr['APP_MAG'] == pytest.approx(3.72, 0.05)
-
+    assert 'alpha_lyr_stis_011.fits' in str(output_dataset[0].ext_hdr['HISTORY'])
+    assert '109vir_stis_005.fits' in str(output_dataset[0].ext_hdr['HISTORY'])
+    
 def test_fluxcal_file():
     """ 
     Generate a mock fluxcal factor cal object and test the content and functionality.
@@ -196,7 +201,7 @@ def test_abs_fluxcal():
     dataset = Dataset([flux_image])
     fluxcal_factor = fluxcal.calibrate_fluxcal_aper(dataset, flux_or_irr = 'flux', phot_kwargs=None)
     assert fluxcal_factor.filter == '3C'
-    #band_flux/200 was the input calibration factor cal_factor of the simulated mock image
+    #band_flux/200 was the input calibration factor cal_factor of the simulated mock image"alpha_lyr_stis_011.fits"
     assert fluxcal_factor.fluxcal_fac == pytest.approx(cal_factor, rel = 0.05)
     #divisive error propagation of the aperture phot error
     err_fluxcal_ap = band_flux/flux_el_ap**2*flux_err_ap
@@ -281,10 +286,12 @@ def test_abs_fluxcal():
     fluxcal_factor_back = fluxcal.calibrate_fluxcal_aper(flux_image_back, flux_or_irr = 'flux', phot_kwargs=aper_kwargs)
     assert fluxcal_factor_back.fluxcal_fac == pytest.approx(fluxcal_factor.fluxcal_fac)
     assert fluxcal_factor_back.ext_hdr["LOCBACK"] == back
+    assert 'alpha_lyr_stis_011.fits' in str (fluxcal_factor_back.ext_hdr['HISTORY'])
     fluxcal_factor_back_gauss = fluxcal.calibrate_fluxcal_gauss2d(flux_image_back, flux_or_irr = 'flux', phot_kwargs=gauss_kwargs)
     assert fluxcal_factor_back_gauss.fluxcal_fac == pytest.approx(fluxcal_factor_gauss.fluxcal_fac)
     assert fluxcal_factor_back_gauss.ext_hdr["LOCBACK"] == back
-
+    assert 'alpha_lyr_stis_011.fits' in str (fluxcal_factor_back_gauss.ext_hdr['HISTORY'])
+    
     # test l4_to_tda.determine_flux
     input_dataset = Dataset([flux_image_back, flux_image_back])
     output_dataset = l4_to_tda.determine_flux(input_dataset, fluxcal_factor_back,  photo = "aperture", phot_kwargs = aper_kwargs)


### PR DESCRIPTION
## Describe your changes
write the applied SED filenames (mostly CALSPEC files) in the History header, when determining the FluxcalFactor, the apparent magnitude and the color correction.

## Type of change
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
#393

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [x] I have filled out the Unit Test Definition Table on confluence, as needed