### PR TITLE
clean out output files in trad dark e2e

### DIFF
--- a/tests/e2e_tests/trad_dark_e2e.py
+++ b/tests/e2e_tests/trad_dark_e2e.py
@@ -72,6 +72,10 @@ def test_trad_dark(e2edata_path, e2eoutput_path):
     if not os.path.exists(build_trad_dark_outputdir):
         os.mkdir(build_trad_dark_outputdir)
 
+    # remove any files in the output directory that may have been there previously
+    for f in os.listdir(build_trad_dark_outputdir):
+        os.remove(os.path.join(build_trad_dark_outputdir, f))
+
     this_caldb = caldb.CalDB() # connection to cal DB
     # remove other KGain calibrations that may exist in case they don't have the added header keywords
     for i in range(len(this_caldb._db['Type'])):
@@ -237,6 +241,9 @@ def test_trad_dark(e2edata_path, e2eoutput_path):
     # remove from caldb
     trad_dark = data.Dark(generated_trad_dark_file.replace("_L1_", "_L2a_", 1))
     this_caldb.remove_entry(trad_dark)
+    # clean out output files that were made
+    for f in os.listdir(build_trad_dark_outputdir):
+        os.remove(os.path.join(build_trad_dark_outputdir, f))
 
 
 @pytest.mark.e2e
@@ -266,6 +273,9 @@ def test_trad_dark_im(e2edata_path, e2eoutput_path):
     build_trad_dark_outputdir = os.path.join(e2eoutput_path, "build_trad_dark_output")
     if not os.path.exists(build_trad_dark_outputdir):
         os.mkdir(build_trad_dark_outputdir)
+    # remove any files in the output directory that may have been there previously
+    for f in os.listdir(build_trad_dark_outputdir):
+        os.remove(os.path.join(build_trad_dark_outputdir, f))
 
     this_caldb = caldb.CalDB() # connection to cal DB
     # remove other KGain calibrations that may exist in case they don't have the added header keywords
@@ -438,6 +448,9 @@ def test_trad_dark_im(e2edata_path, e2eoutput_path):
 
     # remove from caldb
     this_caldb.remove_entry(trad_dark)
+    # clean out output files that were made
+    for f in os.listdir(build_trad_dark_outputdir):
+        os.remove(os.path.join(build_trad_dark_outputdir, f))
 
 if __name__ == "__main__":
     # Use arguments to run the test. Users can then write their own scripts


### PR DESCRIPTION
## Describe your changes
Made the traditional dark e2e tests remove any files from the output folder before and after.  This prevents the code from finding any previous *_DRK_CAL.fits file in the output folder.

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [ ] I have linted my code
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed