### PR TITLE
preserve DQ in photon counting and analog master dark creation

### DIFF
--- a/corgidrp/calibrate_kgain.py
+++ b/corgidrp/calibrate_kgain.py
@@ -874,7 +874,7 @@ def kgain_dataset_2_list(dataset, apply_dq = True):
                     raise Exception('Commanded EM gain must be >= 1')
                 em_gains.append(em_gain)
                 if record_gain:
-                    try: # if EM gain measured directly from frame TODO change hdr name if necessary
+                    try: # if EM gain measured directly from frame
                         gains.append(frame.ext_hdr['EMGAIN_M'])
                     except:
                         if frame.ext_hdr['EMGAIN_A'] > 0: # use applied EM gain if available

--- a/corgidrp/calibrate_nonlin.py
+++ b/corgidrp/calibrate_nonlin.py
@@ -904,7 +904,7 @@ def nonlin_dataset_2_stack(dataset, apply_dq = True):
                     raise Exception('DATETIME must be a string')
                 datetimes.append(datetime)
                 if record_gain:
-                    try: # if EM gain measured directly from frame TODO change hdr name if necessary
+                    try: # if EM gain measured directly from frame
                         gains.append(frame.ext_hdr['EMGAIN_M'])
                     except:
                         if frame.ext_hdr['EMGAIN_A'] > 0: # use applied EM gain if available

