### PR TITLE
make the calspec filenames independent of the version

### DIFF
--- a/corgidrp/fluxcal.py
+++ b/corgidrp/fluxcal.py
@@ -13,7 +13,6 @@ from photutils.psf import fit_2dgaussian
 from scipy import integrate
 from corgidrp.astrom import centroid_with_roi
 from urllib.request import Request, urlopen, urlretrieve
-from bs4 import BeautifulSoup
 
 # Dictionary of anticipated bright and dim CASLPEC standard star names and corresponding fits names
 


### PR DESCRIPTION
## Describe your changes
For absolute flux calibration there is a dictionary of calibration star names and their CALSPEC file name. The CALSPEC file name has version numbers, which can change. The version number should not matter.

## Type of change

Please delete options that are not relevant (and this line).
- New feature (non-breaking change which adds functionality)
1. upper or lower case characters of the star name do not matter anymore
2. the version number of the latest calspec files does not matter anymore


## Reference any relevant issues (don't forget the #)
#394

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed