### PR TITLE
Calspec

### DIFF
--- a/corgidrp/fluxcal.py
+++ b/corgidrp/fluxcal.py
@@ -40,6 +40,8 @@ calspec_url = 'https://archive.stsci.edu/hlsps/reference-atlases/cdbs/current_ca
 
 def get_calspec_file(star_name):
     """
+    look up the calspec fits file name in the names dict and look for 
+    the corresponding file in the .corgidrp/  calspec_data. If not available 
     download the corresponding CALSPEC fits file and return the file path
     
     Args:
@@ -125,19 +127,19 @@ def read_filter_curve(filter_filename):
     transmission = tab['%T'].data
     return lambda_nm * 10 , transmission/100.
 
-def read_cal_spec(calspec_filename, filter_wavelength):
+def read_cal_spec(calspec_file, filter_wavelength):
     """
     read the calspec flux density data interpolated on the wavelength grid of the transmission curve
     
     Args:
-        calspec_filename (str): file name of the CALSPEC fits file
+        calspec_file (str): file path to the CALSPEC fits file
         filter_wavelength (np.array): wavelength grid of the transmission curve in unit Angstroem
     
     Returns:
         np.array: flux density in Jy interpolated on the wavelength grid of the transmission curve 
         in CALSPEC units erg/(s * cm^2 * AA)
     """
-    hdulist = fits.open(calspec_filename)
+    hdulist = fits.open(calspec_file)
     data = hdulist[1].data
     hdulist.close()
     w = data['WAVELENGTH'] #wavelength in Angstroem
@@ -504,7 +506,7 @@ def calibrate_fluxcal_aper(dataset_or_image, calspec_file = None, flux_or_irr = 
     
     if calspec_file is not None:
         calspec_filepath = calspec_file
-        calspec_filename = calspec_file.split('/')[-1]
+        calspec_filename = os.path.basename(calspec_file)
     else:
         star_name = image.pri_hdr["TARGET"]
         calspec_filepath, calspec_filename = get_calspec_file(star_name)
@@ -608,7 +610,7 @@ def calibrate_fluxcal_gauss2d(dataset_or_image, calspec_file = None, flux_or_irr
     
     if calspec_file is not None:
         calspec_filepath = calspec_file
-        calspec_filename = calspec_file.split('/')[-1]
+        calspec_filename = os.path.basename(calspec_file)
     else:
         star_name = image.pri_hdr["TARGET"]
         calspec_filepath, calspec_filename = get_calspec_file(star_name)

--- a/corgidrp/l4_to_tda.py
+++ b/corgidrp/l4_to_tda.py
@@ -1,4 +1,5 @@
 # A file that holds the functions that transmogrify l4 data to TDA (Technical Demo Analysis) data 
+import os
 import numpy as np
 from astropy.io import fits
 from scipy.interpolate import interp1d
@@ -61,7 +62,7 @@ def determine_app_mag(input_data, source_star, scale_factor = 1.):
     
     if source_star.split(".")[-1] == "fits":
         source_filepath = source_star
-        source_filename = source_star.split('/')[-1]
+        source_filename = os.path.basename(source_star)
     else:
         source_filepath, source_filename = fluxcal.get_calspec_file(source_star)
     
@@ -112,12 +113,12 @@ def determine_color_cor(input_dataset, ref_star, source_star):
     # ref_star/source_star is either the star name or the file path to fits file
     if ref_star.split(".")[-1] == "fits":
         calspec_filepath = ref_star
-        calspec_ref_name = ref_star.split('/')[-1]
+        calspec_ref_name = os.path.basename(ref_star)
     else:
         calspec_filepath, calspec_ref_name = fluxcal.get_calspec_file(ref_star)
     if source_star.split(".")[-1] == "fits":
         source_filepath = source_star
-        source_filename = source_star.split('/')[-1]
+        source_filename = os.path.basename(source_star)
     else:
         source_filepath, source_filename = fluxcal.get_calspec_file(source_star)
     

--- a/corgidrp/l4_to_tda.py
+++ b/corgidrp/l4_to_tda.py
@@ -61,7 +61,7 @@ def determine_app_mag(input_data, source_star, scale_factor = 1.):
     
     if source_star.split(".")[-1] == "fits":
         source_filepath = source_star
-        source_filename = source_star
+        source_filename = source_star.split('/')[-1]
     else:
         source_filepath, source_filename = fluxcal.get_calspec_file(source_star)
     
@@ -112,12 +112,12 @@ def determine_color_cor(input_dataset, ref_star, source_star):
     # ref_star/source_star is either the star name or the file path to fits file
     if ref_star.split(".")[-1] == "fits":
         calspec_filepath = ref_star
-        calspec_ref_name = ref_star
+        calspec_ref_name = ref_star.split('/')[-1]
     else:
         calspec_filepath, calspec_ref_name = fluxcal.get_calspec_file(ref_star)
     if source_star.split(".")[-1] == "fits":
         source_filepath = source_star
-        source_filename = source_star
+        source_filename = source_star.split('/')[-1]
     else:
         source_filepath, source_filename = fluxcal.get_calspec_file(source_star)
     

--- a/corgidrp/nd_filter_calibration.py
+++ b/corgidrp/nd_filter_calibration.py
@@ -135,7 +135,7 @@ def compute_avg_calibration_factor(dim_stars_dataset, phot_method, calspec_files
     Parameters:
         dim_stars_dataset (iterable): Dataset containing dim star entries.
         phot_method (str): Photometry method to use ("Aperture" or "Gaussian").
-        calspec_files(list, optional): list of calspec filepaths
+        calspec_files (list, optional): list of calspec filepaths
         flux_or_irr (str): Whether flux ('flux') or in-band irradiance ('irr') should be used.
         phot_kwargs (dict, optional): Dictionary of keyword arguments to pass to calibrate_fluxcal_aper.
 
@@ -440,7 +440,7 @@ def create_nd_filter_cal(stars_dataset,
             (e.g., aper_phot).
         fluxcal_factor (corgidrp.Data.FluxcalFactor, optional): A pre-computed flux factor calibration product to use
             if dim stars are not included as part of the input dataset
-        calspec_files(iterable): list of calspec filepaths
+        calspec_files (list, optional): list of calspec filepaths
 
     Returns:
         sweet_spot_dataset (corgidrp.Data.NDFilterSweetSpotDataset): ND Filter calibration product for the dataset given

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -40,6 +40,7 @@ DIM_STARS = ['TYC 4424-1286-1',
 #DIM_STARS = ['TYC 4433-1800-1', 'TYC 4205-1677-1', 'TYC 4212-455-1', 'TYC 4209-1396-1',
 #            'TYC 4413-304-1', 'UCAC3 313-62260', 'BPS BS 17447-0067', 'TYC 4424-1286-1',
 #             'GSC 02581-02323', 'TYC 4207-219-1']
+calspec_filepath = os.path.join(os.path.dirname(__file__), "test_data", "alpha_lyr_stis_011.fits")
 
 DIM_EXPTIME = 10.0
 BRIGHT_EXPTIME = 5.0
@@ -167,11 +168,10 @@ def mock_bright_dataset_files(bright_exptime, filter_used, OD, cal_factor, save_
     ND_transmission = 10 ** (-OD)
     bright_star_images = []
     for star_name in BRIGHT_STARS:
+        bright_star_flux = nd_filter_calibration.compute_expected_band_irradiance(star_name, filter_used)
+        attenuated_flux = bright_star_flux * ND_transmission
         for dy in [-10, 0, 10]:
             for dx in [-10, 0, 10]:
-                bright_star_flux = nd_filter_calibration.compute_expected_band_irradiance(star_name, 
-                                                                                          filter_used)
-                attenuated_flux = bright_star_flux * ND_transmission
                 flux_image = mocks.create_flux_image(
                     attenuated_flux, FWHM, cal_factor, filter=filter_used, fpamname="ND225", target_name=star_name,
                     fsm_x=dx, fsm_y=dy, exptime=bright_exptime, filedir=output_path,
@@ -265,6 +265,34 @@ def output_dir(tmp_path):
 # ---------------------------------------------------------------------------
 # Test functions using pytest
 # ---------------------------------------------------------------------------
+def test_compute_exp_irrad():
+    print("**Testing calculation of same irradiance with star name and calspec file**")
+    name_irr = nd_filter_calibration.compute_expected_band_irradiance('Vega', '3C')
+    file_irr = nd_filter_calibration.compute_expected_band_irradiance(calspec_filepath, '3C')
+    assert file_irr == name_irr
+
+def test_nd_filter_calibration_object_with_calspec(bright_files_cached):
+    print("**Testing ND filter calibration object generation and expected headers with calspec file input**")
+    # don't want the datasets to get overwritten for subsequent tests
+    ds_copy = copy.deepcopy(Dataset([bright_files_cached[0], bright_files_cached[1]]))
+    ds_copy[1].ext_hdr["FPAMNAME"] = 'OPEN_12'
+    results = nd_filter_calibration.create_nd_filter_cal(
+        ds_copy, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 
+        fluxcal_factor = None, calspec_files = [calspec_filepath])
+    
+    results.save(filedir=default_cal_dir)
+
+    nd_files = [fn for fn in os.listdir(default_cal_dir) if fn.endswith('_NDF_CAL.fits')]
+    assert nd_files, "No NDFilterOD files were generated."
+    with fits.open(os.path.join(default_cal_dir, nd_files[0])) as hdul:
+        primary_hdr = hdul[0].header
+        ext_hdr = hdul[1].header
+        assert primary_hdr.get('SIMPLE') is True, "Primary header missing or SIMPLE not True."
+        assert ext_hdr.get('FPAMNAME') is not None, "Missing FPAMNAME keyword."
+        assert ext_hdr.get('FPAM_H') is not None, "Missing FPAM_H keyword."
+        assert ext_hdr.get('FPAM_V') is not None, "Missing FPAM_V keyword."
+        assert ext_hdr.get('CFAMNAME') is not None, "Missing CFAMNAME keyword."
+
 def test_nd_filter_calibration_object(stars_dataset_cached):
     print("**Testing ND filter calibration object generation and expected headers**")
     # don't want the datasets to get overwritten for subsequent tests
@@ -709,6 +737,8 @@ def main():
 
     print("\n========== BEGIN TESTS ==========")
 
+    run_test(test_compute_exp_irrad)
+    run_test(test_nd_filter_calibration_object_with_calspec, bright_files_cached)
     run_test(test_nd_filter_calibration_object, stars_dataset_cached)
     run_test(test_output_filename_convention, stars_dataset_cached)
     run_test(test_average_od_within_tolerance, stars_dataset_cached)


### PR DESCRIPTION
## Describe your changes
To reduce the number of internet downloads of calspec fits files for absolute flux calibration and nd filter calibration
an direct interface to input calspec fits files is added. To further reduce the priority of internet download, the .corgidrp/calspec_data directory is scanned for already available local calspec fits files. Additionally  a json file with the association of star name to fits file name is generated in the same directory which can be extended.

## Type of change
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
#418

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed