### PR TITLE
Filename correction in e2e tests

### DIFF
--- a/tests/e2e_tests/l2b_to_l4_e2e.py
+++ b/tests/e2e_tests/l2b_to_l4_e2e.py
@@ -84,14 +84,14 @@ def test_l2b_to_l3(e2edata_path, e2eoutput_path):
 
     #Read in the PSFs
     input_file = 'hlc_os11_frames_with_planets.fits'
-    input_hdul = fits.open(os.path.join(e2edata_path,"hcl_os11_v3",input_file))
+    input_hdul = fits.open(os.path.join(e2edata_path,"hlc_os11_v3",input_file))
     input_images = input_hdul[0].data
     header = input_hdul[0].header
     psf_center_x = header['XCENTER']
     psf_center_y = header['YCENTER']
     
     #Get the auxilliary data
-    data = np.loadtxt(os.path.join(e2edata_path,"hcl_os11_v3",'hlc_os11_batch_info.txt'), skiprows=2)
+    data = np.loadtxt(os.path.join(e2edata_path,"hlc_os11_v3",'hlc_os11_batch_info.txt'), skiprows=2)
     batch = data[:,0].astype(int)
     star = data[:,2].astype(int)
     roll = data[:,3]
@@ -391,7 +391,7 @@ if __name__ == "__main__":
 
 
     outputdir = thisfile_dir
-    #This folder should contain an OS11 folder: ""hcl_os11_v3" with the OS11 data in it.
+    #This folder should contain an OS11 folder: ""hlc_os11_v3" with the OS11 data in it.
     e2edata_dir = "/Users/maxmb/Data/corgi/corgidrp/" 
     #Not actually TVAC Data, but we can put it in the TVAC data folder. 
     ap = argparse.ArgumentParser(description="run the l2b->l4 end-to-end test")

--- a/tests/e2e_tests/l2b_to_l4_noncoron_e2e.py
+++ b/tests/e2e_tests/l2b_to_l4_noncoron_e2e.py
@@ -84,7 +84,7 @@ def test_l2b_to_l3(e2edata_path, e2eoutput_path):
 
     #Read in the PSFs
     input_file = 'hlc_os11_no_fpm.fits'
-    input_hdul = fits.open(os.path.join(e2edata_path, "hcl_os11_v3", input_file))
+    input_hdul = fits.open(os.path.join(e2edata_path, "hlc_os11_v3", input_file))
     input_image = input_hdul[0].data
     header = input_hdul[0].header
     # I think we work with (0,0) at the center of the pixel
@@ -300,7 +300,7 @@ if __name__ == "__main__":
 
 
     outputdir = thisfile_dir
-    #This folder should contain an OS11 folder: ""hcl_os11_v3" with the OS11 data in it.
+    #This folder should contain an OS11 folder: ""hlc_os11_v3" with the OS11 data in it.
     e2edata_dir = "/home/jwang/Desktop/CGI_TVAC_Data/" 
     #Not actually TVAC Data, but we can put it in the TVAC data folder. 
     ap = argparse.ArgumentParser(description="run the l2b->l4 end-to-end test")


### PR DESCRIPTION
## Describe your changes

Fixed the issue described in #424, where the filename of the OS11 data was hardcoded with a typo in some e2e tests.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)

Write hlc instead of hcl in l2b_to_l4_e2e tests #424 

## Checklist before requesting a review
- [X] I have linted my code
- [X] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [X] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [X] I have filled out the Unit Test Definition Table on confluence, as needed