### PR TITLE
x/ycent of templates: none handling in fit_psf_centroid

### DIFF
--- a/corgidrp/spec.py
+++ b/corgidrp/spec.py
@@ -221,6 +221,7 @@ def fit_psf_centroid(psf_data, psf_template,
     # Use the center of mass as a starting point if positions were not provided.
     if xcent_template is None or ycent_template is None: 
         xcom_template, ycom_template = np.rint(get_center_of_mass(psf_template))
+        xcent_template, ycent_template = xcom_template, ycom_template
     else:
         xcom_template, ycom_template = (np.rint(xcent_template), np.rint(ycent_template))
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -219,6 +219,16 @@ def test_psf_centroid():
     assert np.all(calibration_2.xfit_err == calibration_3.xfit_err)
     assert np.all(calibration_2.yfit_err == calibration_3.yfit_err)
     
+    # test None in x/ycent header of template file
+    temp_dataset[0].ext_hdr['XCENT'] = None
+    calibration_4 = steps.compute_psf_centroid(
+        dataset=dataset, template_dataset = temp_dataset, filtersweep = filtersweep
+    )
+    assert np.all(calibration_2.xfit - calibration_4.xfit < errortol_pix)
+    assert np.all(calibration_2.yfit - calibration_4.yfit < errortol_pix)
+    assert np.all(calibration_4.xfit_err < errortol_pix)
+    assert np.all(calibration_4.yfit_err < errortol_pix)
+        
 def test_dispersion_model():
     global disp_dict
 


### PR DESCRIPTION
## Describe your changes
assign a value to None x/ycent_template variables in fit_psf_centroid 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
#533

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed