### PR TITLE
apply the DQ values added from detect_cosmic_rays to nonlin and kgain calibrations

### DIFF
--- a/corgidrp/calibrate_nonlin.py
+++ b/corgidrp/calibrate_nonlin.py
@@ -559,9 +559,9 @@ def calibrate_nonlin(dataset_nl,
                         frame_1 = frame_1.astype(np.float64)
         
                         # Subtract background
-                        frame_1_back1 = np.mean(frame_1[rowback1[0]:rowback1[-1]+1, 
+                        frame_1_back1 = np.nanmean(frame_1[rowback1[0]:rowback1[-1]+1, 
                                                         colback1[0]:colback1[-1]+1])
-                        frame_1_back2 = np.mean(frame_1[rowback2[0]:rowback2[-1]+1, 
+                        frame_1_back2 = np.nanmean(frame_1[rowback2[0]:rowback2[-1]+1, 
                                                         colback2[0]:colback2[-1]+1])
                         frame_back = (frame_1_back1 + frame_1_back2) / 2
         
@@ -573,13 +573,13 @@ def calibrate_nonlin(dataset_nl,
                         # Apply mask and calculate the positive mean
                         frame_mean0 *= mask
                         positive_means = frame_mean0[frame_mean0 > 0]
-                        frame_mean1 = np.mean(positive_means) if positive_means.size > 0 else np.nan
+                        frame_mean1 = np.nanmean(positive_means) if positive_means.size > 0 else np.nan
         
                         frame_count.append(frame_count0)
                         frame_mean.append(frame_mean1)
                         
                         mean_frame_index += 1
-                    mean_signal.append(np.mean(frame_mean))
+                    mean_signal.append(np.nanmean(frame_mean))
                 elif repeat_flag:
                     # for repeated exposure frames, split into the first half/set
                     # and the second half/set
@@ -590,9 +590,9 @@ def calibrate_nonlin(dataset_nl,
                         frame_1 = frame_1.astype(np.float64)
         
                         # Subtract background
-                        frame_1_back1 = np.mean(frame_1[rowback1[0]:rowback1[-1]+1, 
+                        frame_1_back1 = np.nanmean(frame_1[rowback1[0]:rowback1[-1]+1, 
                                                         colback1[0]:colback1[-1]+1])
-                        frame_1_back2 = np.mean(frame_1[rowback2[0]:rowback2[-1]+1, 
+                        frame_1_back2 = np.nanmean(frame_1[rowback2[0]:rowback2[-1]+1, 
                                                         colback2[0]:colback2[-1]+1])
                         frame_back = (frame_1_back1 + frame_1_back2) / 2
         
@@ -605,7 +605,7 @@ def calibrate_nonlin(dataset_nl,
                         # Apply mask and calculate the positive mean
                         frame_mean0 *= mask
                         positive_means = frame_mean0[frame_mean0 > 0]
-                        frame_mean1 = np.mean(positive_means) if positive_means.size > 0 else np.nan
+                        frame_mean1 = np.nanmean(positive_means) if positive_means.size > 0 else np.nan
                         
                         frame_count.append(frame_count0)
                         frame_mean.append(frame_mean1)
@@ -621,8 +621,8 @@ def calibrate_nonlin(dataset_nl,
                         frame_1 = frame_1.astype(np.float64)
         
                         # Subtract background
-                        frame_1_back1 = np.mean(frame_1[rowback1[0]:rowback1[-1]+1, colback1[0]:colback1[-1]+1])
-                        frame_1_back2 = np.mean(frame_1[rowback2[0]:rowback2[-1]+1, colback2[0]:colback2[-1]+1])
+                        frame_1_back1 = np.nanmean(frame_1[rowback1[0]:rowback1[-1]+1, colback1[0]:colback1[-1]+1])
+                        frame_1_back2 = np.nanmean(frame_1[rowback2[0]:rowback2[-1]+1, colback2[0]:colback2[-1]+1])
                         frame_back = (frame_1_back1 + frame_1_back2) / 2
         
                         # Calculate counts and mean
@@ -631,7 +631,7 @@ def calibrate_nonlin(dataset_nl,
                         frame_mean0 = frame_1 - frame_back
                         frame_mean0 *= mask
                         positive_means = frame_mean0[frame_mean0 > 0]
-                        frame_mean1 = np.mean(positive_means) if positive_means.size > 0 else np.nan
+                        frame_mean1 = np.nanmean(positive_means) if positive_means.size > 0 else np.nan
         
                         frame_count.append(frame_count0)
                         frame_mean.append(frame_mean1)
@@ -874,6 +874,8 @@ def nonlin_dataset_2_stack(dataset):
         len_cal_frames = 0
         record_gain = True 
         for frame in data_set.frames:
+            bad = np.where(frame.dq > 0)
+            frame.data[bad] = np.nan
             if frame.pri_hdr['OBSNAME'] == 'MNFRAME':
                 if record_exp_time:
                     exp_time_mean_frame = frame.ext_hdr['EXPTIME'] 

--- a/tests/test_kgain_cal.py
+++ b/tests/test_kgain_cal.py
@@ -108,6 +108,9 @@ def setup_module():
         image_sim.ext_hdr['DATETIME'] = time_stack_arr0[j]
         # Temporary keyword value. Mean frame is TBD
         image_sim.pri_hdr['OBSNAME'] = 'MNFRAME'
+        if j == 1:
+            #to test the correct handling of cosmic ray flags
+            image_sim.dq[500, 1200:1400] = 128
         frame_list.append(image_sim)
 
     index = 0
@@ -132,6 +135,9 @@ def setup_module():
             image_sim.ext_hdr['DATETIME'] = time_stack_arr0[t+j*exp_repeat_counts[j]]
             # OBSNAME has no KGAIN value, but NONLIN
             image_sim.pri_hdr['OBSNAME'] = 'NONLIN'
+            #to test the correct handling of cosmic ray flags
+            if t == 1:
+                image_sim.dq[500, 200:300] = 128
             frame_list.append(image_sim)
     dataset_kg = Dataset(frame_list)
 

--- a/tests/test_kgain_cal.py
+++ b/tests/test_kgain_cal.py
@@ -196,6 +196,7 @@ def test_binwidth():
         calibrate_kgain(dataset_kg, n_cal, n_mean, min_val, max_val, 9)
  
 if __name__ == '__main__':
+    setup_module()
     print('Running test_expected_results_sub')
     test_expected_results_sub()
     print('Running test_psi')

--- a/tests/test_nonlin_cal.py
+++ b/tests/test_nonlin_cal.py
@@ -102,6 +102,9 @@ def setup_module():
         image_sim.ext_hdr['DATETIME'] = time_stack_arr0[j]
         # Temporary keyword value. Mean frame is TBD
         image_sim.pri_hdr['OBSNAME'] = 'MNFRAME'
+        #to test the correct handling of cosmic ray flags
+        if j == 1:
+            image_sim.dq[400, 200:300] = 128
         frame_list.append(image_sim)
 
     init_nonlins = []
@@ -135,6 +138,9 @@ def setup_module():
                 image_sim = make_fluxmap_image(fluxMap4,bias,kgain,rn,g,t,coeffs,
                     nonlin_flag=nonlin_flag)
                 image_sim.ext_hdr['DATETIME'] = time_stack_test[idx_t]
+            #to test the correct handling of cosmic ray flags
+            if idx_t == 1:
+                image_sim.dq[400, 200:300] = 128
             image_sim.pri_hdr['OBSNAME'] = 'NONLIN'
             frame_list.append(image_sim)
     # Join all frames in a Dataset
@@ -335,6 +341,7 @@ def test_nonlin_params():
                         nonlin_params=nonlin_params_bad)
  
 if __name__ == '__main__':
+    setup_module()
     print('Running test_nonlin_params')
     test_nonlin_params()
     print('Running test_expected_results_nom_sub')


### PR DESCRIPTION
## Describe your changes
For kgain and nonlinearity calibration functions masked pixels from cosmic ray detection are set to NaN, most mean operations are changed to nanmean.

## Type of change

Please delete options that are not relevant (and this line).
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
#202 

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed