### PR TITLE
Small e2e cleanup

### DIFF
--- a/corgidrp/calibrate_kgain.py
+++ b/corgidrp/calibrate_kgain.py
@@ -274,7 +274,7 @@ def sigma_clip(data, sigma=2.5, max_iters=6):
 
 def calibrate_kgain(dataset_kgain, 
                     n_cal=10, n_mean=30, min_val=800, max_val=3000, binwidth=68,
-                    make_plot=True,plot_outdir='figures', show_plot=False,
+                    make_plot=False,plot_outdir='figures', show_plot=False,
                     logspace_start=-1, logspace_stop=4, logspace_num=200,
                     verbose=False, detector_regions=None, kgain_params=None):
     """

--- a/corgidrp/calibrate_nonlin.py
+++ b/corgidrp/calibrate_nonlin.py
@@ -125,7 +125,7 @@ def calibrate_nonlin(dataset_nl,
                      lowess_frac = 0.1, rms_low_limit = 0.004, rms_upp_limit = 0.2,
                      pfit_upp_cutoff1 = -2, pfit_upp_cutoff2 = -3,
                      pfit_low_cutoff1 = 2, pfit_low_cutoff2 = 1,
-                     make_plot=True, plot_outdir='figures', show_plot=False,
+                     make_plot=False, plot_outdir='figures', show_plot=False,
                      verbose=False, nonlin_params=None):
     """
     Function that derives the non-linearity calibration table for a set of DN

--- a/tests/e2e_tests/photon_count_e2e.py
+++ b/tests/e2e_tests/photon_count_e2e.py
@@ -108,6 +108,7 @@ def test_expected_results_e2e(e2edata_path, e2eoutput_path):
     new_nonlinearity.filename = nonlin_fits_filepath
     new_nonlinearity.pri_hdr = pri_hdr
     new_nonlinearity.ext_hdr = ext_hdr
+    new_nonlinearity.save(filedir=output_dir, filename=test_non_linearity_filename)
     this_caldb.create_entry(new_nonlinearity)
 
     ## Flat field


### PR DESCRIPTION
## Describe your changes
This small PR turns off some default plotting routines and adds a .save to an e2e test (that should have been there) so that they can be run without the UTs having been run before. 

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [x] I have linted my code
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed