### PR TITLE
Print statements in unit tests for AAC V&V

### DIFF
--- a/corgidrp/nd_filter_calibration.py
+++ b/corgidrp/nd_filter_calibration.py
@@ -14,13 +14,14 @@ import warnings
 # Helper Functions
 # =============================================================================
 
+
 def load_transformation_matrix_from_fits(file_path):
     """
     Load a transformation matrix from a FITS file.
-    
+
     Parameters:
         file_path (str): Path to the FITS file containing the transformation matrix.
-    
+
     Returns:
         np.ndarray: The transformation matrix extracted from the FITS file.
     """
@@ -29,6 +30,7 @@ def load_transformation_matrix_from_fits(file_path):
         if data is None:
             data = hdul[1].data
         return np.array(data)
+
 
 def group_by_keyword(dataset, prihdr_keyword=None, exthdr_keyword=None):
     """
@@ -43,7 +45,7 @@ def group_by_keyword(dataset, prihdr_keyword=None, exthdr_keyword=None):
     Returns:
         dict: A dictionary where keys are unique target values and values are the 
             corresponding dataset subsets.
-    
+
     Raises:
         ValueError: If neither keyword is provided.
     """
@@ -169,7 +171,7 @@ def _compute_od_for_file(entry, target, phot_method, phot_kwargs, ref_fpam_name,
       2. Compute centroid (x, y).
       3. Perform photometry (Aperture or Gaussian).
       4. Compute OD from measured flux and the expected flux.
-    
+
     Parameters:
         entry (corgidrp.Data.Image): The dataset entry containing image data and metadata.
         target (str): The target identifier for the dataset entry.
@@ -228,10 +230,10 @@ def process_bright_target(target, files, cal_factor, od_raster_threshold,
     Process bright star files for one target to compute optical density (OD)
     and (x, y) centroids for each dithered observation.
     Checks that FPAM keywords are consistent across all files.
-    
+
     Additional photometry options are passed via phot_kwargs.
     This allows users to override default settings for functions like aper_phot.
-    
+
     Parameters:
         target (str): The target star name.
         files (corgidrp.data.Dataset): Dataset of bright star images
@@ -239,7 +241,7 @@ def process_bright_target(target, files, cal_factor, od_raster_threshold,
         od_raster_threshold (float): Threshold for flagging OD variations.
         phot_method (str): Photometry method to use ("Aperture" or "Gaussian").
         phot_kwargs (dict, optional): Dictionary of keyword arguments to forward to the photometry function.
-    
+
     Returns:
         dict: A dictionary containing computed OD values, centroids, and other metadata.
     """
@@ -269,7 +271,7 @@ def process_bright_target(target, files, cal_factor, od_raster_threshold,
                                                       phot_kwargs, common_fpam_name, 
                                                       common_fpam_h, common_fpam_v, 
                                                       ref_cfam_name, expected_flux)
-        
+
         # Skip if centroid was not valid
         if od is None:
             continue
@@ -311,7 +313,7 @@ def create_nd_sweet_spot_dataset(aggregated_sweet_spot_data, common_metadata, od
                                  input_dataset):
     """
     Create an NDFilterSweetSpotDataset FITS file with the Nx3 sweet-spot array.
-    
+
     Parameters:
         aggregated_sweet_spot_data (numpy.ndarray): The aggregated Nx3 array containing 
             sweet-spot data in the format [OD, x, y].
@@ -357,7 +359,7 @@ def calculate_od_at_new_location(clean_frame_entry, transformation_matrix_file,
     """
     Use the NDFilterSweetSpot Dataset to calculate the OD at a new location for an input 
     image, using a provided EXCAM to FPAM transformation_matrix.
-    
+
     Parameters:
         clean_frame_entry (corgidrp.Data.Image): A clean frame image.
         transformation_matrix_file (string): File path to the 2x2 matrix for transforming 
@@ -402,7 +404,7 @@ def calculate_od_at_new_location(clean_frame_entry, transformation_matrix_file,
 # =============================================================================
 
 def create_nd_filter_cal(stars_dataset,
-                         od_raster_threshold = 0.1,
+                         od_raster_threshold=0.1,
                          phot_method="Aperture",
                          flux_or_irr="irr",
                          phot_kwargs=None,
@@ -413,16 +415,16 @@ def create_nd_filter_cal(stars_dataset,
       2. Compute avg calibration factor from dim stars.
       2. Group bright star frames by target + measure OD, centroids.
       3. Combine all sweet-spot data into a single Nx3 array.
-    
+
     Parameters:
         stars_dataset (Dataset): Dataset containing star images. The splitting into bright and dim stars
             is performed based on the 'FPAMNAME' value in the FITS header. For example, entries with 'FPAMNAME'
             containing "dim" (case-insensitive) are considered dim stars.
         od_raster_threshold (float): Threshold for flagging OD variations.
-            # TO DO: figure out what a reasonable value for this should be 
+            # TO DO: figure out what a reasonable value for this should be
         phot_method (str): Photometry method ("Aperture" or "Gaussian").
         flux_or_irr (str): Either 'flux' or 'irr' for the calibration approach.
-        phot_kwargs (dict, optional): Extra arguments for the actual photometry function 
+        phot_kwargs (dict, optional): Extra arguments for the actual photometry function
             (e.g., aper_phot).
         fluxcal_factor (corgidrp.Data.FluxcalFactor, optional): A pre-computed flux factor calibration product to use
             if dim stars are not included as part of the input dataset
@@ -440,7 +442,7 @@ def create_nd_filter_cal(stars_dataset,
         grouped_nd_files = group_by_keyword(stars_dataset, prihdr_keyword=None, exthdr_keyword='FPAMNAME')
     except:
         grouped_nd_files = group_by_keyword(stars_dataset, prihdr_keyword=None, exthdr_keyword='FSAMNAME')
-        
+
     dim_stars_dataset = []
     bright_stars_dataset = []
 
@@ -517,11 +519,11 @@ def create_nd_filter_cal(stars_dataset,
     print(f"Average OD across bright targets: {overall_avg_od}")
 
     # 5. Create the final NDFilterSweetSpotDataset
-    
+
     sweet_spot_dataset = create_nd_sweet_spot_dataset(
         aggregated_sweet_spot_data=combined_sweet_spot_data,
         common_metadata=common_metadata, od_var_flag = od_var_flag, input_dataset = stars_dataset
     )
 
-    #TO DO: do we want to return flux?
+    # TO DO: do we want to return flux?
     return sweet_spot_dataset

--- a/corgidrp/nd_filter_calibration.py
+++ b/corgidrp/nd_filter_calibration.py
@@ -14,14 +14,13 @@ import warnings
 # Helper Functions
 # =============================================================================
 
-
 def load_transformation_matrix_from_fits(file_path):
     """
     Load a transformation matrix from a FITS file.
-
+    
     Parameters:
         file_path (str): Path to the FITS file containing the transformation matrix.
-
+    
     Returns:
         np.ndarray: The transformation matrix extracted from the FITS file.
     """
@@ -30,7 +29,6 @@ def load_transformation_matrix_from_fits(file_path):
         if data is None:
             data = hdul[1].data
         return np.array(data)
-
 
 def group_by_keyword(dataset, prihdr_keyword=None, exthdr_keyword=None):
     """
@@ -45,7 +43,7 @@ def group_by_keyword(dataset, prihdr_keyword=None, exthdr_keyword=None):
     Returns:
         dict: A dictionary where keys are unique target values and values are the 
             corresponding dataset subsets.
-
+    
     Raises:
         ValueError: If neither keyword is provided.
     """
@@ -171,7 +169,7 @@ def _compute_od_for_file(entry, target, phot_method, phot_kwargs, ref_fpam_name,
       2. Compute centroid (x, y).
       3. Perform photometry (Aperture or Gaussian).
       4. Compute OD from measured flux and the expected flux.
-
+    
     Parameters:
         entry (corgidrp.Data.Image): The dataset entry containing image data and metadata.
         target (str): The target identifier for the dataset entry.
@@ -230,10 +228,10 @@ def process_bright_target(target, files, cal_factor, od_raster_threshold,
     Process bright star files for one target to compute optical density (OD)
     and (x, y) centroids for each dithered observation.
     Checks that FPAM keywords are consistent across all files.
-
+    
     Additional photometry options are passed via phot_kwargs.
     This allows users to override default settings for functions like aper_phot.
-
+    
     Parameters:
         target (str): The target star name.
         files (corgidrp.data.Dataset): Dataset of bright star images
@@ -241,7 +239,7 @@ def process_bright_target(target, files, cal_factor, od_raster_threshold,
         od_raster_threshold (float): Threshold for flagging OD variations.
         phot_method (str): Photometry method to use ("Aperture" or "Gaussian").
         phot_kwargs (dict, optional): Dictionary of keyword arguments to forward to the photometry function.
-
+    
     Returns:
         dict: A dictionary containing computed OD values, centroids, and other metadata.
     """
@@ -271,7 +269,7 @@ def process_bright_target(target, files, cal_factor, od_raster_threshold,
                                                       phot_kwargs, common_fpam_name, 
                                                       common_fpam_h, common_fpam_v, 
                                                       ref_cfam_name, expected_flux)
-
+        
         # Skip if centroid was not valid
         if od is None:
             continue
@@ -313,7 +311,7 @@ def create_nd_sweet_spot_dataset(aggregated_sweet_spot_data, common_metadata, od
                                  input_dataset):
     """
     Create an NDFilterSweetSpotDataset FITS file with the Nx3 sweet-spot array.
-
+    
     Parameters:
         aggregated_sweet_spot_data (numpy.ndarray): The aggregated Nx3 array containing 
             sweet-spot data in the format [OD, x, y].
@@ -359,7 +357,7 @@ def calculate_od_at_new_location(clean_frame_entry, transformation_matrix_file,
     """
     Use the NDFilterSweetSpot Dataset to calculate the OD at a new location for an input 
     image, using a provided EXCAM to FPAM transformation_matrix.
-
+    
     Parameters:
         clean_frame_entry (corgidrp.Data.Image): A clean frame image.
         transformation_matrix_file (string): File path to the 2x2 matrix for transforming 
@@ -404,7 +402,7 @@ def calculate_od_at_new_location(clean_frame_entry, transformation_matrix_file,
 # =============================================================================
 
 def create_nd_filter_cal(stars_dataset,
-                         od_raster_threshold=0.1,
+                         od_raster_threshold = 0.1,
                          phot_method="Aperture",
                          flux_or_irr="irr",
                          phot_kwargs=None,
@@ -415,16 +413,16 @@ def create_nd_filter_cal(stars_dataset,
       2. Compute avg calibration factor from dim stars.
       2. Group bright star frames by target + measure OD, centroids.
       3. Combine all sweet-spot data into a single Nx3 array.
-
+    
     Parameters:
         stars_dataset (Dataset): Dataset containing star images. The splitting into bright and dim stars
             is performed based on the 'FPAMNAME' value in the FITS header. For example, entries with 'FPAMNAME'
             containing "dim" (case-insensitive) are considered dim stars.
         od_raster_threshold (float): Threshold for flagging OD variations.
-            # TO DO: figure out what a reasonable value for this should be
+            # TO DO: figure out what a reasonable value for this should be 
         phot_method (str): Photometry method ("Aperture" or "Gaussian").
         flux_or_irr (str): Either 'flux' or 'irr' for the calibration approach.
-        phot_kwargs (dict, optional): Extra arguments for the actual photometry function
+        phot_kwargs (dict, optional): Extra arguments for the actual photometry function 
             (e.g., aper_phot).
         fluxcal_factor (corgidrp.Data.FluxcalFactor, optional): A pre-computed flux factor calibration product to use
             if dim stars are not included as part of the input dataset
@@ -442,7 +440,7 @@ def create_nd_filter_cal(stars_dataset,
         grouped_nd_files = group_by_keyword(stars_dataset, prihdr_keyword=None, exthdr_keyword='FPAMNAME')
     except:
         grouped_nd_files = group_by_keyword(stars_dataset, prihdr_keyword=None, exthdr_keyword='FSAMNAME')
-
+        
     dim_stars_dataset = []
     bright_stars_dataset = []
 
@@ -519,11 +517,11 @@ def create_nd_filter_cal(stars_dataset,
     print(f"Average OD across bright targets: {overall_avg_od}")
 
     # 5. Create the final NDFilterSweetSpotDataset
-
+    
     sweet_spot_dataset = create_nd_sweet_spot_dataset(
         aggregated_sweet_spot_data=combined_sweet_spot_data,
         common_metadata=common_metadata, od_var_flag = od_var_flag, input_dataset = stars_dataset
     )
 
-    # TO DO: do we want to return flux?
+    #TO DO: do we want to return flux?
     return sweet_spot_dataset

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ statsmodels
 pyklip
 emccd-detect
 tqdm
+termcolor

--- a/tests/test_astrom.py
+++ b/tests/test_astrom.py
@@ -19,9 +19,9 @@ def print_pass():
 
 
 def test_astrom():
-    """
+    """ 
     Generate a simulated image and test the astrometric calibration computation.
-
+    
     """
     # create a simulated image with source guesses and true positions
     # check that the simulated image folder exists and create if not
@@ -30,7 +30,7 @@ def test_astrom():
         os.mkdir(datadir)
 
     field_path = os.path.join(os.path.dirname(__file__), "test_data", "JWST_CALFIELD2020.csv")
-
+    
     # create a dataset with dithers
     # dataset = mocks.create_astrom_data(field_path=field_path, filedir=datadir, rotation=20, dither_pointings=4)
     dataset = mocks.create_astrom_data(field_path=field_path, rotation=20, dither_pointings=4)
@@ -44,8 +44,7 @@ def test_astrom():
     assert isinstance(dataset[0], data.Image)
 
     # perform the astrometric calibration
-    astrom_cal = astrom.boresight_calibration(
-        input_dataset=dataset, field_path=field_path, find_threshold=200)
+    astrom_cal = astrom.boresight_calibration(input_dataset=dataset, field_path=field_path, find_threshold=200)
 
     # the data was generated to have the following image properties
     expected_platescale = 21.8
@@ -88,12 +87,10 @@ def test_astrom():
     pickled_astrom = pickle.loads(pickled)
     assert np.all((astrom_cal.data == pickled_astrom.data)) # check it is the same as the original
 
-
 def test_distortion():
-    """
-    Generate a simulated image and test the distortion map creation as part of
-    the boresight calibration.
-
+    """ 
+    Generate a simulated image and test the distortion map creation as part of the boresight calibration.
+    
     """
     # create a simulated image with source guesses and true positions
     # check that the simulated image folder exists and create if not
@@ -105,7 +102,7 @@ def test_distortion():
     distortion_coeffs_path = os.path.join(os.path.dirname(__file__), "test_data", "distortion_expected_coeffs.csv")
     expected_coeffs = np.genfromtxt(distortion_coeffs_path)
 
-    # create dithered dataset
+    # create dithered dataset 
     # mocks.create_astrom_data(field_path=field_path, filedir=datadir, rotation=20, distortion_coeffs_path=distortion_coeffs_path, dither_pointings=4)
     dataset = mocks.create_astrom_data(field_path=field_path, rotation=20, distortion_coeffs_path=distortion_coeffs_path, dither_pointings=4)
 
@@ -119,35 +116,35 @@ def test_distortion():
     # perform the astrometric calibration
     astrom_cal = astrom.boresight_calibration(input_dataset=dataset, field_path=field_path, find_threshold=400, find_distortion=True, fitorder=3, position_error=0.5)
 
-    # check that the distortion map does not create offsets greater than 4[mas]
-    # compute the distortion maps created from the best fit coeffs
+    ## check that the distortion map does not create offsets greater than 4[mas]
+        # compute the distortion maps created from the best fit coeffs
     coeffs = astrom_cal.distortion_coeffs[:-1]
 
-    # note the image shape and center around the image center
+        # note the image shape and center around the image center
     image_shape = np.shape(dataset[0].data)
     yorig, xorig = np.indices(image_shape)
     y0, x0 = image_shape[0]//2, image_shape[1]//2
     yorig -= y0
     xorig -= x0
 
-    # get the number of fitting params from the order
+        # get the number of fitting params from the order
     fitorder = int(astrom_cal.distortion_coeffs[-1])
     fitparams = (fitorder + 1)**2
     true_fitorder = int(expected_coeffs[-1])
     true_fitparams = (true_fitorder + 1)**2
 
-    # reshape the coeff arrays for the best fit and true coeff params
+        # reshape the coeff arrays for the best fit and true coeff params
     best_params_x = coeffs[:fitparams]
     best_params_x = best_params_x.reshape(fitorder+1, fitorder+1)
-    total_orders = np.arange(fitorder+1)[:, None] + np.arange(fitorder+1)[None, :]
+    total_orders = np.arange(fitorder+1)[:,None] + np.arange(fitorder+1)[None, :]
     best_params_x = best_params_x / 500**(total_orders)
 
     true_params_x = expected_coeffs[:-1][:true_fitparams]
     true_params_x = true_params_x.reshape(true_fitorder+1, true_fitorder+1)
-    true_total_orders = np.arange(true_fitorder+1)[:, None] + np.arange(true_fitorder+1)[None, :]
+    true_total_orders = np.arange(true_fitorder+1)[:,None] + np.arange(true_fitorder+1)[None, :]
     true_params_x = true_params_x / 500**(true_total_orders)
 
-    # evaluate the polynomial at all pixel positions
+        # evaluate the polynomial at all pixel positions
     x_corr = np.polynomial.legendre.legval2d(xorig.ravel(), yorig.ravel(), best_params_x)
     x_corr = x_corr.reshape(xorig.shape)
     x_diff = x_corr - xorig
@@ -156,7 +153,7 @@ def test_distortion():
     true_x_corr = true_x_corr.reshape(xorig.shape)
     true_x_diff = true_x_corr - xorig
 
-    # reshape and evaluate the same for y
+        # reshape and evaluate the same for y
     best_params_y = coeffs[fitparams:]
     best_params_y = best_params_y.reshape(fitorder+1, fitorder+1)
     best_params_y = best_params_y / 500**(total_orders)
@@ -165,7 +162,7 @@ def test_distortion():
     true_params_y = true_params_y.reshape(true_fitorder+1, true_fitorder+1)
     true_params_y = true_params_y / 500**(true_total_orders)
 
-    # evaluate the polynomial at all pixel positions
+        # evaluate the polynomial at all pixel positions
     y_corr = np.polynomial.legendre.legval2d(xorig.ravel(), yorig.ravel(), best_params_y)
     y_corr = y_corr.reshape(yorig.shape)
     y_diff = y_corr - yorig
@@ -181,11 +178,11 @@ def test_distortion():
     atol_dist_pix = atol_dist_mas/mas_per_pix
     lower_lim, upper_lim = int((1024//2) - ((1000/21.8)//2)), int((1024//2) + ((1000/21.8)//2))
 
-    central_1arcsec_x = x_diff[lower_lim: upper_lim+1, lower_lim: upper_lim+1]
-    central_1arcsec_y = y_diff[lower_lim: upper_lim+1, lower_lim: upper_lim+1]
-
-    true_1arcsec_x = true_x_diff[lower_lim: upper_lim+1, lower_lim: upper_lim+1]
-    true_1arcsec_y = true_y_diff[lower_lim: upper_lim+1, lower_lim: upper_lim+1]
+    central_1arcsec_x = x_diff[lower_lim: upper_lim+1,lower_lim: upper_lim+1]
+    central_1arcsec_y = y_diff[lower_lim: upper_lim+1,lower_lim: upper_lim+1]
+    
+    true_1arcsec_x = true_x_diff[lower_lim: upper_lim+1,lower_lim: upper_lim+1]
+    true_1arcsec_y = true_y_diff[lower_lim: upper_lim+1,lower_lim: upper_lim+1]
 
     test_result_distortion_x = np.all(np.abs(central_1arcsec_x - true_1arcsec_x) < atol_dist_pix)
     print(f'\nDistortion map in x is accurate within {atol_dist_mas} mas in central square arcsecond: ', end='')
@@ -209,13 +206,13 @@ def test_distortion():
     # check they can be pickled (for CTC operations)
     pickled = pickle.dumps(astrom_cal_2)
     pickled_astrom = pickle.loads(pickled)
-    assert np.all((astrom_cal.data == pickled_astrom.data))  # check it is the same as the original
+    assert np.all((astrom_cal.data == pickled_astrom.data)) # check it is the same as the original
 
 
 def test_seppa2dxdy():
     """Test that conversion from separation/position angle to delta x/y 
     produces the expected result for varying input separations and angles."""
-
+    
     seps = np.array([10.0,15.0,20,10,10,10,10])
     pas = np.array([0.,90.,-90,45,-45,135,-135])
 
@@ -269,28 +266,27 @@ def test_get_polar_dist():
     in varying directions."""
 
     # Test vertical line
-    seppa1 = (10, 0)
-    seppa2 = (10, 180)
+    seppa1 = (10,0)
+    seppa2 = (10,180)
     dist = 20.
 
-    assert astrom.get_polar_dist(seppa1, seppa2) == dist
+    assert astrom.get_polar_dist(seppa1,seppa2) == dist
 
     # Test horizontal line
-    seppa1 = (10, 90)
-    seppa2 = (10, 270)
+    seppa1 = (10,90)
+    seppa2 = (10,270)
     dist = 20.
 
-    assert astrom.get_polar_dist(seppa1, seppa2) == dist
+    assert astrom.get_polar_dist(seppa1,seppa2) == dist
 
     # Test 45 degree line
-    seppa1 = (10, 0)
-    seppa2 = (10, 90)
+    seppa1 = (10,0)
+    seppa2 = (10,90)
     dist = 10. * np.sqrt(2.)
 
-    assert astrom.get_polar_dist(seppa1, seppa2) == dist
+    assert astrom.get_polar_dist(seppa1,seppa2) == dist
 
     pass
-
 
 if __name__ == "__main__":
     test_astrom()

--- a/tests/test_astrom.py
+++ b/tests/test_astrom.py
@@ -7,11 +7,21 @@ import corgidrp.mocks as mocks
 import corgidrp.astrom as astrom
 import corgidrp.data as data
 import astropy.io.ascii as ascii
+from termcolor import cprint
+
+
+def print_fail():
+    cprint(' FAIL ', "black", "on_red")
+
+
+def print_pass():
+    cprint(' PASS ', "black", "on_green")
+
 
 def test_astrom():
-    """ 
+    """
     Generate a simulated image and test the astrometric calibration computation.
-    
+
     """
     # create a simulated image with source guesses and true positions
     # check that the simulated image folder exists and create if not
@@ -20,7 +30,7 @@ def test_astrom():
         os.mkdir(datadir)
 
     field_path = os.path.join(os.path.dirname(__file__), "test_data", "JWST_CALFIELD2020.csv")
-    
+
     # create a dataset with dithers
     # dataset = mocks.create_astrom_data(field_path=field_path, filedir=datadir, rotation=20, dither_pointings=4)
     dataset = mocks.create_astrom_data(field_path=field_path, rotation=20, dither_pointings=4)
@@ -68,10 +78,11 @@ def test_astrom():
     pickled_astrom = pickle.loads(pickled)
     assert np.all((astrom_cal.data == pickled_astrom.data)) # check it is the same as the original
 
+
 def test_distortion():
-    """ 
+    """
     Generate a simulated image and test the distortion map creation as part of the boresight calibration.
-    
+
     """
     # create a simulated image with source guesses and true positions
     # check that the simulated image folder exists and create if not

--- a/tests/test_astrom.py
+++ b/tests/test_astrom.py
@@ -161,7 +161,7 @@ def test_distortion():
     true_params_y = expected_coeffs[:-1][true_fitparams:]
     true_params_y = true_params_y.reshape(true_fitorder+1, true_fitorder+1)
     true_params_y = true_params_y / 500**(true_total_orders)
-
+    
         # evaluate the polynomial at all pixel positions
     y_corr = np.polynomial.legendre.legval2d(xorig.ravel(), yorig.ravel(), best_params_y)
     y_corr = y_corr.reshape(yorig.shape)
@@ -212,7 +212,7 @@ def test_distortion():
 def test_seppa2dxdy():
     """Test that conversion from separation/position angle to delta x/y 
     produces the expected result for varying input separations and angles."""
-    
+
     seps = np.array([10.0,15.0,20,10,10,10,10])
     pas = np.array([0.,90.,-90,45,-45,135,-135])
 
@@ -264,7 +264,7 @@ def test_create_circular_mask():
 def test_get_polar_dist():
     """Test that astrom.get_polar_dist() calculates distances correctly 
     in varying directions."""
-
+    
     # Test vertical line
     seppa1 = (10,0)
     seppa2 = (10,180)

--- a/tests/test_corethroughput.py
+++ b/tests/test_corethroughput.py
@@ -304,7 +304,6 @@ def test_psf_pix_and_ct():
 
     print('Tests about PSF locations and CT values passed')
 
-
 def test_fpm_pos():
     """
     Test 1090882 - Given 1) the location of the center of the FPM coronagraphic
@@ -314,48 +313,45 @@ def test_fpm_pos():
     FPM coronagraphic mask during the core throughput observing sequence.
 
     Python algorithm written during TVAC for using FPAM and FSAM matrices
-
+    
           delta_pam = np.array([[dh], [dv]]) # fill these in
           # read FPAM or FSAM matrices: 
           M = np.array([[ M00, M01], [M10, M11]], dtype=float32)
           delta_pix = M @ delta_pam
     """
     # FPAM/FSAM transformations
-    fpam_fsam_cal = FpamFsamCal(os.path.join(
-        corgidrp.default_cal_dir,
+    fpam_fsam_cal = FpamFsamCal(os.path.join(corgidrp.default_cal_dir,
         'FpamFsamCal_2024-02-10T00:00:00.000.fits'))
-
+    
     fpam2excam_matrix, fsam2excam_matrix = fpam_fsam_cal.data
     # TVAC files
-    fpam2excam_matrix_tvac = fits.getdata(os.path.join(
-        here, 'test_data', 'fpam_to_excam_modelbased.fits'))
-    fsam2excam_matrix_tvac = fits.getdata(os.path.join(
-        here, 'test_data', 'fsam_to_excam_modelbased.fits'))
+    fpam2excam_matrix_tvac = fits.getdata(os.path.join(here, 'test_data',
+        'fpam_to_excam_modelbased.fits'))
+    fsam2excam_matrix_tvac = fits.getdata(os.path.join(here, 'test_data',
+        'fsam_to_excam_modelbased.fits'))
+
 
     # test 1:
     # Check that DRP calibration files for FPAM and FSAM agree with TVAC files
     # Some irrelevant rounding happens when defining FpamFsamCal() in data.py
     assert np.all(fpam2excam_matrix - fpam2excam_matrix_tvac <= 1e-9)
     assert np.all(fsam2excam_matrix - fsam2excam_matrix_tvac <= 1e-9)
-
+   
     # test 2:
     # Using values within the range should return a meaningful value. Tested 10 times
-    FPM_center_pos_pix = np.array(
-        [dataset_cor[0].ext_hdr['STARLOCX'],
-         dataset_cor[0].ext_hdr['STARLOCY']])
-    FPAM_center_pos_um = np.array(
-        [dataset_cor[0].ext_hdr['FPAM_H'],
-         dataset_cor[0].ext_hdr['FPAM_V']])
-    FSAM_center_pos_um = np.array(
-        [dataset_cor[0].ext_hdr['FSAM_H'],
-         dataset_cor[0].ext_hdr['FSAM_V']])
+    FPM_center_pos_pix = np.array([dataset_cor[0].ext_hdr['STARLOCX'],
+            dataset_cor[0].ext_hdr['STARLOCY']])
+    FPAM_center_pos_um = np.array([dataset_cor[0].ext_hdr['FPAM_H'],
+            dataset_cor[0].ext_hdr['FPAM_V']])
+    FSAM_center_pos_um =  np.array([dataset_cor[0].ext_hdr['FSAM_H'],
+            dataset_cor[0].ext_hdr['FSAM_V']])
     rng = np.random.default_rng(0)
     fpm_pos_result_list = []  # initialize
     n_trials = 10
     for ii in range(n_trials):
         # Random shift for Delta H/V in um
-        delta_fpam_um = np.array([rng.uniform(1, 10), rng.uniform(1, 10)])
-        delta_fsam_um = np.array([rng.uniform(1, 10), rng.uniform(1, 10)])
+        delta_fpam_um = np.array([rng.uniform(1,10), rng.uniform(1,10)])
+        delta_fsam_um = np.array([rng.uniform(1,10), rng.uniform(1,10)])
         # Update dataset_ct headers
         dataset_ct[0].ext_hdr['FPAM_H'] = dataset_cor[0].ext_hdr['FPAM_H'] + delta_fpam_um[0]
         dataset_ct[0].ext_hdr['FPAM_V'] = dataset_cor[0].ext_hdr['FPAM_V'] + delta_fpam_um[1]
@@ -391,7 +387,6 @@ def test_fpm_pos():
 
     print('Tests about FPAM/FSAM to EXCAM passed')
 
-
 def test_cal_file():
     """ Test creation of core throughput calibration file. """
 
@@ -412,7 +407,7 @@ def test_cal_file():
     assert np.all(ct_cal_file_load.ct_excam == ct_cal_file_in.ct_excam)
     assert np.all(ct_cal_file_load.ct_fpam == ct_cal_file_in.ct_fpam)
     assert np.all(ct_cal_file_load.ct_fsam == ct_cal_file_in.ct_fsam)
-
+    
     # This test checks that the CT cal file has the right information by making
     # sure that I=O (Note: the comparison b/w analytical predictions
     # vs. centroid/pixelized data is part of the tests on test_psf_pix_and_ct before)
@@ -437,8 +432,8 @@ def test_cal_file():
     psf_cube_in = []
     for frame in dataset_ct:
         try:
-            # Pupil images of the unocculted source satisfy:
-            # DPAM=PUPIL, LSAM=OPEN, FSAM=OPEN and FPAM=OPEN_12
+        # Pupil images of the unocculted source satisfy:
+        # DPAM=PUPIL, LSAM=OPEN, FSAM=OPEN and FPAM=OPEN_12
             exthd = frame.ext_hdr
             if (exthd['DPAMNAME']=='PUPIL' and exthd['LSAMNAME']=='OPEN' and
                 exthd['FSAMNAME']=='OPEN' and exthd['FPAMNAME']=='OPEN_12'):
@@ -454,9 +449,8 @@ def test_cal_file():
     cal_file_side_1 = ct_cal_file.data.shape[2]
     for i_psf, psf in enumerate(psf_cube_in):
         loc_00 = np.argwhere(psf == ct_cal_file.data[i_psf][0][0])[0]
-        assert np.all(
-            psf[loc_00[0]:loc_00[0]+cal_file_side_0,
-                loc_00[1]:loc_00[1]+cal_file_side_1] == ct_cal_file.data[i_psf])
+        assert np.all(psf[loc_00[0]:loc_00[0]+cal_file_side_0,
+            loc_00[1]:loc_00[1]+cal_file_side_1] == ct_cal_file.data[i_psf])
 
     # Verify that the PSF images are best centered at each set of coordinates.
     test_result_psf_max_row = []  # intialize
@@ -479,9 +473,9 @@ def test_cal_file():
     if ct_cal_file.ct_excam_hdr['EXTNAME'] != 'CTEXCAM':
         raise ValueError('The extension name of the CT values on EXCAM is not correct')
     # x location wrt FPM
-    assert np.all(psf_loc_input[:, 0] == ct_cal_file.ct_excam[0])
+    assert np.all(psf_loc_input[:,0] == ct_cal_file.ct_excam[0])
     # y location wrt FPM
-    assert np.all(psf_loc_input[:, 1] == ct_cal_file.ct_excam[1])
+    assert np.all(psf_loc_input[:,1] == ct_cal_file.ct_excam[1])
     # CT map
     assert np.all(ct_input == ct_cal_file.ct_excam[2])
 
@@ -490,19 +484,17 @@ def test_cal_file():
     if ct_cal_file.ct_fpam_hdr['EXTNAME'] != 'CTFPAM':
         raise ValueError('The extension name of the FPAM values on EXCAM is not correct')
     assert np.all(ct_cal_file.ct_fpam == np.array([dataset_ct[0].ext_hdr['FPAM_H'],
-                                                   dataset_ct[0].ext_hdr['FPAM_V']]))
+        dataset_ct[0].ext_hdr['FPAM_V']]))
     if ct_cal_file.ct_fsam_hdr['EXTNAME'] != 'CTFSAM':
         raise ValueError('The extension name of the FSAM values on EXCAM is not correct')
-    assert np.all(
-        ct_cal_file.ct_fsam == np.array([dataset_ct[0].ext_hdr['FSAM_H'],
-                                         dataset_ct[0].ext_hdr['FSAM_V']]))
+    assert np.all(ct_cal_file.ct_fsam == np.array([dataset_ct[0].ext_hdr['FSAM_H'],
+        dataset_ct[0].ext_hdr['FSAM_V']]))
 
     # Remove test CT cal file
     if os.path.exists(ct_cal_file.filepath):
         os.remove(ct_cal_file.filepath)
 
     print('Tests about the CT cal file passed')
-
 
 def test_ct_interp():
     """ Tests the interpolation within the standard range by popping out data
@@ -514,14 +506,14 @@ def test_ct_interp():
     ct_cal_in = corethroughput.generate_ct_cal(dataset_ct_interp)
     # Get CT FPM center
     # FPAM/FSAM
-    fpam_fsam_cal = FpamFsamCal(os.path.join(
-        corgidrp.default_cal_dir, 'FpamFsamCal_2024-02-10T00:00:00.000.fits'))
+    fpam_fsam_cal = FpamFsamCal(os.path.join(corgidrp.default_cal_dir,
+        'FpamFsamCal_2024-02-10T00:00:00.000.fits'))
     fpam_ct_pix = ct_cal_in.GetCTFPMPosition(dataset_cor, fpam_fsam_cal)[0]
     # Reference grid to test the interpolation: wrt CT FPM because the positions
     # used to interpolate the CT are, by definition, wrt the FPM
-    x_grid = ct_cal_in.ct_excam[0, :] - fpam_ct_pix[0]
-    y_grid = ct_cal_in.ct_excam[1, :] - fpam_ct_pix[1]
-    core_throughput = ct_cal_in.ct_excam[2, :]
+    x_grid = ct_cal_in.ct_excam[0,:] - fpam_ct_pix[0]
+    y_grid = ct_cal_in.ct_excam[1,:] - fpam_ct_pix[1]
+    core_throughput = ct_cal_in.ct_excam[2,:]
 
     # In this test, we will estimate the CT at a location that agrees with one
     # of the locations used to build the CT interpolation set by removing
@@ -531,7 +523,7 @@ def test_ct_interp():
     # off-axis PSF is removed
     pupil_image = np.zeros([1024, 1024])
     # Set it to some known value for a selected range of pixels
-    pupil_image[510:530, 510:530] = 1
+    pupil_image[510:530, 510:530]=1
     prhd, exthd_pupil = create_default_L3_headers()
     # DRP
     exthd_pupil['DRPCTIME'] = time.Time.now().isot
@@ -553,9 +545,9 @@ def test_ct_interp():
     exthd_pupil['FSAM_H'] = FSAM_H_CT
     exthd_pupil['FSAM_V'] = FSAM_V_CT
     # Mock error
-    err = np.ones([1024, 1024])
+    err = np.ones([1024,1024])
     # Generate random indices between 0 and the number of radii and azimuths,
-    # excluding the edge cases
+    # excluding the edge cases 
     n_random = 50
     rtol_ct = 0.05
     ct_result_list = []  # initialize
@@ -564,10 +556,10 @@ def test_ct_interp():
     for idx in range(n_random):
         random_index_radius = rng.choice(np.arange(1, n_radii-1), 1)
         random_index_az = rng.choice(np.arange(1, n_azimuths-1), 1)
-
-        # Convert these to flattned indices
+     
+        #Convert these to flattned indices
         random_indices_flat = random_index_radius + random_index_az*n_radii
-
+        
         # Record the missing value
         missing_x = x_grid[random_indices_flat]
         missing_y = y_grid[random_indices_flat]
@@ -575,10 +567,7 @@ def test_ct_interp():
         # Generate CT dataset w/o the latter (needed to call the interpolant
         # without this location)
         # Dataset for CT map interpolation: pupil images plus off-axis PSFs
-        data_ct = [Image(pupil_image,
-                         pri_hdr=prhd,
-                         ext_hdr=exthd_pupil,
-                         err=err)]
+        data_ct = [Image(pupil_image,pri_hdr = prhd, ext_hdr = exthd_pupil, err = err)]
         data_ct += create_ct_interp(
             n_radii=n_radii,
             n_azimuths=n_azimuths,
@@ -601,7 +590,7 @@ def test_ct_interp():
         print('') if test_result_ct else print_fail()
         assert test_result_ct, 'Error more than 5% (linear radii mapping)'
         # Test with radii mapped into their logarithmic values before
-        # constructing the interpolant
+        # constructing the interpolant 
         interpolated_value_log = ct_cal_tmp.InterpolateCT(
             missing_x, missing_y, dataset_cor, fpam_fsam_cal, logr=True)[0]
         # Good to within 2%
@@ -618,9 +607,9 @@ def test_ct_interp():
     with pytest.raises(ValueError):
         # Too Big
         ct_cal_tmp.InterpolateCT(radii.max()+1, 0, dataset_cor, fpam_fsam_cal) 
-
+             
     with pytest.raises(ValueError):
-        # Too small
+        #Too small
         ct_cal_tmp.InterpolateCT(0.9*radii.min(), 0, dataset_cor, fpam_fsam_cal)
 
     # Test that something with an azimuth out of range returns the same result
@@ -637,12 +626,10 @@ def test_ct_interp():
     interpolated_value_in = ct_cal_tmp.InterpolateCT(
         x_new_in, y_new_in, dataset_cor, fpam_fsam_cal)[0]
 
-    assert interpolated_value_out == pytest.approx(interpolated_value_in, abs=0.01), "Error more than 1%% error"
+    assert interpolated_value_out == pytest.approx(interpolated_value_in, abs=0.01), "Error more than  error"
     # Make sure it still works with a non-zero starting azimuth: min_angle below
-    data_ct = [Image(pupil_image,
-                     pri_hdr=prhd,
-                     ext_hdr=exthd_pupil,
-                     err=err)]
+    data_ct = [Image(pupil_image,pri_hdr = prhd, ext_hdr = exthd_pupil,
+            err = err)]
     data_ct_interp = create_ct_interp(
         n_radii=n_radii,
         n_azimuths=n_azimuths,
@@ -661,7 +648,7 @@ def test_ct_interp():
     y_az_out = 0.9*np.max(radii) * np.sin(max_angle + 0.2)
     interpolated_value_az_out = ct_cal_az.InterpolateCT(
         x_az_out, y_az_out, dataset_cor, fpam_fsam_cal)[0]
-
+    
     # In range of the new shifted azimuths
     x_az_in = 0.9*np.max(radii) * np.cos(0.2)
     y_az_in = 0.9*np.max(radii) * np.sin(0.2)
@@ -671,7 +658,6 @@ def test_ct_interp():
     assert interpolated_value_az_out == pytest.approx(interpolated_value_az_in, abs=0.01), "Error more than 1% error"
 
     print('Tests about CT interpolation passed')
-
 
 def test_get_1d_ct():
     """Test that corethroughput.get_1d_ct() produces an array of the correct 

--- a/tests/test_corethroughput.py
+++ b/tests/test_corethroughput.py
@@ -6,6 +6,7 @@ from astropy.io import fits
 from scipy.signal import decimate
 from astropy.modeling import models
 from astropy.modeling.models import Gaussian2D
+from termcolor import cprint
 
 import corgidrp
 from corgidrp.mocks import (create_default_L3_headers, create_ct_psfs,
@@ -21,6 +22,15 @@ if os.path.exists(os.path.join(corgidrp.default_cal_dir, ct_cal_test_file)):
 from corgidrp import caldb
 
 here = os.path.abspath(os.path.dirname(__file__))
+
+
+def print_fail():
+    cprint(' FAIL ', "black", "on_red")
+
+
+def print_pass():
+    cprint(' PASS ', "black", "on_green")
+
 
 def setup_module():
     """

--- a/tests/test_corethroughput.py
+++ b/tests/test_corethroughput.py
@@ -281,7 +281,9 @@ def test_psf_pix_and_ct():
     # core throughput in (0,1]
     assert np.all(ct_est) > 0
     assert np.all(ct_est) <= 1
-
+    # comparison between I/O values (<=1% due to pixelization effects vs.
+    # expected analytical value)
+    assert np.all(np.abs(ct_est-ct_in) <= 0.01)
 
     # Test 2:
     # Functional test with some mock data with known PSF location and CT
@@ -489,7 +491,7 @@ def test_cal_file():
         raise ValueError('The extension name of the FSAM values on EXCAM is not correct')
     assert np.all(ct_cal_file.ct_fsam == np.array([dataset_ct[0].ext_hdr['FSAM_H'],
         dataset_ct[0].ext_hdr['FSAM_V']]))
-
+    
     # Remove test CT cal file
     if os.path.exists(ct_cal_file.filepath):
         os.remove(ct_cal_file.filepath)
@@ -514,7 +516,7 @@ def test_ct_interp():
     x_grid = ct_cal_in.ct_excam[0,:] - fpam_ct_pix[0]
     y_grid = ct_cal_in.ct_excam[1,:] - fpam_ct_pix[1]
     core_throughput = ct_cal_in.ct_excam[2,:]
-
+    
     # In this test, we will estimate the CT at a location that agrees with one
     # of the locations used to build the CT interpolation set by removing
     # the data point and estimating the CT with the remaining unchanged set
@@ -626,7 +628,7 @@ def test_ct_interp():
     interpolated_value_in = ct_cal_tmp.InterpolateCT(
         x_new_in, y_new_in, dataset_cor, fpam_fsam_cal)[0]
 
-    assert interpolated_value_out == pytest.approx(interpolated_value_in, abs=0.01), "Error more than  error"
+    assert interpolated_value_out == pytest.approx(interpolated_value_in, abs=0.01), "Error more than 1% error"
     # Make sure it still works with a non-zero starting azimuth: min_angle below
     data_ct = [Image(pupil_image,pri_hdr = prhd, ext_hdr = exthd_pupil,
             err = err)]
@@ -648,13 +650,13 @@ def test_ct_interp():
     y_az_out = 0.9*np.max(radii) * np.sin(max_angle + 0.2)
     interpolated_value_az_out = ct_cal_az.InterpolateCT(
         x_az_out, y_az_out, dataset_cor, fpam_fsam_cal)[0]
-    
+
     # In range of the new shifted azimuths
     x_az_in = 0.9*np.max(radii) * np.cos(0.2)
     y_az_in = 0.9*np.max(radii) * np.sin(0.2)
     interpolated_value_az_in = ct_cal_az.InterpolateCT(
         x_az_in, y_az_in, dataset_cor, fpam_fsam_cal)[0]
-
+    
     assert interpolated_value_az_out == pytest.approx(interpolated_value_az_in, abs=0.01), "Error more than 1% error"
 
     print('Tests about CT interpolation passed')

--- a/tests/test_corethroughput.py
+++ b/tests/test_corethroughput.py
@@ -261,21 +261,46 @@ def test_psf_pix_and_ct():
     # Difference between expected and retrieved locations for the max (peak) method
     diff_psf_loc = psf_loc_in - psf_loc_est
     # Set a difference of 0.005 pixels
-    assert np.all(np.abs(diff_psf_loc) <= 0.005)
+    atol_psf_loc = 0.005
+    atol_ct = 0.01
+
+    test_result = np.all(np.abs(diff_psf_loc) <= atol_psf_loc)
+    assert test_result
+    # Print out the result
+    print('\nGaussian position from estimate_psf_pix_and_ct() is correct to within %.3f pixels: ' % (atol_psf_loc), end='')
+    print_pass() if test_result else print_fail()
+
+    # comparison between I/O values (<=1% due to pixelization effects vs.
+    # expected analytical value)
+    test_result = np.all(np.abs(ct_est-ct_in) <= atol_ct)
+    assert test_result
+    # Print out the result
+    print('\nGaussian CT value from estimate_psf_pix_and_ct() is correct to within %.1f%%: ' % (atol_ct*100), end='')
+    print_pass() if test_result else print_fail()
+
     # core throughput in (0,1]
     assert np.all(ct_est) > 0
     assert np.all(ct_est) <= 1
-    # comparison between I/O values (<=1% due to pixelization effects vs.
-    # expected analytical value)
-    assert np.all(np.abs(ct_est-ct_in) <= 0.01)
+
 
     # Test 2:
     # Functional test with some mock data with known PSF location and CT
     # Synthetic PSF from setup_module
     psf_loc_est, ct_est = corethroughput.estimate_psf_pix_and_ct(dataset_ct_syn)
     # In this test, there must be an exact agreement
-    assert np.all(psf_loc_est[0] == psf_loc_syn)
-    assert np.abs(ct_est[0]-ct_syn) < 1e-16
+
+    test_result = np.all(psf_loc_est[0] == psf_loc_syn)
+    assert test_result
+    # Print out the result
+    print('Synthetic PSF position from estimate_psf_pix_and_ct() is exactly correct: ', end='')
+    print_pass() if test_result else print_fail()
+
+    atol_ct = 1e-16
+    test_result = np.abs(ct_est[0]-ct_syn) < atol_ct
+    assert test_result
+    # Print out the result
+    print('Synthetic PSF CT value from estimate_psf_pix_and_ct() is correct to within %.1g: ' % (atol_ct), end='')
+    print_pass() if test_result else print_fail()
 
     print('Tests about PSF locations and CT values passed')
 

--- a/tests/test_fluxcal.py
+++ b/tests/test_fluxcal.py
@@ -10,18 +10,20 @@ import corgidrp.l4_to_tda as l4_to_tda
 from astropy.modeling.models import BlackBody
 import astropy.units as u
 
-data = np.ones([1024,1024]) * 2 
-err = np.ones([1,1024,1024]) * 0.5
+data = np.ones([1024, 1024]) * 2
+err = np.ones([1, 1024, 1024]) * 0.5
 prhd, exthd = create_default_L3_headers()
 exthd["CFAMNAME"] = '3C'
 exthd["FPAMNAME"] = 'ND475'
 prhd["TARGET"] = 'VEGA'
-image1 = Image(data,pri_hdr = prhd, ext_hdr = exthd, err = err)
+image1 = Image(data, pri_hdr=prhd, ext_hdr=exthd, err=err)
 image2 = image1.copy()
 image1.filename = "test1_L4_.fits"
 image2.filename = "test2_L4_.fits"
-dataset=Dataset([image1, image2])
-calspec_filepath = os.path.join(os.path.dirname(__file__), "test_data", "alpha_lyr_stis_011.fits")
+dataset = Dataset([image1, image2])
+calspec_filepath = os.path.join(
+    os.path.dirname(__file__), "test_data", "alpha_lyr_stis_011.fits")
+
 
 def test_get_filter_name():
     """
@@ -31,20 +33,20 @@ def test_get_filter_name():
     global transmission
     filepath = fluxcal.get_filter_name(image1)
     assert filepath.split("/")[-1] == 'transmission_ID-21_3C_v0.csv'
-    
+
     wave, transmission = fluxcal.read_filter_curve(filepath)
-    
-    assert np.any(wave>=7130)
+
+    assert np.any(wave >= 7130)
     assert np.any(transmission < 1.)
-    
-    #test a wrong filter name
+
+    # test a wrong filter name
     image3 = image1.copy()
     image3.ext_hdr["CFAMNAME"] = '5C'
     dataset2 = Dataset([image3, image3])
     with pytest.raises(ValueError):
         filepath = fluxcal.get_filter_name(image3)
         pass
-    
+
 
 def test_flux_calc():
     """
@@ -53,33 +55,34 @@ def test_flux_calc():
     global band_flux
     calspec_flux = fluxcal.read_cal_spec(calspec_filepath, wave)
     assert calspec_flux[0] == pytest.approx(1.6121e-09, 1e-15) 
-    
+
     band_flux = fluxcal.calculate_band_flux(transmission, calspec_flux, wave)
     eff_lambda = fluxcal.calculate_effective_lambda(transmission, calspec_flux, wave)
     assert eff_lambda == pytest.approx((wave[0]+wave[-1])/2., 3)
-    
+
+
 def test_colorcor():
     """
     test that the pivot reference wavelengths is close to the center of the bandpass
     and the color correction is calculated correctly
     """
-    
+
     lambda_piv = fluxcal.calculate_pivot_lambda(transmission, wave)
     assert lambda_piv == pytest.approx((wave[0]+wave[-1])/2., 0.3)
-    
+
     calspec_flux = fluxcal.read_cal_spec(calspec_filepath, wave)
-    ## BB of an O5 star
+    # BB of an O5 star
     bbscale = 1.e-21 * u.erg/(u.s * u.cm**2 * u.AA * u.steradian)
-    flux_source = BlackBody(scale = bbscale, temperature=54000.0 * u.K)
+    flux_source = BlackBody(scale=bbscale, temperature=54000.0 * u.K)
     K_bb = fluxcal.compute_color_cor(transmission, wave, calspec_flux, lambda_piv, flux_source(wave))
     assert K_bb == pytest.approx(1., 0.01)
-    
-    flux_source = BlackBody(scale = bbscale, temperature=100. * u.K)
+
+    flux_source = BlackBody(scale=bbscale, temperature=100. * u.K)
     K_bb = fluxcal.compute_color_cor(transmission, wave, calspec_flux, lambda_piv, flux_source(wave))
-    assert K_bb > 2#weakest star to be detected
+    assert K_bb > 2  # weakest star to be detected
     # sanity check
     K = fluxcal.compute_color_cor(transmission, wave, calspec_flux, lambda_piv, calspec_flux)
-    assert K == 1 
+    assert K == 1
 
     # test the corresponding pipeline step
     output_dataset = l4_to_tda.determine_color_cor(dataset, calspec_filepath, calspec_filepath)
@@ -91,7 +94,8 @@ def test_colorcor():
     output_dataset = l4_to_tda.determine_color_cor(dataset, calspec_name, source_name)
     assert output_dataset[0].ext_hdr['LAM_REF'] == lambda_piv
     assert output_dataset[0].ext_hdr['COL_COR'] == pytest.approx(1,1e-2) 
-    
+
+
 def test_calspec_download():
     """
     test the download of a calspec fits file
@@ -102,9 +106,10 @@ def test_calspec_download():
     filepath = fluxcal.get_calspec_file('TYC 4424-1286-1')
     assert os.path.exists(filepath)
     os.remove(filepath)
-    
+
     with pytest.raises(ValueError):
         filepath = fluxcal.get_calspec_file('Todesstern')
+
 
 def test_app_mag():
     """
@@ -116,101 +121,120 @@ def test_app_mag():
     assert output_dataset[0].ext_hdr['APP_MAG'] == 0.
     output_dataset = l4_to_tda.determine_app_mag(dataset, calspec_filepath)
     assert output_dataset[0].ext_hdr['APP_MAG'] == pytest.approx(0.0, 0.03) 
-    output_dataset = l4_to_tda.determine_app_mag(dataset, calspec_filepath, scale_factor = 0.5)
+    output_dataset = l4_to_tda.determine_app_mag(dataset, calspec_filepath, scale_factor=0.5)
     assert output_dataset[0].ext_hdr['APP_MAG'] == pytest.approx(0.+-2.5*np.log10(0.5), 0.03)
     output_dataset = l4_to_tda.determine_app_mag(dataset, '109 Vir')
     assert output_dataset[0].ext_hdr['APP_MAG'] == pytest.approx(3.72, 0.05)
 
+
 def test_fluxcal_file():
-    """ 
+    """
     Generate a mock fluxcal factor cal object and test the content and functionality.
     """
     fluxcal_factor = np.array([[2e-12]])
     fluxcal_factor_error = np.array([[[1e-14]]])
-    fluxcal_fac = FluxcalFactor(fluxcal_factor, err = fluxcal_factor_error, pri_hdr = prhd, ext_hdr = exthd, input_dataset = dataset)
+    fluxcal_fac = FluxcalFactor(
+        fluxcal_factor, err=fluxcal_factor_error, pri_hdr=prhd, ext_hdr=exthd,
+        input_dataset=dataset)
     assert fluxcal_fac.filter == '3C'
-    assert fluxcal_fac.fluxcal_fac == fluxcal_factor[0,0]
-    assert fluxcal_fac.fluxcal_err == fluxcal_factor_error[0,0,0]
-    assert(fluxcal_fac.filename.split(".")[0] == "test2_ABF_CAL")
-    
+    assert fluxcal_fac.fluxcal_fac == fluxcal_factor[0, 0]
+    assert fluxcal_fac.fluxcal_err == fluxcal_factor_error[0, 0, 0]
+    assert (fluxcal_fac.filename.split(".")[0] == "test2_ABF_CAL")
+
     calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
     filename = fluxcal_fac.filename
     if not os.path.exists(calibdir):
         os.mkdir(calibdir)
     fluxcal_fac.save(filedir=calibdir, filename=filename)        
-        
+
     fluxcal_filepath = os.path.join(calibdir, filename)
 
     fluxcal_fac_file = FluxcalFactor(fluxcal_filepath)
     assert fluxcal_fac_file.filter == '3C'
-    assert fluxcal_fac_file.fluxcal_fac == fluxcal_factor[0,0]
-    assert fluxcal_fac_file.fluxcal_err == fluxcal_factor_error[0,0,0]
+    assert fluxcal_fac_file.fluxcal_fac == fluxcal_factor[0, 0]
+    assert fluxcal_fac_file.fluxcal_err == fluxcal_factor_error[0, 0, 0]
     # JM: I moved this out of the fluxcal class and into fluxcal.py because, depending on the method you use to 
     # make the fluxcal factor, the BUNIT will vary. Doing a mock without running fluxcal methods won't update BUNIT
-    #assert fluxcal_fac_file.ext_hdr["BUNIT"] == 'erg/(s * cm^2 * AA)/(electron/s)'
+    # assert fluxcal_fac_file.ext_hdr["BUNIT"] == 'erg/(s * cm^2 * AA)/(electron/s)'
+
 
 def test_abs_fluxcal():
-    """ 
+    """
     Generate a simulated image and test the flux calibration computation.
-    
+
     """
     # create a simulated image with source guesses and true positions
     # check that the simulated image folder exists and create if not
     datadir = os.path.join(os.path.dirname(__file__), "test_data", "sim_fluxcal")
     if not os.path.exists(datadir):
         os.mkdir(datadir)
-    
+
+    # check that the results folder exists and create if not
+    resdir = os.path.join(os.path.dirname(__file__), "test_data", "results")
+    if not os.path.exists(resdir):
+        os.mkdir(resdir)
+
     fwhm = 3
-    cal_factor = band_flux/200
-    #create a simulated mock image with a central point source + noise that has a flux band_flux 
-    #and a flux calibration factor band_flux/200
-    #that results in a total extracted count of 200 photo electrons
-    flux_image = create_flux_image(band_flux, fwhm, cal_factor, filter='3C', target_name='Vega', fsm_x=0.0, 
-                      fsm_y=0.0, exptime=1.0, filedir=datadir, platescale=21.8, background=0,
-                      add_gauss_noise=True, noise_scale=1., file_save=True)
-    assert type(flux_image) == Image
+    flux_ratio = 200
+    cal_factor = band_flux/flux_ratio
+    # create a simulated mock image with a central point source + noise that
+    # has a flux band_flux and a flux calibration factor band_flux/200
+    # that results in a total extracted count of 200 photo electrons
+    flux_image = create_flux_image(
+        band_flux, fwhm, cal_factor, filter='3C', target_name='Vega',
+        fsm_x=0.0, fsm_y=0.0, exptime=1.0, filedir=datadir, platescale=21.8,
+        background=0, add_gauss_noise=True, noise_scale=1., file_save=True)
+    assert isinstance(flux_image, Image)
     sigma = fwhm/(2.*np.sqrt(2*np.log(2)))
-    radius = 3.* sigma
-    
-    #Test the aperture photometry
-    #The error of one pixel is 1, so the error of the aperture sum should be: 
+    radius = 3.0 * sigma
+
+    # Test the aperture photometry
+    # The error of one pixel is 1, so the error of the aperture sum should be:
     error_sum = np.sqrt(np.pi * radius * radius)
-    [flux_el_ap, flux_err_ap] = fluxcal.aper_phot(flux_image, radius, frac_enc_energy=0.997, method='subpixel', subpixels=5,
-              background_sub=False, r_in=5, r_out=10, centering_method='xy', centroid_roi_radius=5)
-    #200 is the input count of photo electrons
-    assert flux_el_ap == pytest.approx(200, rel = 0.05)
-    assert flux_err_ap == pytest.approx(error_sum, rel = 0.05)
-    
-    
-    #Test the 2D Gaussian fit photometry
-    #The error of one pixel is 1, so the error of a circular aperture with radius of 2 sigma should be about:
+    [flux_el_ap, flux_err_ap] = fluxcal.aper_phot(
+        flux_image, radius, frac_enc_energy=0.997, method='subpixel',
+        subpixels=5, background_sub=False, r_in=5, r_out=10,
+        centering_method='xy', centroid_roi_radius=5)
+    # 200 is the input count of photo electrons
+    assert flux_el_ap == pytest.approx(flux_ratio, rel=0.05)
+    assert flux_err_ap == pytest.approx(error_sum, rel=0.05)
+
+    # Test the 2D Gaussian fit photometry
+    # The error of one pixel is 1, so the error of a circular aperture with
+    # radius of 2 sigma should be about:
     error_gauss = np.sqrt(np.pi * 4 * sigma * sigma)
-    flux_el_gauss, flux_err_gauss = fluxcal.phot_by_gauss2d_fit(flux_image, fwhm, fit_shape = 41)
-    assert flux_el_gauss == pytest.approx(200, rel = 0.05)
-    assert flux_err_gauss == pytest.approx(error_gauss, rel = 0.05)
-    
-    flux_el_gauss, flux_err_gauss = fluxcal.phot_by_gauss2d_fit(flux_image, fwhm)
-    assert flux_el_gauss == pytest.approx(200, rel = 0.05)
-    assert flux_err_gauss == pytest.approx(error_gauss, rel = 0.05)
-    #test the generation of the flux cal factors cal file
+    flux_el_gauss, flux_err_gauss = fluxcal.phot_by_gauss2d_fit(
+        flux_image, fwhm, fit_shape=41)
+    assert flux_el_gauss == pytest.approx(flux_ratio, rel=0.05)
+    assert flux_err_gauss == pytest.approx(error_gauss, rel=0.05)
+
+    flux_el_gauss, flux_err_gauss = fluxcal.phot_by_gauss2d_fit(
+        flux_image, fwhm)
+    assert flux_el_gauss == pytest.approx(flux_ratio, rel=0.05)
+    assert flux_err_gauss == pytest.approx(error_gauss, rel=0.05)
+    # test the generation of the flux cal factors cal file
     dataset = Dataset([flux_image])
-    fluxcal_factor = fluxcal.calibrate_fluxcal_aper(dataset, flux_or_irr = 'flux', phot_kwargs=None)
+    fluxcal_factor = fluxcal.calibrate_fluxcal_aper(
+        dataset, flux_or_irr='flux', phot_kwargs=None)
     assert fluxcal_factor.filter == '3C'
-    #band_flux/200 was the input calibration factor cal_factor of the simulated mock image
-    assert fluxcal_factor.fluxcal_fac == pytest.approx(cal_factor, rel = 0.05)
-    #divisive error propagation of the aperture phot error
+    # band_flux/200 was the input calibration factor cal_factor of the
+    # simulated mock image
+    assert fluxcal_factor.fluxcal_fac == pytest.approx(cal_factor, rel=0.05)
+    # divisive error propagation of the aperture phot error
     err_fluxcal_ap = band_flux/flux_el_ap**2*flux_err_ap
     assert fluxcal_factor.fluxcal_err == pytest.approx(err_fluxcal_ap)
     # TO DO: add this test back in when filename conventions are settled
-    #assert fluxcal_factor.filename == 'mock_flux_image_Vega_0.0_0.0_FluxcalFactor_3C_ND475.fits'
-    fluxcal_factor_gauss = fluxcal.calibrate_fluxcal_gauss2d(dataset, flux_or_irr = 'flux', phot_kwargs=None)
+    # assert fluxcal_factor.filename == 'mock_flux_image_Vega_0.0_0.0_FluxcalFactor_3C_ND475.fits'
+    fluxcal_factor_gauss = fluxcal.calibrate_fluxcal_gauss2d(
+        dataset, flux_or_irr='flux', phot_kwargs=None)
     assert fluxcal_factor_gauss.filter == '3C'
-    assert fluxcal_factor_gauss.fluxcal_fac == pytest.approx(cal_factor,rel = 0.05)
-    #divisive error propagation of the 2D Gaussian fit phot error
+    assert fluxcal_factor_gauss.fluxcal_fac == pytest.approx(cal_factor,
+                                                             rel=0.05)
+    # divisive error propagation of the 2D Gaussian fit phot error
     err_fluxcal_gauss = band_flux/flux_el_gauss**2*flux_err_gauss
     assert fluxcal_factor_gauss.fluxcal_err == pytest.approx(err_fluxcal_gauss)
-    
-    #test the flux conversion computation.
+
+    # test the flux conversion computation.
     old_ind = corgidrp.track_individual_errors
     corgidrp.track_individual_errors = True
     flux_dataset = Dataset([flux_image, flux_image])
@@ -219,45 +243,46 @@ def test_abs_fluxcal():
     assert output_dataset[0].ext_hdr['BUNIT'] == "erg/(s*cm^2*AA)"
     assert output_dataset[0].ext_hdr['FLUXFAC'] == fluxcal_factor.fluxcal_fac
     assert "fluxcal_factor" in str(output_dataset[0].ext_hdr['HISTORY'])
-    
-    #this is the amplitude of the simulated 2D Gaussian mock image in the center
-    #it should be close to the value in the output image center
-    el_cen = flux_dataset[0].data[512,512]
+
+    # this is the amplitude of the simulated 2D Gaussian mock image in the
+    # center it should be close to the value in the output image center
+    el_cen = flux_dataset[0].data[512, 512]
     amplitude = el_cen * fluxcal_factor.fluxcal_fac
     data_cen = output_dataset[0].data[512, 512]
     assert data_cen == pytest.approx(amplitude)
     assert output_dataset[0].err_hdr["LAYER_2"] == "fluxcal_error"
-    #this is the error propagation of the multiplication with the flux calibration factor
-    #and should agree with the value of the output image
-    flux_err_cen = flux_dataset[0].err[0,512,512]
+    # this is the error propagation of the multiplication with the flux
+    # calibration factor and should agree with the value of the output image
+    flux_err_cen = flux_dataset[0].err[0, 512, 512]
     err_layer2 = fluxcal_factor.fluxcal_err * el_cen
-    err_comb = np.sqrt((flux_err_cen * fluxcal_factor.fluxcal_fac)**2 + err_layer2**2)
-    assert output_dataset[0].err[0,512, 512] == pytest.approx(err_comb)
-    assert output_dataset[0].err[1,512, 512] == pytest.approx(err_layer2)
-    
-    #Test the optional background subtraction#
+    err_comb = np.sqrt((flux_err_cen * fluxcal_factor.fluxcal_fac)**2 +
+                       err_layer2**2)
+    assert output_dataset[0].err[0, 512, 512] == pytest.approx(err_comb)
+    assert output_dataset[0].err[1, 512, 512] == pytest.approx(err_layer2)
+
+    # Test the optional background subtraction#
     flux_image_back = create_flux_image(band_flux, fwhm, cal_factor, filter='3C', target_name='Vega', fsm_x=0.0, 
                       fsm_y=0.0, exptime=1.0, filedir=datadir, platescale=21.8, background=3,
                       add_gauss_noise=True, noise_scale=1., file_save=True)
-    
+
     [flux_back, flux_err_back, back] = fluxcal.aper_phot(flux_image_back, radius, frac_enc_energy=0.997, method='subpixel', subpixels=5,
               background_sub=True, r_in=5, r_out=10, centering_method='xy', centroid_roi_radius=5)
 
-    #calculated median background should be close to the input
+    # calculated median background should be close to the input
     assert back == pytest.approx(3, abs = 0.03)
-    #the found values should be close to the ones without background subtraction
+    # the found values should be close to the ones without background subtraction
     assert flux_back == pytest.approx(flux_el_ap, abs = 1)
     assert flux_err_back == pytest.approx(flux_err_ap, abs = 0.03)
 
     [flux_back, flux_err_back, back] = fluxcal.phot_by_gauss2d_fit(flux_image_back, fwhm, fit_shape=None, background_sub=True, r_in=5,
                         r_out=10, centering_method='xy', centroid_roi_radius=5)
-    #calculated median background should be close to the input
+    # calculated median background should be close to the input
     assert back == pytest.approx(3, abs = 0.03)
-    #the found values should be close to the ones without background subtraction
+    # the found values should be close to the ones without background subtraction
     assert flux_back == pytest.approx(flux_el_gauss, abs = 1)
     assert flux_err_back == pytest.approx(flux_err_gauss, abs = 0.03)
-    
-    #Also test again the generation of the cal file now with a background subtraction
+
+    # Also test again the generation of the cal file now with a background subtraction
     aper_kwargs = {
         "encircled_radius": radius,
         "frac_enc_energy": 0.997,

--- a/tests/test_fluxcal.py
+++ b/tests/test_fluxcal.py
@@ -22,9 +22,8 @@ image1 = Image(data,pri_hdr = prhd, ext_hdr = exthd, err = err)
 image2 = image1.copy()
 image1.filename = "test1_L4_.fits"
 image2.filename = "test2_L4_.fits"
-dataset = Dataset([image1, image2])
-calspec_filepath = os.path.join(
-    os.path.dirname(__file__), "test_data", "alpha_lyr_stis_011.fits")
+dataset=Dataset([image1, image2])
+calspec_filepath = os.path.join(os.path.dirname(__file__), "test_data", "alpha_lyr_stis_011.fits")
 
 
 def print_fail():
@@ -48,7 +47,7 @@ def test_get_filter_name():
     
     assert np.any(wave>=7130)
     assert np.any(transmission < 1.)
-
+    
     #test a wrong filter name
     image3 = image1.copy()
     image3.ext_hdr["CFAMNAME"] = '5C'
@@ -65,7 +64,7 @@ def test_flux_calc():
     global band_flux
     calspec_flux = fluxcal.read_cal_spec(calspec_filepath, wave)
     assert calspec_flux[0] == pytest.approx(1.6121e-09, 1e-15) 
-
+    
     band_flux = fluxcal.calculate_band_flux(transmission, calspec_flux, wave)
     eff_lambda = fluxcal.calculate_effective_lambda(transmission, calspec_flux, wave)
     assert eff_lambda == pytest.approx((wave[0]+wave[-1])/2., 3)
@@ -85,7 +84,7 @@ def test_colorcor():
     flux_source = BlackBody(scale = bbscale, temperature=54000.0 * u.K)
     K_bb = fluxcal.compute_color_cor(transmission, wave, calspec_flux, lambda_piv, flux_source(wave))
     assert K_bb == pytest.approx(1., 0.01)
-
+    
     flux_source = BlackBody(scale = bbscale, temperature=100. * u.K)
     K_bb = fluxcal.compute_color_cor(transmission, wave, calspec_flux, lambda_piv, flux_source(wave))
     assert K_bb > 2#weakest star to be detected
@@ -128,7 +127,7 @@ def test_app_mag():
     assert output_dataset[0].ext_hdr['APP_MAG'] == 0.
     output_dataset = l4_to_tda.determine_app_mag(dataset, calspec_filepath)
     assert output_dataset[0].ext_hdr['APP_MAG'] == pytest.approx(0.0, 0.03) 
-    output_dataset = l4_to_tda.determine_app_mag(dataset, calspec_filepath, scale_factor=0.5)
+    output_dataset = l4_to_tda.determine_app_mag(dataset, calspec_filepath, scale_factor = 0.5)
     assert output_dataset[0].ext_hdr['APP_MAG'] == pytest.approx(0.+-2.5*np.log10(0.5), 0.03)
     output_dataset = l4_to_tda.determine_app_mag(dataset, '109 Vir')
     assert output_dataset[0].ext_hdr['APP_MAG'] == pytest.approx(3.72, 0.05)
@@ -141,8 +140,8 @@ def test_fluxcal_file():
     fluxcal_factor_error = np.array([[[1e-14]]])
     fluxcal_fac = FluxcalFactor(fluxcal_factor, err = fluxcal_factor_error, pri_hdr = prhd, ext_hdr = exthd, input_dataset = dataset)
     assert fluxcal_fac.filter == '3C'
-    assert fluxcal_fac.fluxcal_fac == fluxcal_factor[0, 0]
-    assert fluxcal_fac.fluxcal_err == fluxcal_factor_error[0, 0, 0]
+    assert fluxcal_fac.fluxcal_fac == fluxcal_factor[0,0]
+    assert fluxcal_fac.fluxcal_err == fluxcal_factor_error[0,0,0]
     assert(fluxcal_fac.filename.split(".")[0] == "test2_ABF_CAL")
     
     calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
@@ -201,15 +200,15 @@ def test_abs_fluxcal():
     #200 is the input count of photo electrons
     assert flux_el_ap == pytest.approx(200, rel = 0.05)
     assert flux_err_ap == pytest.approx(error_sum, rel = 0.05)
-
-
+    
+    
     #Test the 2D Gaussian fit photometry
     #The error of one pixel is 1, so the error of a circular aperture with radius of 2 sigma should be about:
     error_gauss = np.sqrt(np.pi * 4 * sigma * sigma)
     flux_el_gauss, flux_err_gauss = fluxcal.phot_by_gauss2d_fit(flux_image, fwhm, fit_shape = 41)
     assert flux_el_gauss == pytest.approx(200, rel = 0.05)
     assert flux_err_gauss == pytest.approx(error_gauss, rel = 0.05)
-
+    
     flux_el_gauss, flux_err_gauss = fluxcal.phot_by_gauss2d_fit(flux_image, fwhm)
     assert flux_el_gauss == pytest.approx(200, rel = 0.05)
     assert flux_err_gauss == pytest.approx(error_gauss, rel = 0.05)
@@ -364,3 +363,6 @@ if __name__ == '__main__':
     test_app_mag()
     test_fluxcal_file()
     test_abs_fluxcal()
+
+
+

--- a/tests/test_fluxcal.py
+++ b/tests/test_fluxcal.py
@@ -12,13 +12,13 @@ import astropy.units as u
 from termcolor import cprint
 
 
-data = np.ones([1024, 1024]) * 2
-err = np.ones([1, 1024, 1024]) * 0.5
+data = np.ones([1024,1024]) * 2 
+err = np.ones([1,1024,1024]) * 0.5
 prhd, exthd = create_default_L3_headers()
 exthd["CFAMNAME"] = '3C'
 exthd["FPAMNAME"] = 'ND475'
 prhd["TARGET"] = 'VEGA'
-image1 = Image(data, pri_hdr=prhd, ext_hdr=exthd, err=err)
+image1 = Image(data,pri_hdr = prhd, ext_hdr = exthd, err = err)
 image2 = image1.copy()
 image1.filename = "test1_L4_.fits"
 image2.filename = "test2_L4_.fits"
@@ -43,20 +43,20 @@ def test_get_filter_name():
     global transmission
     filepath = fluxcal.get_filter_name(image1)
     assert filepath.split("/")[-1] == 'transmission_ID-21_3C_v0.csv'
-
+    
     wave, transmission = fluxcal.read_filter_curve(filepath)
-
-    assert np.any(wave >= 7130)
+    
+    assert np.any(wave>=7130)
     assert np.any(transmission < 1.)
 
-    # test a wrong filter name
+    #test a wrong filter name
     image3 = image1.copy()
     image3.ext_hdr["CFAMNAME"] = '5C'
     dataset2 = Dataset([image3, image3])
     with pytest.raises(ValueError):
         filepath = fluxcal.get_filter_name(image3)
         pass
-
+    
 
 def test_flux_calc():
     """
@@ -69,30 +69,29 @@ def test_flux_calc():
     band_flux = fluxcal.calculate_band_flux(transmission, calspec_flux, wave)
     eff_lambda = fluxcal.calculate_effective_lambda(transmission, calspec_flux, wave)
     assert eff_lambda == pytest.approx((wave[0]+wave[-1])/2., 3)
-
-
+    
 def test_colorcor():
     """
     test that the pivot reference wavelengths is close to the center of the bandpass
     and the color correction is calculated correctly
     """
-
+    
     lambda_piv = fluxcal.calculate_pivot_lambda(transmission, wave)
     assert lambda_piv == pytest.approx((wave[0]+wave[-1])/2., 0.3)
-
+    
     calspec_flux = fluxcal.read_cal_spec(calspec_filepath, wave)
-    # BB of an O5 star
+    ## BB of an O5 star
     bbscale = 1.e-21 * u.erg/(u.s * u.cm**2 * u.AA * u.steradian)
-    flux_source = BlackBody(scale=bbscale, temperature=54000.0 * u.K)
+    flux_source = BlackBody(scale = bbscale, temperature=54000.0 * u.K)
     K_bb = fluxcal.compute_color_cor(transmission, wave, calspec_flux, lambda_piv, flux_source(wave))
     assert K_bb == pytest.approx(1., 0.01)
 
-    flux_source = BlackBody(scale=bbscale, temperature=100. * u.K)
+    flux_source = BlackBody(scale = bbscale, temperature=100. * u.K)
     K_bb = fluxcal.compute_color_cor(transmission, wave, calspec_flux, lambda_piv, flux_source(wave))
-    assert K_bb > 2  # weakest star to be detected
+    assert K_bb > 2#weakest star to be detected
     # sanity check
     K = fluxcal.compute_color_cor(transmission, wave, calspec_flux, lambda_piv, calspec_flux)
-    assert K == 1
+    assert K == 1 
 
     # test the corresponding pipeline step
     output_dataset = l4_to_tda.determine_color_cor(dataset, calspec_filepath, calspec_filepath)
@@ -104,8 +103,7 @@ def test_colorcor():
     output_dataset = l4_to_tda.determine_color_cor(dataset, calspec_name, source_name)
     assert output_dataset[0].ext_hdr['LAM_REF'] == lambda_piv
     assert output_dataset[0].ext_hdr['COL_COR'] == pytest.approx(1,1e-2) 
-
-
+    
 def test_calspec_download():
     """
     test the download of a calspec fits file
@@ -116,10 +114,9 @@ def test_calspec_download():
     filepath = fluxcal.get_calspec_file('TYC 4424-1286-1')
     assert os.path.exists(filepath)
     os.remove(filepath)
-
+    
     with pytest.raises(ValueError):
         filepath = fluxcal.get_calspec_file('Todesstern')
-
 
 def test_app_mag():
     """
@@ -136,42 +133,38 @@ def test_app_mag():
     output_dataset = l4_to_tda.determine_app_mag(dataset, '109 Vir')
     assert output_dataset[0].ext_hdr['APP_MAG'] == pytest.approx(3.72, 0.05)
 
-
 def test_fluxcal_file():
-    """
+    """ 
     Generate a mock fluxcal factor cal object and test the content and functionality.
     """
     fluxcal_factor = np.array([[2e-12]])
     fluxcal_factor_error = np.array([[[1e-14]]])
-    fluxcal_fac = FluxcalFactor(
-        fluxcal_factor, err=fluxcal_factor_error, pri_hdr=prhd, ext_hdr=exthd,
-        input_dataset=dataset)
+    fluxcal_fac = FluxcalFactor(fluxcal_factor, err = fluxcal_factor_error, pri_hdr = prhd, ext_hdr = exthd, input_dataset = dataset)
     assert fluxcal_fac.filter == '3C'
     assert fluxcal_fac.fluxcal_fac == fluxcal_factor[0, 0]
     assert fluxcal_fac.fluxcal_err == fluxcal_factor_error[0, 0, 0]
-    assert (fluxcal_fac.filename.split(".")[0] == "test2_ABF_CAL")
-
+    assert(fluxcal_fac.filename.split(".")[0] == "test2_ABF_CAL")
+    
     calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
     filename = fluxcal_fac.filename
     if not os.path.exists(calibdir):
         os.mkdir(calibdir)
     fluxcal_fac.save(filedir=calibdir, filename=filename)        
-
+        
     fluxcal_filepath = os.path.join(calibdir, filename)
 
     fluxcal_fac_file = FluxcalFactor(fluxcal_filepath)
     assert fluxcal_fac_file.filter == '3C'
-    assert fluxcal_fac_file.fluxcal_fac == fluxcal_factor[0, 0]
-    assert fluxcal_fac_file.fluxcal_err == fluxcal_factor_error[0, 0, 0]
+    assert fluxcal_fac_file.fluxcal_fac == fluxcal_factor[0,0]
+    assert fluxcal_fac_file.fluxcal_err == fluxcal_factor_error[0,0,0]
     # JM: I moved this out of the fluxcal class and into fluxcal.py because, depending on the method you use to 
     # make the fluxcal factor, the BUNIT will vary. Doing a mock without running fluxcal methods won't update BUNIT
-    # assert fluxcal_fac_file.ext_hdr["BUNIT"] == 'erg/(s * cm^2 * AA)/(electron/s)'
-
+    #assert fluxcal_fac_file.ext_hdr["BUNIT"] == 'erg/(s * cm^2 * AA)/(electron/s)'
 
 def test_abs_fluxcal():
-    """
+    """ 
     Generate a simulated image and test the flux calibration computation.
-
+    
     """
     rel_tol_flux = 0.05
 
@@ -198,36 +191,31 @@ def test_abs_fluxcal():
         background=0, add_gauss_noise=True, noise_scale=1., file_save=True)
     assert isinstance(flux_image, Image)
     sigma = fwhm/(2.*np.sqrt(2*np.log(2)))
-    radius = 3.0 * sigma
-
-    # Test the aperture photometry
-    # The error of one pixel is 1, so the error of the aperture sum should be:
+    radius = 3.* sigma
+    
+    #Test the aperture photometry
+    #The error of one pixel is 1, so the error of the aperture sum should be: 
     error_sum = np.sqrt(np.pi * radius * radius)
-    [flux_el_ap, flux_err_ap] = fluxcal.aper_phot(
-        flux_image, radius, frac_enc_energy=0.997, method='subpixel',
-        subpixels=5, background_sub=False, r_in=5, r_out=10,
-        centering_method='xy', centroid_roi_radius=5)
-    # 200 is the input count of photo electrons
-    assert flux_el_ap == pytest.approx(flux_ratio, rel=0.05)
-    assert flux_err_ap == pytest.approx(error_sum, rel=0.05)
+    [flux_el_ap, flux_err_ap] = fluxcal.aper_phot(flux_image, radius, frac_enc_energy=0.997, method='subpixel', subpixels=5,
+              background_sub=False, r_in=5, r_out=10, centering_method='xy', centroid_roi_radius=5)
+    #200 is the input count of photo electrons
+    assert flux_el_ap == pytest.approx(200, rel = 0.05)
+    assert flux_err_ap == pytest.approx(error_sum, rel = 0.05)
 
-    # Test the 2D Gaussian fit photometry
-    # The error of one pixel is 1, so the error of a circular aperture with
-    # radius of 2 sigma should be about:
+
+    #Test the 2D Gaussian fit photometry
+    #The error of one pixel is 1, so the error of a circular aperture with radius of 2 sigma should be about:
     error_gauss = np.sqrt(np.pi * 4 * sigma * sigma)
-    flux_el_gauss, flux_err_gauss = fluxcal.phot_by_gauss2d_fit(
-        flux_image, fwhm, fit_shape=41)
-    assert flux_el_gauss == pytest.approx(flux_ratio, rel=0.05)
-    assert flux_err_gauss == pytest.approx(error_gauss, rel=0.05)
+    flux_el_gauss, flux_err_gauss = fluxcal.phot_by_gauss2d_fit(flux_image, fwhm, fit_shape = 41)
+    assert flux_el_gauss == pytest.approx(200, rel = 0.05)
+    assert flux_err_gauss == pytest.approx(error_gauss, rel = 0.05)
 
-    flux_el_gauss, flux_err_gauss = fluxcal.phot_by_gauss2d_fit(
-        flux_image, fwhm)
-    assert flux_el_gauss == pytest.approx(flux_ratio, rel=0.05)
-    assert flux_err_gauss == pytest.approx(error_gauss, rel=0.05)
-    # test the generation of the flux cal factors cal file
+    flux_el_gauss, flux_err_gauss = fluxcal.phot_by_gauss2d_fit(flux_image, fwhm)
+    assert flux_el_gauss == pytest.approx(200, rel = 0.05)
+    assert flux_err_gauss == pytest.approx(error_gauss, rel = 0.05)
+    #test the generation of the flux cal factors cal file
     dataset = Dataset([flux_image])
-    fluxcal_factor = fluxcal.calibrate_fluxcal_aper(
-        dataset, flux_or_irr='flux', phot_kwargs=None)
+    fluxcal_factor = fluxcal.calibrate_fluxcal_aper(dataset, flux_or_irr = 'flux', phot_kwargs=None)
     assert fluxcal_factor.filter == '3C'
     # band_flux/200 was the input calibration factor cal_factor of the
     # simulated mock image
@@ -255,8 +243,8 @@ def test_abs_fluxcal():
     # divisive error propagation of the 2D Gaussian fit phot error
     err_fluxcal_gauss = band_flux/flux_el_gauss**2*flux_err_gauss
     assert fluxcal_factor_gauss.fluxcal_err == pytest.approx(err_fluxcal_gauss)
-
-    # test the flux conversion computation.
+    
+    #test the flux conversion computation.
     old_ind = corgidrp.track_individual_errors
     corgidrp.track_individual_errors = True
     flux_dataset = Dataset([flux_image, flux_image])
@@ -265,49 +253,45 @@ def test_abs_fluxcal():
     assert output_dataset[0].ext_hdr['BUNIT'] == "erg/(s*cm^2*AA)"
     assert output_dataset[0].ext_hdr['FLUXFAC'] == fluxcal_factor.fluxcal_fac
     assert "fluxcal_factor" in str(output_dataset[0].ext_hdr['HISTORY'])
-
-    # this is the amplitude of the simulated 2D Gaussian mock image in the
-    # center it should be close to the value in the output image center
-    el_cen = flux_dataset[0].data[512, 512]
+    
+    #this is the amplitude of the simulated 2D Gaussian mock image in the center
+    #it should be close to the value in the output image center
+    el_cen = flux_dataset[0].data[512,512]
     amplitude = el_cen * fluxcal_factor.fluxcal_fac
     data_cen = output_dataset[0].data[512, 512]
     assert data_cen == pytest.approx(amplitude)
     assert output_dataset[0].err_hdr["LAYER_2"] == "fluxcal_error"
-    # this is the error propagation of the multiplication with the flux
-    # calibration factor and should agree with the value of the output image
-    flux_err_cen = flux_dataset[0].err[0, 512, 512]
+    #this is the error propagation of the multiplication with the flux calibration factor
+    #and should agree with the value of the output image
+    flux_err_cen = flux_dataset[0].err[0,512,512]
     err_layer2 = fluxcal_factor.fluxcal_err * el_cen
-    err_comb = np.sqrt((flux_err_cen * fluxcal_factor.fluxcal_fac)**2 +
-                       err_layer2**2)
-    assert output_dataset[0].err[0, 512, 512] == pytest.approx(err_comb)
-    assert output_dataset[0].err[1, 512, 512] == pytest.approx(err_layer2)
+    err_comb = np.sqrt((flux_err_cen * fluxcal_factor.fluxcal_fac)**2 + err_layer2**2)
+    assert output_dataset[0].err[0,512, 512] == pytest.approx(err_comb)
+    assert output_dataset[0].err[1,512, 512] == pytest.approx(err_layer2)
+    
+    #Test the optional background subtraction#
+    flux_image_back = create_flux_image(band_flux, fwhm, cal_factor, filter='3C', target_name='Vega', fsm_x=0.0, 
+                      fsm_y=0.0, exptime=1.0, filedir=datadir, platescale=21.8, background=3,
+                      add_gauss_noise=True, noise_scale=1., file_save=True)
+    
+    [flux_back, flux_err_back, back] = fluxcal.aper_phot(flux_image_back, radius, frac_enc_energy=0.997, method='subpixel', subpixels=5,
+              background_sub=True, r_in=5, r_out=10, centering_method='xy', centroid_roi_radius=5)
 
-    # Test the optional background subtraction#
-    flux_image_back = create_flux_image(
-        band_flux, fwhm, cal_factor, filter='3C', target_name='Vega', fsm_x=0.0,
-        fsm_y=0.0, exptime=1.0, filedir=datadir, platescale=21.8, background=3,
-        add_gauss_noise=True, noise_scale=1., file_save=True)
+    #calculated median background should be close to the input
+    assert back == pytest.approx(3, abs = 0.03)
+    #the found values should be close to the ones without background subtraction
+    assert flux_back == pytest.approx(flux_el_ap, abs = 1)
+    assert flux_err_back == pytest.approx(flux_err_ap, abs = 0.03)
 
-    [flux_back, flux_err_back, back] = fluxcal.aper_phot(
-        flux_image_back, radius, frac_enc_energy=0.997, method='subpixel', subpixels=5,
-        background_sub=True, r_in=5, r_out=10, centering_method='xy', centroid_roi_radius=5)
-
-    # calculated median background should be close to the input
-    assert back == pytest.approx(3, abs=0.03)
-    # the found values should be close to the ones without background subtraction
-    assert flux_back == pytest.approx(flux_el_ap, abs=1)
-    assert flux_err_back == pytest.approx(flux_err_ap, abs=0.03)
-
-    [flux_back, flux_err_back, back] = fluxcal.phot_by_gauss2d_fit(
-        flux_image_back, fwhm, fit_shape=None, background_sub=True, r_in=5,
-        r_out=10, centering_method='xy', centroid_roi_radius=5)
-    # calculated median background should be close to the input
-    assert back == pytest.approx(3, abs=0.03)
-    # the found values should be close to the ones without background subtraction
-    assert flux_back == pytest.approx(flux_el_gauss, abs=1)
-    assert flux_err_back == pytest.approx(flux_err_gauss, abs=0.03)
-
-    # Also test again the generation of the cal file now with a background subtraction
+    [flux_back, flux_err_back, back] = fluxcal.phot_by_gauss2d_fit(flux_image_back, fwhm, fit_shape=None, background_sub=True, r_in=5,
+                        r_out=10, centering_method='xy', centroid_roi_radius=5)
+    #calculated median background should be close to the input
+    assert back == pytest.approx(3, abs = 0.03)
+    #the found values should be close to the ones without background subtraction
+    assert flux_back == pytest.approx(flux_el_gauss, abs = 1)
+    assert flux_err_back == pytest.approx(flux_err_gauss, abs = 0.03)
+    
+    #Also test again the generation of the cal file now with a background subtraction
     aper_kwargs = {
         "encircled_radius": radius,
         "frac_enc_energy": 0.997,
@@ -320,59 +304,58 @@ def test_abs_fluxcal():
         "centroid_roi_radius": 5
     }
     gauss_kwargs = {
-        'fwhm': fwhm,
-        'fit_shape': None,
-        'background_sub': True, 
+        'fwhm': fwhm,                  
+        'fit_shape': None,            
+        'background_sub': True,        
         'r_in': 5.0,                   
         'r_out': 10.0,                
-        'centering_method': 'xy',
-        'centroid_roi_radius': 5 
+        'centering_method': 'xy',     
+        'centroid_roi_radius': 5       
     }
-    fluxcal_factor_back = fluxcal.calibrate_fluxcal_aper(flux_image_back, flux_or_irr='flux', phot_kwargs=aper_kwargs)
+    fluxcal_factor_back = fluxcal.calibrate_fluxcal_aper(flux_image_back, flux_or_irr = 'flux', phot_kwargs=aper_kwargs)
     assert fluxcal_factor_back.fluxcal_fac == pytest.approx(fluxcal_factor.fluxcal_fac)
     assert fluxcal_factor_back.ext_hdr["LOCBACK"] == back
-    fluxcal_factor_back_gauss = fluxcal.calibrate_fluxcal_gauss2d(flux_image_back,flux_or_irr='flux', phot_kwargs=gauss_kwargs)
+    fluxcal_factor_back_gauss = fluxcal.calibrate_fluxcal_gauss2d(flux_image_back, flux_or_irr = 'flux', phot_kwargs=gauss_kwargs)
     assert fluxcal_factor_back_gauss.fluxcal_fac == pytest.approx(fluxcal_factor_gauss.fluxcal_fac)
     assert fluxcal_factor_back_gauss.ext_hdr["LOCBACK"] == back
 
     # test l4_to_tda.determine_flux
     input_dataset = Dataset([flux_image_back, flux_image_back])
-    output_dataset = l4_to_tda.determine_flux(input_dataset, fluxcal_factor_back, photo="aperture", phot_kwargs=aper_kwargs)
+    output_dataset = l4_to_tda.determine_flux(input_dataset, fluxcal_factor_back,  photo = "aperture", phot_kwargs = aper_kwargs)
     assert output_dataset[0].ext_hdr["FLUX"] == pytest.approx(band_flux)
-    assert output_dataset[0].ext_hdr["LOCBACK"] == pytest.approx(3, abs=0.03)
-    # sanity check: vega is input source, so app mag 0
+    assert output_dataset[0].ext_hdr["LOCBACK"] == pytest.approx(3, abs = 0.03)
+    #sanity check: vega is input source, so app mag 0
     assert output_dataset[0].ext_hdr["APP_MAG"] == pytest.approx(0.0)
-
-    output_dataset = l4_to_tda.determine_flux(input_dataset, fluxcal_factor_back_gauss, photo="2dgauss", phot_kwargs=gauss_kwargs)
+    
+    output_dataset = l4_to_tda.determine_flux(input_dataset, fluxcal_factor_back_gauss,  photo = "2dgauss", phot_kwargs = gauss_kwargs)
     assert output_dataset[0].ext_hdr["FLUX"] == pytest.approx(band_flux)
-    assert output_dataset[0].ext_hdr["LOCBACK"] == pytest.approx(3, abs=0.03)
-    # sanity check: Vega is input source, so app mag 0
+    assert output_dataset[0].ext_hdr["LOCBACK"] == pytest.approx(3, abs = 0.03)
+    #sanity check: Vega is input source, so app mag 0
     assert output_dataset[0].ext_hdr["APP_MAG"] == pytest.approx(0.0)
-
-    # estimate of the error propagated to the final flux
+    
+    #estimate of the error propagated to the final flux
     flux_err_ap = np.sqrt(error_sum**2 * fluxcal_factor.fluxcal_fac**2 + fluxcal_factor.fluxcal_err**2 * 200**2)
     flux_err_gauss = np.sqrt(error_gauss**2 * fluxcal_factor_gauss.fluxcal_fac**2 + fluxcal_factor_gauss.fluxcal_err**2 * 200**2)
-
+    
     input_dataset = Dataset([flux_image, flux_image])
-    output_dataset = l4_to_tda.determine_flux(input_dataset, fluxcal_factor, photo="aperture", phot_kwargs=None)
+    output_dataset = l4_to_tda.determine_flux(input_dataset, fluxcal_factor,  photo = "aperture", phot_kwargs = None)
     assert output_dataset[0].ext_hdr["FLUX"] == pytest.approx(band_flux)
-    assert output_dataset[0].ext_hdr["FLUXERR"] == pytest.approx(flux_err_ap, rel=0.1)
+    assert output_dataset[0].ext_hdr["FLUXERR"] == pytest.approx(flux_err_ap, rel = 0.1)
     assert output_dataset[0].ext_hdr["LOCBACK"] == 0
     mag_err_ap = 2.5/np.log(10) * flux_err_ap/band_flux
-
-    assert output_dataset[0].ext_hdr["MAGERR"] == pytest.approx(mag_err_ap, rel=0.1)
-
-    output_dataset = l4_to_tda.determine_flux(input_dataset, fluxcal_factor_gauss,  photo="2dgauss", phot_kwargs=None)
+    
+    assert output_dataset[0].ext_hdr["MAGERR"] == pytest.approx(mag_err_ap, rel = 0.1)
+    
+    output_dataset = l4_to_tda.determine_flux(input_dataset, fluxcal_factor_gauss,  photo = "2dgauss", phot_kwargs = None)
     assert output_dataset[0].ext_hdr["FLUX"] == pytest.approx(band_flux)
-    assert output_dataset[0].ext_hdr["FLUXERR"] == pytest.approx(flux_err_gauss, rel=0.1)
+    assert output_dataset[0].ext_hdr["FLUXERR"] == pytest.approx(flux_err_gauss, rel = 0.1)
     assert output_dataset[0].ext_hdr["LOCBACK"] == 0
     mag_err_gauss = 2.5/np.log(10) * flux_err_gauss/band_flux
-
-    assert output_dataset[0].ext_hdr["MAGERR"] == pytest.approx(mag_err_gauss, rel=0.1)
-
+    
+    assert output_dataset[0].ext_hdr["MAGERR"] == pytest.approx(mag_err_gauss, rel = 0.1)
+    
     corgidrp.track_individual_errors = old_ind
-
-
+    
 if __name__ == '__main__':
     test_get_filter_name()
     test_flux_calc()

--- a/tests/test_fluxcal.py
+++ b/tests/test_fluxcal.py
@@ -9,6 +9,8 @@ import corgidrp.fluxcal as fluxcal
 import corgidrp.l4_to_tda as l4_to_tda
 from astropy.modeling.models import BlackBody
 import astropy.units as u
+from termcolor import cprint
+
 
 data = np.ones([1024, 1024]) * 2
 err = np.ones([1, 1024, 1024]) * 0.5
@@ -23,6 +25,14 @@ image2.filename = "test2_L4_.fits"
 dataset = Dataset([image1, image2])
 calspec_filepath = os.path.join(
     os.path.dirname(__file__), "test_data", "alpha_lyr_stis_011.fits")
+
+
+def print_fail():
+    cprint(' FAIL ', "black", "on_red")
+
+
+def print_pass():
+    cprint(' PASS ', "black", "on_green")
 
 
 def test_get_filter_name():
@@ -221,14 +231,11 @@ def test_abs_fluxcal():
     assert fluxcal_factor.filter == '3C'
     # band_flux/200 was the input calibration factor cal_factor of the
     # simulated mock image
-    assert fluxcal_factor.fluxcal_fac == pytest.approx(cal_factor,
-                                                       rel=rel_tol_flux)
-    # Print out the test result
-    if np.isclose(fluxcal_factor.fluxcal_fac, cal_factor, rtol=rel_tol_flux):
-        result = 'PASS'
-    else:
-        result = 'FAIL'
-    print('\n*** Flux from fluxcal.calibrate_fluxcal_aper() is correct to within %.2f%% ***:    %s' % (rel_tol_flux*100, result))
+    test_result = fluxcal_factor.fluxcal_fac == pytest.approx(cal_factor, rel=rel_tol_flux)
+    assert test_result
+    # Print out the result
+    print('\nFlux from fluxcal.calibrate_fluxcal_aper() is correct to within %.2f%% ***: ' % (rel_tol_flux*100), end='')
+    print_pass() if test_result else print_fail()
 
     # divisive error propagation of the aperture phot error
     err_fluxcal_ap = band_flux/flux_el_ap**2*flux_err_ap
@@ -238,14 +245,12 @@ def test_abs_fluxcal():
     fluxcal_factor_gauss = fluxcal.calibrate_fluxcal_gauss2d(
         dataset, flux_or_irr='flux', phot_kwargs=None)
     assert fluxcal_factor_gauss.filter == '3C'
-    assert fluxcal_factor_gauss.fluxcal_fac == pytest.approx(cal_factor,
-                                                             rel=rel_tol_flux)
-    # Print out the test result
-    if np.isclose(fluxcal_factor_gauss.fluxcal_fac, cal_factor, rtol=rel_tol_flux):
-        result = 'PASS'
-    else:
-        result = 'FAIL'
-    print('\n*** Flux from fluxcal.calibrate_fluxcal_gauss2d() is correct to within %.2f%% ***:    %s' % (rel_tol_flux*100, result))
+    test_result = fluxcal_factor_gauss.fluxcal_fac == pytest.approx(
+        cal_factor, rel=rel_tol_flux)
+    assert test_result
+    # Print out the result
+    print('\nFlux from fluxcal.calibrate_fluxcal_gauss2d() is correct to within %.2f%% ***: ' % (rel_tol_flux*100), end='')
+    print_pass() if test_result else print_fail()
 
     # divisive error propagation of the 2D Gaussian fit phot error
     err_fluxcal_gauss = band_flux/flux_el_gauss**2*flux_err_gauss

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -557,12 +557,14 @@ def test_calculate_od_at_new_location(output_dir):
     # Expect the final location = (2+3, 2+3) = (5,5).
     # Bilinear interpolation of corners: (2,3,4,5) at center => 3.5
     expected_value = 3.5
-    assert abs(interpolated_od - expected_value) < 1e-6, (
+    atol_nd = 1e-6
+    assert abs(interpolated_od - expected_value) < atol_nd, (
         f"Expected OD={expected_value}, got {interpolated_od}"
     )
+    print('')
     print(
-        f"test_calculate_od_at_new_location_nd_sweetspot_real_class PASSED: "
-        f"interpolated OD={interpolated_od}"
+        f"test_calculate_od_at_new_location PASSED: "
+        f"estimated OD = {interpolated_od}, expected OD = {expected_value}"
     )
 
 

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -87,7 +87,7 @@ def is_real_positive_scalar(var):
         var (float): variable to check
 
     Returns:
-     result (bool): Whether the check passes or not.
+        result (bool): Whether the check passes or not.
 
     """
     result = True
@@ -97,13 +97,14 @@ def is_real_positive_scalar(var):
         result = False
     if var <= 0:
         result = False
+
     return result
 
 
 # ---------------------------------------------------------------------------
 # Functions to generate mocks
 # ---------------------------------------------------------------------------
-def mock_dim_dataset_files(dim_exptime, filter_used, cal_factor, save_mocks, output_path=None, 
+def mock_dim_dataset_files(dim_exptime, filter_used, cal_factor, save_mocks, output_path=None,
                            background_val=0, add_gauss_noise_val=False):
     """
     Generate and save mock dim dataset files for specified exposure time and filter.
@@ -270,7 +271,7 @@ def test_nd_filter_calibration_object(stars_dataset_cached):
     ds_copy = copy.deepcopy(stars_dataset_cached)
     results = nd_filter_calibration.create_nd_filter_cal(
         ds_copy, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 
-        fluxcal_factor=None)
+        fluxcal_factor = None)
 
     results.save(filedir=default_cal_dir)
 
@@ -288,7 +289,7 @@ def test_nd_filter_calibration_object(stars_dataset_cached):
 
 def test_output_filename_convention(stars_dataset_cached):
     print("**Testing output filename naming conventions**")
-
+    
     # Make a copy of the dataset and retrieve expected values.
     ds_copy = copy.deepcopy(stars_dataset_cached)
 
@@ -314,10 +315,10 @@ def test_average_od_within_tolerance(stars_dataset_cached_bright_count):
     ds_copy, n_bright = copy.deepcopy(stars_dataset_cached_bright_count)
     results = nd_filter_calibration.create_nd_filter_cal(
         ds_copy, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS,
-        fluxcal_factor=None)
+        fluxcal_factor = None)
     ods = results.data
     avg_od = np.mean(ods[:, 0])
-    std_od = np.std(ods[:, 0])
+    std_od = np.std(ods[:,0])
     results_hdr = results.ext_hdr
     od_flag = results_hdr.get('ODFLAG')
 
@@ -326,6 +327,7 @@ def test_average_od_within_tolerance(stars_dataset_cached_bright_count):
     )
     if std_od < OD_RASTER_THRESHOLD:
         assert not od_flag, f"Low OD variation but flag is set"
+
     else:
         assert od_flag, f"High OD variation but flag is not set"
 
@@ -406,14 +408,14 @@ def test_multiple_nd_levels(dim_dir, output_dir, test_od):
         BRIGHT_EXPTIME, FILTER_USED, test_od, CAL_FACTOR, save_mocks=True, output_path=bright_mocks_dir
     )
 
-    dim_filepaths = glob.glob(os.path.join(dim_dir, "*"))  # use cached dim images
+    dim_filepaths = glob.glob(os.path.join(dim_dir, "*")) # use cached dim images
     dim_images = [Image(path) for path in dim_filepaths]
     combined_files = bright_images + dim_images
     combined_dataset = l2b_tol3.divide_by_exptime(Dataset(combined_files))
 
     results = nd_filter_calibration.create_nd_filter_cal(
-        combined_dataset, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS,
-        fluxcal_factor=None)
+        combined_dataset, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 
+        fluxcal_factor = None)
     ods = results.data
     avg_od = np.mean(ods[:, 0])
     assert abs(avg_od - test_od) < 0.2, (
@@ -511,7 +513,7 @@ def test_aperture_radius_sensitivity(stars_dataset_cached, aper_radius):
     ds_copy = copy.deepcopy(stars_dataset_cached)
     results = nd_filter_calibration.create_nd_filter_cal(
         ds_copy, OD_RASTER_THRESHOLD, "Aperture", "irr", phot_args, 
-        fluxcal_factor=None)
+        fluxcal_factor = None)
     ods = results.data
     avg_od = np.mean(ods[:, 0])
     assert abs(avg_od - INPUT_OD) < 0.3, (

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -605,7 +605,7 @@ def test_calculate_od_at_new_location(output_dir):
     ndcal_exthdr["FPAM_V"] = 0.0
     nd_sweetspot_dataset = NDFilterSweetSpotDataset(data_or_filepath=sweetspot_data, pri_hdr=ndcal_prihdr, ext_hdr=ndcal_exthdr,
                                                     input_dataset=fake_input_dataset)
- 
+
     # Create an identity transformation matrix FITS file in output_dir
     transformation_matrix_file = mock_transformation_matrix(output_dir)
 
@@ -630,7 +630,11 @@ def test_calculate_od_at_new_location(output_dir):
     # Bilinear interpolation of corners: (2,3,4,5) at center => 3.5
     expected_value = 3.5
     atol_nd = 1e-6
-    assert abs(interpolated_od - expected_value) < atol_nd, (
+    test_result_od_accuracy = abs(interpolated_od - expected_value) < atol_nd
+    print(f'calculate_od_at_new_location() estimates OD as {expected_value} +/- {atol_nd}: ', end='')
+    print_pass() if test_result_od_accuracy else print_fail()
+
+    assert test_result_od_accuracy, (
         f"Expected OD={expected_value}, got {interpolated_od}"
     )
     print('')

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -104,7 +104,7 @@ def is_real_positive_scalar(var):
 # ---------------------------------------------------------------------------
 # Functions to generate mocks
 # ---------------------------------------------------------------------------
-def mock_dim_dataset_files(dim_exptime, filter_used, cal_factor, save_mocks, output_path=None,
+def mock_dim_dataset_files(dim_exptime, filter_used, cal_factor, save_mocks, output_path=None, 
                            background_val=0, add_gauss_noise_val=False):
     """
     Generate and save mock dim dataset files for specified exposure time and filter.
@@ -272,7 +272,7 @@ def test_nd_filter_calibration_object(stars_dataset_cached):
     results = nd_filter_calibration.create_nd_filter_cal(
         ds_copy, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 
         fluxcal_factor = None)
-
+    
     results.save(filedir=default_cal_dir)
 
     nd_files = [fn for fn in os.listdir(default_cal_dir) if fn.endswith('_NDF_CAL.fits')]
@@ -314,7 +314,7 @@ def test_average_od_within_tolerance(stars_dataset_cached_bright_count):
     print("**Testing computed OD within tolerance**")
     ds_copy, n_bright = copy.deepcopy(stars_dataset_cached_bright_count)
     results = nd_filter_calibration.create_nd_filter_cal(
-        ds_copy, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS,
+        ds_copy, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 
         fluxcal_factor = None)
     ods = results.data
     avg_od = np.mean(ods[:, 0])
@@ -607,7 +607,7 @@ def test_calculate_od_at_new_location(output_dir):
     ndcal_exthdr["FPAM_V"] = 0.0
     nd_sweetspot_dataset = NDFilterSweetSpotDataset(data_or_filepath=sweetspot_data, pri_hdr=ndcal_prihdr, ext_hdr=ndcal_exthdr,
                                                     input_dataset=fake_input_dataset)
-
+ 
     # Create an identity transformation matrix FITS file in output_dir
     transformation_matrix_file = mock_transformation_matrix(output_dir)
 


### PR DESCRIPTION
## Describe your changes
- Adding print statements to several unit tests for Alignment and Calibration V&V.
- Adding some tests within the unit tests as needed, such as checking output array sizes.
- Only real functional change was switching from a 5% absolute to a 5% relative tolerance for a unit test on the core throughput estimate accuracy.

## Type of change

Please delete options that are not relevant (and this line).

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
None

## Checklist before requesting a review
- [X] I have linted my code...except for line too long, and (primarily) only in tests that I modified.
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed