### PR TITLE
Add .readthedocs.yml to develop branch

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
## Describe your changes
Added the .readthedocs.yaml configuration file to develop to enable documentation builds for the develop branch on Read the Docs.

## Type of change
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [x] I have filled out the Unit Test Definition Table on confluence, as needed