--- a/corgidrp/darks.py
+++ b/corgidrp/darks.py
@@ -218,15 +218,14 @@ def build_trad_dark(dataset, detector_params, detector_regions=None, full_frame=
     # the frames due to statistical variance
     masked_frames = np.ma.masked_array(frames, bpmaps)
     stat_std = np.ma.std(masked_frames, axis=0)/np.sqrt(unmasked_num)
-    # where the number of unmasked frames is 1, the std is 0, but we want error to increase as the number of usuable frames decreases, so fudge it a little:
+    stat_std = np.ma.getdata(stat_std)
     rows_one, cols_one = np.where(unmasked_num==1)
-    rows_normal, cols_normal = np.where(unmasked_num == len(dataset))
+    rows_normal, cols_normal = np.where(unmasked_num == unmasked_num.max())
+    if unmasked_num.max() <= 1: # this would virtually never happen
+        raise Exception('No pixels found to have more than 1 acceptable frame in a sub-stack.')
     # now pick a pixel from rows_normal and cols_normal to use as a reference for the approximated error for the pixels that have 1 unmasked frame, undo the division by sqrt(unmasked_num), and divide by 1
-    stat_std[rows_one, cols_one] = stat_std[rows_normal[0], cols_normal[0]] * np.sqrt(len(dataset))/1
+    stat_std[rows_one, cols_one] = stat_std[rows_normal[0], cols_normal[0]] * np.sqrt(unmasked_num.max())/1
     total_err = np.sqrt(mean_err**2 + stat_std**2)
-    # There are no masked pixels in total_err, and FITS can't save masked arrays,
-    # so turn it into a regular array
-    total_err = np.ma.getdata(total_err)
     # bitwise_or flag value for those that are masked all the way through for all
     # frames
     fittable_inds = np.where(combined_bpmap != 1)
@@ -260,11 +259,12 @@ def build_trad_dark(dataset, detector_params, detector_regions=None, full_frame=
 class CalDarksLSQException(Exception):
     """Exception class for calibrate_darks_lsq."""
 
-def calibrate_darks_lsq(dataset, detector_params, detector_regions=None):
+def calibrate_darks_lsq(dataset, detector_params, weighting=True, detector_regions=None):
     """The input dataset represents a collection of frame stacks of the
-    same number of dark frames (in e- units), where the stacks are for various
-    EM gain values and exposure times.  The frames in each stack should be
-    SCI full frames that:
+    (in e- units), where the stacks are for various
+    EM gain values and exposure times.  Stacks with fewer frames than other 
+    stacks are accordingly weighed less in the fit.  
+    The frames in each stack should be SCI full frames that:
 
     - have had their bias subtracted (assuming full frame)
     - have had masks made for cosmic rays
@@ -311,6 +311,12 @@ def calibrate_darks_lsq(dataset, detector_params, detector_regions=None):
         frames that will be used for photon counting.
     detector_params (corgidrp.data.DetectorParams):
         a calibration file storing detector calibration values
+    weighting (bool):
+        If True, weighting is used for the least squares fit, and the weighting
+        takes into account the err coming from the input frames, the statistical
+        variation among the supposedly identical frames in each sub-stack, and 
+        the effect of any DQ masking.  If False, all data is evenly weighted in 
+        the least squares fit.  Defaults to True.
     detector_regions (dict):
         a dictionary of detector geometry properties.  Keys should be as found
         in detector_areas in detector.py.
@@ -320,13 +326,12 @@ def calibrate_darks_lsq(dataset, detector_params, detector_regions=None):
     noise_maps : corgidrp.data.DetectorNoiseMaps instance
         Includes a 3-D stack of frames for the data, err, and the dq.
         input data: np.stack([FPN_map, CIC_map, DC_map])
-        input err:  np.stack([FPN_std_map, C_std_map_combo, DC_std_map])
-        FPN_std_map, C_std_map_combo, and DC_std_map contain the fitting error, but C_std_map_combo includes
-        also the statistical error across the frames and accounts for any err
-        content of the individual input frames.  We include it in the CIC part
-        since it will not be scaled by EM gain or exposure time when the master
-        dark is created.  In all the err, masked pixels are accounted for in
-        the calculations.
+        input err:  np.stack([FPN_std_map, C_std_map, DC_std_map])
+        FPN_std_map, C_std_map, and DC_std_map contain the fitting error.
+        In all the err, masked pixels are accounted for in
+        the calculations, and the err from the input frames, along with statistical 
+        error due to having fewer frames available per sub-stack due to any masking,
+        is used for weighting the data in the least squares fit.
         input dq:   np.stack([output_dq, output_dq, output_dq])
         The pixels that are masked for EVERY frame in all sub-stacks
         but 3 (or less) are assigned a flag value from the combination of the frames.
@@ -420,9 +425,6 @@ def calibrate_darks_lsq(dataset, detector_params, detector_regions=None):
         The standard deviation per pixel for the calibrated CIC.
     DC_std_map : array-like (full frame)
         The standard deviation per pixel for the calibrated dark current.
-    stacks_err : array-like (full frame)
-        Standard error per pixel coming from the frames in datasets used to
-        calibrate the noise maps.
     """
     if detector_regions is None:
             detector_regions = detector_areas
@@ -457,10 +459,9 @@ def calibrate_darks_lsq(dataset, detector_params, detector_regions=None):
             'which is the recommended number per sub-stack for an analog '
             'master dark')
         if i > 0:
-            if np.shape(datasets[i-1].all_data) != np.shape(datasets[i].all_data):
-                raise CalDarksLSQException('All sub-stacks must have the '
-                            'same number of frames and frame shape.')
-        try: # if EM gain measured directly from frame TODO change hdr name if necessary
+            if np.shape(datasets[i-1].all_data[1:]) != np.shape(datasets[i].all_data[1:]):
+                raise CalDarksLSQException('All sub-stacks must have the same frame shape.')
+        try: # if EM gain measured directly from frame
             EMgain_arr = np.append(EMgain_arr, datasets[i].frames[0].ext_hdr['EMGAIN_M'])
         except:
             if datasets[i].frames[0].ext_hdr['EMGAIN_A'] > 0: # use applied EM gain if available
@@ -494,15 +495,19 @@ def calibrate_darks_lsq(dataset, detector_params, detector_regions=None):
         # the frames due to statistical variance
         masked_frames = np.ma.masked_array(frames, bpmaps)
         stat_std = np.ma.std(masked_frames, axis=0)/np.sqrt(unmasked_num)
+        stat_std = np.ma.getdata(stat_std)
+        stat_std[telem_rows] = 1 # something non-zero; masked in the DQ anyways, and this assignment here prevents np.inf issues/warnings later
         # where the number of unmasked frames is 1, the std is 0, but we want error to increase as the number of usuable frames decreases, so fudge it a little:
         rows_one, cols_one = np.where(unmasked_num==1)
-        rows_normal, cols_normal = np.where(unmasked_num == len(datasets[i]))
+        zero_inds = np.where(unmasked_num==0)
+        if zero_inds[0].size != 0:
+            stat_std[zero_inds] = 1 # just assign as something non-zero; doesn't really matter b/c such pixels will be masked in the DQ; this will prevent warning outputs
+        rows_normal, cols_normal = np.where(unmasked_num == unmasked_num.max())
+        if unmasked_num.max() <= 1: # this would virtually never happen
+            raise Exception('No pixels found to have more than 1 acceptable frame in a sub-stack.')
         # now pick a pixel from rows_normal and cols_normal to use as a reference for the approximated error for the pixels that have 1 unmasked frame, undo the division by sqrt(unmasked_num), and divide by 1
-        stat_std[rows_one, cols_one] = stat_std[rows_normal[0], cols_normal[0]] * np.sqrt(len(datasets[i]))/1
+        stat_std[rows_one, cols_one] = stat_std[rows_normal[0], cols_normal[0]] * np.sqrt(unmasked_num.max())/1
         total_err = np.sqrt(mean_err**2 + stat_std**2)
-        # There are no masked pixels in total_err, and FITS can't save masked arrays,
-        # so turn it into a regular array
-        total_err = np.ma.getdata(total_err)
         pixel_mask = (unmasked_num < len(datasets[i].frames)/2).astype(int)
         mean_num = np.mean(unmasked_num)
         mean_frame[telem_rows] = np.nan
@@ -575,26 +580,36 @@ def calibrate_darks_lsq(dataset, detector_params, detector_regions=None):
     CIC_map = np.zeros_like(mean_stack[0])
     DC_map = np.zeros_like(mean_stack[0])
 
-    # input data error comes from .err arrays; could use this for error bars
-    # in input data for weighted least squares, but we'll just simply get the
-    # std error and add it in quadrature to least squares fit standard dev
-    stacks_err = np.sqrt(np.sum(mean_err_stack**2, axis=0)/np.sqrt(len(mean_err_stack)))
-
     # matrix to be used for least squares and covariance matrix
-    X = np.array([np.ones([len(EMgain_arr)]), EMgain_arr, EMgain_arr*exptime_arr]).T
-    mean_stack_Y = np.transpose(mean_stack, (2,0,1))
-    params_Y = np.linalg.pinv(X)@mean_stack_Y
+    # Create Xx with shape (M, 3, rows, cols), where M = len(EMgain_arr)
+    rows, cols = mean_stack.shape[1], mean_stack.shape[2]
+    X = np.array([np.ones([len(EMgain_arr)]).astype(float), EMgain_arr, EMgain_arr*exptime_arr]).T  # (M,3)
+    Xx = np.broadcast_to(X[:, :, None, None], (len(EMgain_arr), 3, rows, cols))
+    # weighting matrix; sub-stacks with few usable frames get a low weight
+    mean_err_stack[telem_rows] = 1 # instead of 0 to avoid inf weighting
+    if weighting:
+        W = 1/mean_err_stack
+    else:
+        W = np.ones_like(mean_err_stack) # all weighted the same
+    wY = W*mean_stack
+    wX = np.transpose(W*np.transpose(Xx, (1,0,2,3)), (1,0,2,3))
+    wXTwX = np.einsum('ji...,ik...',np.transpose(wX,(1,0,2,3)), wX)
+    wXTwXinv = np.linalg.inv(wXTwX)
+    pinv_wX = np.einsum('...ij,jk...', wXTwXinv, np.transpose(wX,(1,0,2,3)))
+    params_t = np.einsum('...ij,j...', pinv_wX, wY)
+    params = np.transpose(params_t,(2,0,1))
+    
     #next line: checked with KKT method for including bounds
     #actually, do this after determining everything else so that
     # bias_offset, etc is accurate
-    #params_Y[params_Y < 0] = 0
-    params = np.transpose(params_Y, (1,2,0))
+    #params_Y[params_Y < 0]= 0
     FPN_map = params[0]
     CIC_map = params[1]
     DC_map = params[2]
     # using chi squared for ordinary least squares (OLS) variance estiamate
     # This is OLS since the parameters to fit are linear in fit function
     # 3: number of fitted params
+    params_Y = np.transpose(params_t, (1,2,0))
     residual_stack = mean_stack - np.transpose(X@params_Y, (1,2,0))
     sigma2_frame = np.sum(residual_stack**2, axis=0)/(M - 3)
     # average sigma2 for image area and use that for all three vars since
@@ -645,10 +660,10 @@ def calibrate_darks_lsq(dataset, detector_params, detector_regions=None):
         # NOTE assume no error in g_arr values (or t_arr or k_arr)
         res = mean_stack[i] - EMgain_arr[i]*CIC_map - FPN_map - EMgain_arr[i]*exptime_arr[i]*DC_map
         # upper and lower bounds
-        res_up = ((mean_stack[i]+np.abs(stacks_err)) -
+        res_up = ((mean_stack[i]) -
                   EMgain_arr[i]*(CIC_map-CIC_std_map) - (FPN_map-FPN_std_map)
                   - EMgain_arr[i]*exptime_arr[i]*(DC_map-DC_std_map))
-        res_low = ((mean_stack[i]-np.abs(stacks_err)) -
+        res_low = ((mean_stack[i]) -
                    EMgain_arr[i]*(CIC_map+CIC_std_map) - (FPN_map+FPN_std_map)
                   - EMgain_arr[i]*exptime_arr[i]*(DC_map+DC_std_map))
         res_prescan = slice_section(res, 'SCI', 'prescan', detector_regions)
@@ -712,9 +727,6 @@ def calibrate_darks_lsq(dataset, detector_params, detector_regions=None):
     CIC_image_map[CIC_image_map < 0] = 0
     DC_image_map[DC_image_map < 0] = 0
 
-    # Since CIC will not be scaled by gain or exptime when master dark created
-    # using these noise maps, just bundle stacks_err in with C_std_map
-    C_std_map_combo = np.sqrt(CIC_std_map**2 + stacks_err**2)
     # assume headers from a dataset frame for headers of calibrated noise map
     prihdr = datasets[0].frames[0].pri_hdr
     exthdr = datasets[0].frames[0].ext_hdr
@@ -738,7 +750,7 @@ def calibrate_darks_lsq(dataset, detector_params, detector_regions=None):
     exthdr['B_O_UNIT'] = 'DN'
 
     input_stack = np.stack([FPN_map, CIC_map, DC_map])
-    input_err = np.stack([[FPN_std_map, C_std_map_combo, DC_std_map]])
+    input_err = np.stack([[FPN_std_map, CIC_std_map, DC_std_map]])
     input_dq = np.stack([output_dq, output_dq, output_dq])
 
     noise_maps = DetectorNoiseMaps(input_stack, prihdr.copy(), exthdr.copy(), dataset,
@@ -801,7 +813,7 @@ def build_synthesized_dark(dataset, noisemaps, detector_regions=None, full_frame
         _, unique_vals = dataset.split_dataset(exthdr_keywords=['EXPTIME', 'EMGAIN_C', 'KGAINPAR'])
         if len(unique_vals) > 1:
             raise Exception('Input dataset should contain frames of the same exposure time, commanded EM gain, and k gain.')
-        try: # use measured EM gain if available TODO change hdr name if necessary
+        try: # use measured EM gain if available
             g = dataset.frames[0].ext_hdr['EMGAIN_M']
         except:
             g = dataset.frames[0].ext_hdr['EMGAIN_A']

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -223,7 +223,7 @@ def detect_cosmic_rays(input_dataset, detector_params, k_gain = None, sat_thresh
         kgain = k_gain.value
     emgain_list = []
     for frame in crmasked_dataset:
-        try: # use measured gain if available TODO change hdr name if necessary
+        try: # use measured gain if available
             emgain = frame.ext_hdr['EMGAIN_M']
         except:
             if frame.ext_hdr['EMGAIN_A'] > 0: # use applied EM gain if available
@@ -308,7 +308,7 @@ def correct_nonlinearity(input_dataset, non_lin_correction, threshold=np.inf):
         raise ValueError("EM gain not found in header of input dataset. Non-linearity correction requires EM gain to be in header.")
 
     for i in range(linearized_cube.shape[0]):
-        try: # use measured gain if available TODO change hdr name if necessary
+        try: # use measured gain if available
             em_gain = linearized_dataset[i].ext_hdr["EMGAIN_M"]
         except:
             em_gain = linearized_dataset[i].ext_hdr["EMGAIN_A"]

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -19,7 +19,7 @@ def add_photon_noise(input_dataset):
     phot_noise_dataset = input_dataset.copy() # necessary at all?
 
     for i, frame in enumerate(phot_noise_dataset.frames):
-        try: # use measured gain if available TODO change hdr name if necessary
+        try: # use measured gain if available
             em_gain = phot_noise_dataset[i].ext_hdr["EMGAIN_M"]
         except:
             em_gain = frame.ext_hdr.get("EMGAIN_A", 0)
@@ -304,7 +304,7 @@ def em_gain_division(input_dataset):
     emgain_error = emgain_dataset.all_err
 
     for i in range(len(emgain_dataset)):
-        try: # use measured gain if available TODO change hdr name if necessary
+        try: # use measured gain if available
             emgain = emgain_dataset[i].ext_hdr["EMGAIN_M"]
         except:
             emgain = emgain_dataset[i].ext_hdr["EMGAIN_A"]

--- a/corgidrp/photon_counting.py
+++ b/corgidrp/photon_counting.py
@@ -199,7 +199,7 @@ def get_pc_mean(input_dataset, pc_master_dark=None, T_factor=None, pc_ecount_max
         if thresh < 0:
             raise PhotonCountException('thresh must be nonnegative')
         
-        if 'EMGAIN_M' in dataset.frames[0].ext_hdr: # if EM gain measured directly from frame TODO change hdr name if necessary
+        if 'EMGAIN_M' in dataset.frames[0].ext_hdr: # if EM gain measured directly from frame
             em_gain = dataset.frames[0].ext_hdr['EMGAIN_M']
         else:
             em_gain = dataset.frames[0].ext_hdr['EMGAIN_A']

--- a/corgidrp/photon_counting.py
+++ b/corgidrp/photon_counting.py
@@ -266,7 +266,9 @@ def get_pc_mean(input_dataset, pc_master_dark=None, T_factor=None, pc_ecount_max
         up = mean_expected_up +  pc_variance
         low = mean_expected_low -  pc_variance
         errs.append(np.max([up - mean_expected, mean_expected - low], axis=0))
-        dq = (nframes == 0).astype(int) 
+        good_inds = np.where(nframes != 0)
+        dq = np.bitwise_or.reduce(dataset.all_dq, axis=0)
+        dq[good_inds] = 0 
         pc_means.append(mean_expected)
         dqs.append(dq)
         
@@ -297,10 +299,10 @@ def get_pc_mean(input_dataset, pc_master_dark=None, T_factor=None, pc_ecount_max
             dark_sub = "no"
 
         # now subtract the dark PC mean
+        combined_dq = np.bitwise_or(dqs[0], dqs[1])
         combined_pc_mean = pc_means[0] - pc_means[1]
         combined_pc_mean[combined_pc_mean<0] = 0
         combined_err = np.sqrt(errs[0]**2 + errs[1]**2)
-        combined_dq = np.bitwise_or(dqs[0], dqs[1])
         pri_hdr = dataset[-1].pri_hdr.copy()
         ext_hdr = dataset[-1].ext_hdr.copy()
         err_hdr = dataset[-1].err_hdr.copy()

--- a/corgidrp/pump_trap_calibration.py
+++ b/corgidrp/pump_trap_calibration.py
@@ -3291,6 +3291,7 @@ def create_TrapCalibration_from_trap_dict(trap_dict,input_dataset):
     #Great the header from the first file
     first_file_pri_hdr = input_dataset[0].pri_hdr
     first_file_ext_hdr = input_dataset[0].ext_hdr
+    first_file_ext_hdr['BUNIT'] = 'N/A'
 
     trapcal = TrapCalibration(trap_cal_array,pri_hdr = first_file_pri_hdr, 
                     ext_hdr = first_file_ext_hdr, 

--- a/tests/e2e_tests/noisemap_cal_e2e.py
+++ b/tests/e2e_tests/noisemap_cal_e2e.py
@@ -209,8 +209,15 @@ def test_noisemap_calibration_from_l1(e2edata_path, e2eoutput_path):
     fix_headers_for_tvac(stack_arr_files)
 
     ####### Run the DRP walker
-    template = "l1_to_l2a_noisemap.json"
-    walker.walk_corgidrp(stack_arr_files, "", noisemap_outputdir,template=template)
+    #template = "l1_to_l2a_noisemap.json"
+    recipe = walker.autogen_recipe(stack_arr_files, noisemap_outputdir)
+    ### Modify a keyword
+    for step in recipe['steps']:
+        if step['name'] == "calibrate_darks":
+            step['keywords'] = {}
+            step['keywords']['weighting'] = False # to be comparable to II&T code, which does no weighting
+    walker.run_recipe(recipe, save_recipe_file=True)
+    #walker.walk_corgidrp(stack_arr_files, "", noisemap_outputdir,template=template)
 
     # clean up by removing entry
     this_caldb.remove_entry(kgain)
@@ -225,10 +232,10 @@ def test_noisemap_calibration_from_l1(e2edata_path, e2eoutput_path):
     # iit_noisemap_fname = os.path.join(iit_noisemap_datadir,"iit_test_noisemaps.fits")
     corgidrp_noisemap = data.autoload(corgidrp_noisemap_fname)
     
-    assert(np.nanmax(np.abs(corgidrp_noisemap.data[0]- F_map)) < 1e-11)
-    assert(np.nanmax(np.abs(corgidrp_noisemap.data[1]- C_map)) < 1e-11)
-    assert(np.nanmax(np.abs(corgidrp_noisemap.data[2]- D_map)) < 1e-11)
-    assert(np.abs(corgidrp_noisemap.ext_hdr['B_O']- bias_offset) < 1e-11)
+    assert(np.nanmax(np.abs(corgidrp_noisemap.data[0]- F_map)) < 3e-11)
+    assert(np.nanmax(np.abs(corgidrp_noisemap.data[1]- C_map)) < 3e-11)
+    assert(np.nanmax(np.abs(corgidrp_noisemap.data[2]- D_map)) < 3e-11)
+    assert(np.abs(corgidrp_noisemap.ext_hdr['B_O']- bias_offset) < 3e-11)
     pass
 
     this_caldb.remove_entry(corgidrp_noisemap)
@@ -401,8 +408,16 @@ def test_noisemap_calibration_from_l2a(e2edata_path, e2eoutput_path):
     set_obstype_for_darks(l2a_filepaths)
 
     ####### Run the DRP walker
-    template = "l2a_to_l2a_noisemap.json"
-    walker.walk_corgidrp(l2a_filepaths, "", noisemap_outputdir,template=template)
+    #template = "l2a_to_l2a_noisemap.json"
+    #walker.walk_corgidrp(l2a_filepaths, "", noisemap_outputdir,template=template)
+    recipe = walker.autogen_recipe(l2a_filepaths, noisemap_outputdir)
+    ### Modify a keyword
+    for step in recipe['steps']:
+        if step['name'] == "calibrate_darks":
+            step['keywords'] = {}
+            step['keywords']['weighting'] = False # to be comparable to II&T code, which does no weighting
+    walker.run_recipe(recipe, save_recipe_file=True)
+
 
     # getting output filename
     for f in os.listdir(noisemap_outputdir):
@@ -420,10 +435,10 @@ def test_noisemap_calibration_from_l2a(e2edata_path, e2eoutput_path):
     # iit_noisemap = data.autoload(iit_noisemap_fname)
     
 
-    assert(np.nanmax(np.abs(corgidrp_noisemap.data[0]- F_map)) < 1e-11)
-    assert(np.nanmax(np.abs(corgidrp_noisemap.data[1]- C_map)) < 1e-11)
-    assert(np.nanmax(np.abs(corgidrp_noisemap.data[2]- D_map)) < 1e-11)
-    assert(np.abs(corgidrp_noisemap.ext_hdr['B_O']- bias_offset) < 1e-11)
+    assert(np.nanmax(np.abs(corgidrp_noisemap.data[0]- F_map)) < 3e-11)
+    assert(np.nanmax(np.abs(corgidrp_noisemap.data[1]- C_map)) < 3e-11)
+    assert(np.nanmax(np.abs(corgidrp_noisemap.data[2]- D_map)) < 3e-11)
+    assert(np.abs(corgidrp_noisemap.ext_hdr['B_O']- bias_offset) < 3e-11)
     pass
 
     # create synthesized master dark in output folder (for inspection and for having a sample synthesized dark with all the right headers)

--- a/tests/test_calibrate_darks_lsq.py
+++ b/tests/test_calibrate_darks_lsq.py
@@ -67,88 +67,88 @@ warnings.filterwarnings('ignore', category=RuntimeWarning,
 
 def test_expected_results_sub():
     """Outputs are as expected, for smaller-sized frames."""
+    for weighting in [True, False]:
+        noise_maps = calibrate_darks_lsq(dataset, detector_params, weighting, dat)
+        F_image_map = imaging_slice('SCI', noise_maps.FPN_map, dat)
+        # F
+        assert (np.isclose(np.mean(F_image_map), FPN//eperdn*eperdn,
+                                    atol=FPN/5))
+        # No FPN was inserted in non-image areas (so that bias subtraction
+        #wouldn't simply remove it), so it should be 0 in prescan
+        F_prescan_map = slice_section(noise_maps.FPN_map, 'SCI', 'prescan', dat)
+        assert(np.isclose(np.nanmean(F_prescan_map), 0, atol=5))
+        # C
+        assert(np.isclose(np.nanmean(noise_maps.CIC_map), cic, atol=0.01))
+        assert(len(noise_maps.CIC_map[noise_maps.CIC_map < 0]) == 0)
+        # D
+        D_image_map = imaging_slice('SCI', noise_maps.DC_map, dat)
+        assert(np.isclose(np.mean(D_image_map),
+                        dark_current, atol=2e-4))
+        assert(len(noise_maps.DC_map[noise_maps.DC_map < 0]) == 0)
+        # D_map: 0 everywhere except image area
+        im_rows, im_cols, r0c0 = imaging_area_geom('SCI', dat)
+        # D_nonimg = D_map[~D_map[r0c0[0]:r0c0[0]+im_rows,
+        #             r0c0[1]:r0c0[1]+im_cols]]
+        D_map = noise_maps.DC_map.copy()
+        D_map[r0c0[0]:r0c0[0]+im_rows,
+                    r0c0[1]:r0c0[1]+im_cols] = 0
+        # now whole map should be 0
+        assert(np.nanmin(D_map) == 0)
+        if N == 30:
+            # bias_offset (tolerance of 5 for N=30 since I used a small number
+            # of frames for that dataset, especially for the high-gain ones)
+            assert(np.isclose(noise_maps.bias_offset, 0, atol=5)) #in DN
+        if N == 600:
+            assert(np.isclose(noise_maps.bias_offset, 0, atol=1)) #in DN
+        # dark current only in image area
+        D_std_map_im = noise_maps.DC_err[r0c0[0]:r0c0[0]+im_rows,
+                                    r0c0[1]:r0c0[1]+im_cols]
+        # assert that the std dev coming from the fit itself is < noise itself
+        assert(np.nanmean(D_std_map_im) < np.nanmean(D_image_map))
+        # noise_maps.CIC_err accounts for the err from the input frames and the
+        # statistical error (std dev across frames), so skip the assertion for CIC here
+        assert(np.nanmean(noise_maps.FPN_err) < np.nanmean(noise_maps.FPN_map))
 
-    noise_maps = calibrate_darks_lsq(dataset, detector_params, dat)
-    F_image_map = imaging_slice('SCI', noise_maps.FPN_map, dat)
-    # F
-    assert (np.isclose(np.mean(F_image_map), FPN//eperdn*eperdn,
-                                atol=FPN/5))
-    # No FPN was inserted in non-image areas (so that bias subtraction
-    #wouldn't simply remove it), so it should be 0 in prescan
-    F_prescan_map = slice_section(noise_maps.FPN_map, 'SCI', 'prescan', dat)
-    assert(np.isclose(np.nanmean(F_prescan_map), 0, atol=5))
-    # C
-    assert(np.isclose(np.nanmean(noise_maps.CIC_map), cic, atol=0.01))
-    assert(len(noise_maps.CIC_map[noise_maps.CIC_map < 0]) == 0)
-    # D
-    D_image_map = imaging_slice('SCI', noise_maps.DC_map, dat)
-    assert(np.isclose(np.mean(D_image_map),
-                    dark_current, atol=2e-4))
-    assert(len(noise_maps.DC_map[noise_maps.DC_map < 0]) == 0)
-    # D_map: 0 everywhere except image area
-    im_rows, im_cols, r0c0 = imaging_area_geom('SCI', dat)
-    # D_nonimg = D_map[~D_map[r0c0[0]:r0c0[0]+im_rows,
-    #             r0c0[1]:r0c0[1]+im_cols]]
-    D_map = noise_maps.DC_map.copy()
-    D_map[r0c0[0]:r0c0[0]+im_rows,
-                r0c0[1]:r0c0[1]+im_cols] = 0
-    # now whole map should be 0
-    assert(np.nanmin(D_map) == 0)
-    if N == 30:
-        # bias_offset (tolerance of 5 for N=30 since I used a small number
-        # of frames for that dataset, especially for the high-gain ones)
-        assert(np.isclose(noise_maps.bias_offset, 0, atol=5)) #in DN
-    if N == 600:
-        assert(np.isclose(noise_maps.bias_offset, 0, atol=1)) #in DN
-    # dark current only in image area
-    D_std_map_im = noise_maps.DC_err[r0c0[0]:r0c0[0]+im_rows,
-                                r0c0[1]:r0c0[1]+im_cols]
-    # assert that the std dev coming from the fit itself is < noise itself
-    assert(np.nanmean(D_std_map_im) < np.nanmean(D_image_map))
-    # noise_maps.CIC_err accounts for the err from the input frames and the
-    # statistical error (std dev across frames), so skip the assertion for CIC here
-    assert(np.nanmean(noise_maps.FPN_err) < np.nanmean(noise_maps.FPN_map))
+        # check the noisemap can be pickled (for CTC operations)
+        pickled = pickle.dumps(noise_maps)
+        pickled_noisemap = pickle.loads(pickled)
+        assert np.all((noise_maps.data == pickled_noisemap.data) | np.isnan(noise_maps.data))
 
-    # check the noisemap can be pickled (for CTC operations)
-    pickled = pickle.dumps(noise_maps)
-    pickled_noisemap = pickle.loads(pickled)
-    assert np.all((noise_maps.data == pickled_noisemap.data) | np.isnan(noise_maps.data))
+        # save noise map
+        calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
+        nm_filename = noise_maps.filename
+        if not os.path.exists(calibdir):
+            os.mkdir(calibdir)
+        noise_maps.save(filedir=calibdir, filename=nm_filename)
+        nm_filepath = os.path.join(calibdir, nm_filename)
+        nm_f = DetectorNoiseMaps(nm_filepath)
 
-    # save noise map
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
-    nm_filename = noise_maps.filename
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    noise_maps.save(filedir=calibdir, filename=nm_filename)
-    nm_filepath = os.path.join(calibdir, nm_filename)
-    nm_f = DetectorNoiseMaps(nm_filepath)
+        # check the noisemap can be pickled (for CTC operations)
+        pickled = pickle.dumps(nm_f)
+        pickled_noisemap = pickle.loads(pickled)
+        assert np.all((noise_maps.data == pickled_noisemap.data) | np.isnan(noise_maps.data))
 
-    # check the noisemap can be pickled (for CTC operations)
-    pickled = pickle.dumps(nm_f)
-    pickled_noisemap = pickle.loads(pickled)
-    assert np.all((noise_maps.data == pickled_noisemap.data) | np.isnan(noise_maps.data))
+        # tests the copy method, from filepath way of creating class
+        # instance, too
+        nm_open = nm_f.copy()
+        assert(np.array_equal(nm_open.data, noise_maps.data, equal_nan=True))
 
-    # tests the copy method, from filepath way of creating class
-    # instance, too
-    nm_open = nm_f.copy()
-    assert(np.array_equal(nm_open.data, noise_maps.data, equal_nan=True))
+        # check headers
+        assert(noise_maps.data.ndim == 3)
+        test_filename = dataset.frames[-1].filename.split('.fits')[0] + '_DNM_CAL.fits'
+        test_filename = re.sub('_L[0-9].', '', test_filename)
+        assert(noise_maps.filename == test_filename)
+        assert(noise_maps.ext_hdr["BUNIT"] == "Detected Electrons")
+        assert(noise_maps.err_hdr["BUNIT"] == "Detected Electrons")
+        assert("DetectorNoiseMaps" in str(noise_maps.ext_hdr["HISTORY"]))
+        assert(noise_maps.ext_hdr['B_O_UNIT'] == 'DN')
 
-    # check headers
-    assert(noise_maps.data.ndim == 3)
-    test_filename = dataset.frames[-1].filename.split('.fits')[0] + '_DNM_CAL.fits'
-    test_filename = re.sub('_L[0-9].', '', test_filename)
-    assert(noise_maps.filename == test_filename)
-    assert(noise_maps.ext_hdr["BUNIT"] == "Detected Electrons")
-    assert(noise_maps.err_hdr["BUNIT"] == "Detected Electrons")
-    assert("DetectorNoiseMaps" in str(noise_maps.ext_hdr["HISTORY"]))
-    assert(noise_maps.ext_hdr['B_O_UNIT'] == 'DN')
-
-    assert(nm_open.data.ndim == 3)
-    assert(nm_open.filename == test_filename)
-    assert(nm_open.ext_hdr["BUNIT"] == "Detected Electrons")
-    assert(nm_open.err_hdr["BUNIT"] == "Detected Electrons")
-    assert("DetectorNoiseMaps" in str(nm_open.ext_hdr["HISTORY"]))
-    assert(nm_open.ext_hdr['B_O_UNIT'] == 'DN')
+        assert(nm_open.data.ndim == 3)
+        assert(nm_open.filename == test_filename)
+        assert(nm_open.ext_hdr["BUNIT"] == "Detected Electrons")
+        assert(nm_open.err_hdr["BUNIT"] == "Detected Electrons")
+        assert("DetectorNoiseMaps" in str(nm_open.ext_hdr["HISTORY"]))
+        assert(nm_open.ext_hdr['B_O_UNIT'] == 'DN')
 
 def test_sub_stack_len():
     """datasets should have at least 4 sub-stacks."""
@@ -174,6 +174,7 @@ def test_g_gtr_1():
     data_set = dataset.copy()
     ds, _ = data_set.split_dataset(exthdr_keywords=['EXPTIME', 'EMGAIN_C', 'KGAINPAR'])
     ds[0].frames[0].ext_hdr['EMGAIN_C'] = 1
+    ds[0].frames[1].ext_hdr['EMGAIN_C'] = 1
     with pytest.raises(CalDarksLSQException):
         calibrate_darks_lsq(data_set, detector_params, dat)
 
@@ -192,6 +193,7 @@ def test_t_gtr_0():
     data_set = dataset.copy()
     ds, _ = data_set.split_dataset(exthdr_keywords=['EXPTIME', 'EMGAIN_C', 'KGAINPAR'])
     ds[0].frames[0].ext_hdr['EXPTIME'] = 0
+    ds[0].frames[1].ext_hdr['EXPTIME'] = 0
     with pytest.raises(CalDarksLSQException):
         calibrate_darks_lsq(data_set, detector_params, dat)
 
@@ -201,6 +203,7 @@ def test_k_gtr_0():
     data_set = dataset.copy()
     ds, _ = data_set.split_dataset(exthdr_keywords=['EXPTIME', 'EMGAIN_C', 'KGAINPAR'])
     ds[0].frames[0].ext_hdr['KGAINPAR'] = 0
+    ds[0].frames[1].ext_hdr['KGAINPAR'] = 0
     with pytest.raises(CalDarksLSQException):
         calibrate_darks_lsq(data_set, detector_params, dat)
 
@@ -229,19 +232,65 @@ def test_mean_num():
     # error for dark current at pixel (10,12) should be 0 since dark current only in the image area
     assert nm_out.err[0,2,10,12] == 0
 
+def test_weighting():
+    '''Test that weighting works:  High-err sub-stacks don't affect the fit much.'''
+    noise_maps = calibrate_darks_lsq(dataset, detector_params, dat)
+    CIC_image_map = imaging_slice('SCI', noise_maps.CIC_map, dat)
+    wrong_dataset = dataset.copy()
+    # Let the frames corresponding to 2 EM gain values (for all exposure time values) be erroneous. 
+    # The CIC should be noticeably off, and the check we did in test_expected_results_sub() should fail.
+    # Frames are arranged in sets of 30 with each set corresponding to (t1, g1), (t1, g2), ..., (t1, g7), (t2, g1), (t2, g2), .... 
+    # So we're changing all g6 and g7 sets to be erroneous.
+    s1 = 6
+    s2 = 7
+    for s in [s1, s2]:
+        for i in range(7):
+            wrong_dataset.all_data[int(7*30*i + s*30):int(7*30*i + s*30+30)] = wrong_dataset.all_data[int(7*30*i + s*30):int(7*30*i + s*30+30)]/6  
+    wrong_noise_maps = calibrate_darks_lsq(wrong_dataset, detector_params, dat)
+    wrong_CIC_image_map = imaging_slice('SCI', wrong_noise_maps.CIC_map, dat)
+    assert(not np.isclose(np.mean(CIC_image_map),
+                    np.mean(wrong_CIC_image_map), atol=0.01))
+    # make err for this sub-stack large, so weighting should make fit much better
+    for s in [s1, s2]:
+        for i in range(7):
+            wrong_dataset.all_err[int(7*30*i + s*30):int(7*30*i + s*30+30)] += 100000
+    wrong_noise_maps_err = calibrate_darks_lsq(wrong_dataset, detector_params, dat)
+    wrong_CIC_image_map_err = imaging_slice('SCI', wrong_noise_maps_err.CIC_map, dat)
+    assert(np.isclose(np.mean(CIC_image_map),
+                    np.mean(wrong_CIC_image_map_err), atol=0.01))
+    # and err should be reduced overall now too despite effectively having fewer stacks for fitting
+    assert(np.nanmean(wrong_noise_maps_err.CIC_err) > np.nanmean(wrong_noise_maps.CIC_err))
+    # This time, make err for this sub-stack large through dq (all but 1 frame in the sub-stack)
+    # (undo err adjustment I did above)
+    for s in [s1, s2]:
+        for i in range(7):
+            wrong_dataset.all_err[int(7*30*i + s*30):int(7*30*i + s*30+30)] -= 100000
+            wrong_dataset.all_dq[int(7*30*i + s*30):int(7*30*i + s*30+29), :, 1:] = 1 # leave one pixel unmasked so that the total masking Exception isn't raised
+    wrong_noise_maps_dq = calibrate_darks_lsq(wrong_dataset, detector_params, dat)
+    wrong_CIC_image_map_dq = imaging_slice('SCI', wrong_noise_maps_dq.CIC_map, dat)
+    # We artificially made err big above, which brought the mean CIC value much closer to the expected value.
+    # However, our leverage in weighting is much more limited when only the DQ is used to affect the weighting. (In reality, the 
+    # err should also be large if the data is in fact bad data.) 
+    # But the result is still a number closer to the correct value compared to the case where no appropriate weighting is used:
+    assert(np.abs(np.mean(CIC_image_map) - np.mean(wrong_CIC_image_map_dq)) < 
+           np.abs(np.mean(CIC_image_map) - np.mean(wrong_CIC_image_map)))
+    # and err should be reduced overall now too despite effectively having fewer stacks for fitting
+    assert(np.nanmean(wrong_noise_maps_dq.CIC_err) > np.nanmean(wrong_noise_maps.CIC_err))
+    
 
 if __name__ == '__main__':
     setup_module()
 
+    test_weighting()
     test_mean_num()
     test_expected_results_sub()
     test_sub_stack_len()
     test_g_arr_unique()
-    test_g_gtr_1()
     test_t_arr_unique()
+    test_g_gtr_1()
     test_t_gtr_0()
     test_k_gtr_0()
-
+    
     teardown_module()
 
 


### PR DESCRIPTION
## Describe your changes
DQ is now preserved in photon counting and analog master dark creation.  Sub-stacks can now have different numbers of frames for master dark creation, and this difference in sub-stack length is accounted for in weighting for the least squares fit, along with the frames' err and statistical variation. (Allowing for different numbers of frames in various sub-stacks is important according to recent con-ops I learned about from Guillermo.)  Also, the DQ flag of 256 that the original calibration introduced has been removed as it unnecessarily threw away data (albeit data with large error).

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
#444 , #178 

## Checklist before requesting a review
- [ ] I have linted my code
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed