### PR TITLE
Teardown bugfix

### DIFF
--- a/tests/test_nonlin_cal.py
+++ b/tests/test_nonlin_cal.py
@@ -150,24 +150,6 @@ def setup_module():
     min_write = 800
     max_write = 10000
 
-def teardown_module():
-    """
-    Runs at the end. Deletes variables
-    """
-    global n_cal, n_mean
-    global init_nonlins_arr
-    global rms_test
-    global exp_time_stack_arr0, time_stack_arr0, len_list0, gain_arr0
-    global dataset_nl
-    global norm_val, min_write, max_write
-
-    del n_cal, n_mean
-    del init_nonlins_arr
-    del rms_test
-    del exp_time_stack_arr0, time_stack_arr0, len_list0, gain_arr0
-    del dataset_nl
-    del norm_val, min_write, max_write
-
 def test_expected_results_nom_sub():
     """Outputs are as expected for the provided frames with nominal arrays."""
     nonlin_out = calibrate_nonlin(dataset_nl, n_cal, n_mean, norm_val, min_write,
@@ -273,6 +255,24 @@ def test_expected_results_time_sub():
     assert np.less(rms2,rms_test)
     assert np.less(rms3,rms_test)
     assert np.less(rms4,rms_test)
+
+def teardown_module():
+    """
+    Runs at the end of tests; deletes variables
+    """
+    global n_cal, n_mean
+    global init_nonlins_arr
+    global rms_test
+    global exp_time_stack_arr0, time_stack_arr0, len_list0, gain_arr0
+    global dataset_nl
+    global norm_val, min_write, max_write
+
+    del n_cal, n_mean
+    del init_nonlins_arr
+    del rms_test
+    del exp_time_stack_arr0, time_stack_arr0, len_list0, gain_arr0
+    del dataset_nl
+    del norm_val, min_write, max_write
 
 def test_norm_val():
     """norm_val must be divisible by 20."""

--- a/tests/test_nonlin_cal.py
+++ b/tests/test_nonlin_cal.py
@@ -273,25 +273,6 @@ def test_expected_results_time_sub():
     assert np.less(rms2,rms_test)
     assert np.less(rms3,rms_test)
     assert np.less(rms4,rms_test)
-  
-
-def teardown_module():
-    """
-    Run at end of tests. Deletes variables
-
-    """
-    global n_cal, n_mean
-    global init_nonlins_arr
-    global rms_test
-    global exp_time_stack_arr0, time_stack_arr0, len_list0, gain_arr0
-    global dataset_nl
-
-    del n_cal, n_mean
-    del init_nonlins_arr
-    del rms_test
-    del exp_time_stack_arr0, time_stack_arr0, len_list0, gain_arr0
-    del dataset_nl
-
 
 def test_norm_val():
     """norm_val must be divisible by 20."""

--- a/tests/test_nonlin_cal.py
+++ b/tests/test_nonlin_cal.py
@@ -316,6 +316,8 @@ def test_nonlin_params():
                         nonlin_params=nonlin_params_bad)
  
 if __name__ == '__main__':
+    print('Running setup_module')
+    setup_module()
     print('Running test_nonlin_params')
     test_nonlin_params()
     print('Running test_expected_results_nom_sub')
@@ -330,4 +332,6 @@ if __name__ == '__main__':
     test_max_gt_min()
     print('Running test_psi')
     test_psi()
+    print('Running teardown_module')
+    teardown_module()
     print('Non-Linearity Calibration tests passed')


### PR DESCRIPTION
## Describe your changes

Fixed the issue described in #436, where test_nonlin_cal.py defined teardown_module() twice. The first definition was being overridden by the second definition, but the second definition did not delete all of the required variables. I have removed one of the definitions and ensured that all variables are deleted correctly by this module.

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)

test_nonlin_cal.py defines teardown_module() twice #436 

## Checklist before requesting a review
- [X] I have linted my code
- [X] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [X] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [X] I have filled out the Unit Test Definition Table on confluence, as needed