### PR TITLE
PSF subtraction to include measured throughput at source location(s)

### DIFF
--- a/corgidrp/calibrate_nonlin.py
+++ b/corgidrp/calibrate_nonlin.py
@@ -9,7 +9,10 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 from scipy.interpolate import interp1d
 from statsmodels.nonparametric.smoothers_lowess import lowess
-from numpy.exceptions import RankWarning
+try:
+    from numpy.exceptions import RankWarning
+except:
+    from numpy import RankWarning
 
 from corgidrp import check
 import corgidrp.data as data

--- a/corgidrp/klip_fm.py
+++ b/corgidrp/klip_fm.py
@@ -195,7 +195,12 @@ def meas_klip_thrupt(sci_dataset_in,ref_dataset_in, # pre-psf-subtracted dataset
         np.array: array of shape (N,n_seps,2), where N is 1 + the number of KL mode truncation choices and n_seps 
         is the number of separations sampled. Index 0 contains the separations sampled, and each following index
         contains the dimensionless KLIP throughput and FWHM in pixels measured at each separation for each KL mode 
-        truncation choice.
+        truncation choice. An example for 4 KL mode truncation choices, using r1 and r2 for separations and n_seps=2: 
+            [ [[r1,r1],[r2,r2]], 
+            [[KL_thpt_r1_KL1, FWHM_r1_KL1],[KL_thpt_r2_KL1, FWHM_r2_KL1]], 
+            [[KL_thpt_r1_KL2, FWHM_r1_KL2],[KL_thpt_r2_KL2, FWHM_r2_KL2]], 
+            [[KL_thpt_r1_KL3, FWHM_r1_KL3],[KL_thpt_r2_KL3, FWHM_r2_KL3]], 
+            [[KL_thpt_r1_KL4, FWHM_r1_KL4],[KL_thpt_r2_KL4, FWHM_r2_KL4]] ]
     """
     
     if sci_dataset_in[0].ext_hdr['CFAMNAME'] == '1F':

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -510,6 +510,10 @@ def do_psf_subtraction(input_dataset,
                        kt_pas=None,
                        kt_snr=20.,
                        num_processes=None,
+                       source_psf=None,
+                       source_fwhm=2.8,
+                       source_nsigma_threshold=5.0,
+                       image_without_planet=None,
                        **klip_kwargs
                        ):
     
@@ -536,7 +540,8 @@ def do_psf_subtraction(input_dataset,
         crop_sizexy (list of int, optional): Desired size to crop the images to before PSF subtraction. Defaults to 
             None, which results in the step choosing a crop size based on the imaging mode. 
         measure_klip_thrupt (bool, optional): Whether to measure KLIP throughput via injection-recovery. Separations 
-            and throughput levels for each separation and KL mode are saved in Dataset[0].hdu_list['KL_THRU']. 
+            and throughput levels for each separation and KL mode are saved in Dataset[0].hdu_list['KL_THRU'], and the KL 
+            throughput for any sources found are stored in Dataset[0].hdu_list['KL_THRUS']. 
             Defaults to True.
         measure_1d_core_thrupt (bool, optional): Whether to measure the core throughput as a function of separation. 
             Separations and throughput levels for each separation are saved in Dataset[0].hdu_list['CT_THRU'].
@@ -550,6 +555,10 @@ def do_psf_subtraction(input_dataset,
             PSFs at each separation for KLIP throughput calibration. Defaults to [0.,90.,180.,270.].
         kt_snr (float, optional): SNR of fake signals to inject during KLIP throughput calibration. Defaults to 20.
         num_processes (int): number of processes for parallelizing the PSF subtraction
+        source_psf (ndarray, optional): The PSF used for source detection. If None, a Gaussian approximation is created.
+        source_fwhm (float, optional): Full-width at half-maximum of the source PSF in pixels.
+        source_nsigma_threshold (float, optional): The SNR threshold for source detection.
+        image_without_planet (ndarray, optional): An image without any sources (~noise map) to make snmap more accurate.
         klip_kwargs: Additional keyword arguments to be passed to pyKLIP fm.klip_dataset, as defined `here <https://pyklip.readthedocs.io/en/latest/pyklip.html#pyklip.fm.klip_dataset>`. 
             'mode', e.g. ADI/RDI/ADI+RDI, is chosen autonomously if not specified. 'annuli' defaults to 1. 'annuli_spacing' 
             defaults to 'constant'. 'subsections' defaults to 1. 'movement' defaults to 1. 'numbasis' defaults to [1,4,8,16].
@@ -699,16 +708,20 @@ def do_psf_subtraction(input_dataset,
 
         #Find the sources and get their positions
         klip_src_thpt_list = []
+        source_distances_list = []
+        angles_list = []
+        max_num_sources = 0
         for i in range(len(frame.data)):
             frame_copy = frame.copy()
             frame_copy.data = frame_copy.data[i]
-            psf_subtracted_image_with_source = find_source(frame_copy)
+            psf_subtracted_image_with_source = find_source(frame_copy, psf=source_psf, fwhm=source_fwhm, nsigma_threshold=source_nsigma_threshold,
+                image_without_planet=image_without_planet)
             source_header = psf_subtracted_image_with_source.ext_hdr
 
             snyx = np.array([list(map(float, source_header[key].split(','))) for key in source_header if key.startswith("SNYX")])
             xcen = psf_subtracted_image_with_source.ext_hdr['CRPIX1']
             ycen = psf_subtracted_image_with_source.ext_hdr['CRPIX2']
-            source_distances =np.sort(np.sqrt((snyx[:,1] - xcen)**2 + (snyx[:,2] - ycen)**2))
+            source_distances =np.sqrt((snyx[:,1] - xcen)**2 + (snyx[:,2] - ycen)**2)
             angles = np.arctan2((snyx[:,2] - ycen),(snyx[:,1] - xcen))*180/np.pi
             angles[angles<0] = 360 - angles[angles<0] # to get angles in [0,360] range instead of [-pi,pi]
             klip_src_thpt = meas_klip_thrupt(sci_dataset_masked,ref_dataset_masked, # pre-psf-subtracted dataset
@@ -721,9 +734,43 @@ def do_psf_subtraction(input_dataset,
                         pas=angles,
                         num_processes=num_processes
                         )
-            klip_src_thpt_list.append(klip_src_thpt)
+            if len(source_distances) > max_num_sources:
+                max_num_sources = len(source_distances)
+            klip_src_thpt_list.append(klip_src_thpt[1+i]) # just need the thpt at the sources for that particular KL mode truncation choice
+            source_distances_list.append(source_distances)
+            angles_list.append(angles)
             del frame_copy
+        source_thrupt_hdr = fits.Header()
+        source_thrupt_hdr['COMMENT'] = ('array of shape (KL_n,n_sources,4), where KL_n is the number of KL mode truncation choices and n_sources '
+            'is the maximum number of sources found out of all the KL mode truncation choices, and None is used to fill in the axis for number of sources '
+            'for KL modes that do have sources less than the maximum number of sources.  Here is an example for 4 KL mode truncation choices for which the '
+            'first one had the most found sources (2), where r is for separation (in pixels from the star center), '
+            'theta is for angle in degrees counterclockwise from north/up, thpt is for dimensionless KLIP throughput, and FWHM is the FWHM in pixels: '
+            '[ [[r_source1_KL1, theta_source1_KL1, thpt_source1_KL1, FWHM_source1_KL1], [r_source2_KL1, theta_source2_KL1, thpt_source2_KL1, FWHM_source2_KL1]], '
+            '  [[r_source1_KL2, theta_source1_KL2, thpt_source1_KL2, FWHM_source1_KL2], [None, None, None, None]], '
+            '  [[r_source1_KL3, theta_source1_KL3, thpt_source1_KL3, FWHM_source1_KL3], [None, None, None, None]], '
+            '  [[r_source1_KL4, theta_source1_KL4, thpt_source1_KL4, FWHM_source1_KL4], [None, None, None, None]] ]')
+        source_thrupt_hdr['UNITS'] = 'Separation: EXCAM pixels. Angle counterclockwise from north/up: degrees. KLIP throughput: values between 0 and 1. FWHM: EXCAM pixels'
+        source_klip_thpt = np.zeros((len(klip_src_thpt_list), max_num_sources, 4))
+        for kl in range(len(klip_src_thpt_list)): 
+            num_sources_kl = len(klip_src_thpt_list[kl])
+            for s in range(num_sources_kl):
+                source_klip_thpt[kl, s, 0] = source_distances_list[kl][s]
+                source_klip_thpt[kl, s, 1] = angles_list[kl][s]
+                source_klip_thpt[kl, s, 2] = klip_src_thpt_list[kl][s][0]
+                source_klip_thpt[kl, s, 3] = klip_src_thpt_list[kl][s][1]
+            for ss in range(num_sources_kl, max_num_sources):
+                source_klip_thpt[kl, ss, 0] = None
+                source_klip_thpt[kl, ss, 1] = None
+                source_klip_thpt[kl, ss, 2] = None
+                source_klip_thpt[kl, ss, 3] = None
+        source_thrupt_hdu_list = [fits.ImageHDU(data=source_klip_thpt, header=source_thrupt_hdr, name='KL_THRUS')]
+        dataset_out[0].hdu_list.extend(source_thrupt_hdu_list)
+        # Save throughput as an extension on the psf-subtracted Image
+        # Add history msg
+        source_history_msg = f'KLIP throughput measured at sources and saved to Image class HDU List extension "KL_THRUS".'
 
+        # now for KLIP throughput for general (or specified) separations and angles
         klip_thpt = meas_klip_thrupt(sci_dataset_masked,ref_dataset_masked, # pre-psf-subtracted dataset
                             dataset_out,
                             ct_calibration,
@@ -737,9 +784,18 @@ def do_psf_subtraction(input_dataset,
         thrupt_hdr = fits.Header()
         # Core throughput values on EXCAM wrt pixel (0,0) (not a "CT map", which is
         # wrt FPM's center 
-        thrupt_hdr['COMMENT'] = ('KLIP Throughput and retrieved FWHM as a function of separation for each KLMode '
-                                '(r, KL1, KL2, ...) = (data[0], data[1], data[2]). The last axis contains the'
-                                'KL throughput in the 0th index and the FWHM in the 1st index')
+        # thrupt_hdr['COMMENT'] = ('KLIP Throughput and retrieved FWHM as a function of separation for each KLMode '
+        #                         '(r, KL1, KL2, ...) = (data[0], data[1], data[2]). The last axis contains the'
+        #                         'KL throughput in the 0th index and the FWHM in the 1st index')
+        thrupt_hdr['COMMENT'] = ('array of shape (N,n_seps,2), where N is 1 + the number of KL mode truncation choices and n_seps '
+            'is the number of separations (in pixels from the star center) sampled. Index 0 contains the separations sampled (twice, to fill up the last axis of dimension 2), and each following index '
+            'contains the dimensionless KLIP throughput and FWHM in pixels measured at each separation for each KL mode '
+            'truncation choice. An example for 4 KL mode truncation choices, using r1 and r2 for separations and n_seps=2: '
+            '[ [[r1,r1],[r2,r2]], '
+            '[[KL_thpt_r1_KL1, FWHM_r1_KL1],[KL_thpt_r2_KL1, FWHM_r2_KL1]], '
+            '[[KL_thpt_r1_KL2, FWHM_r1_KL2],[KL_thpt_r2_KL2, FWHM_r2_KL2]], '
+            '[[KL_thpt_r1_KL3, FWHM_r1_KL3],[KL_thpt_r2_KL3, FWHM_r2_KL3]], '
+            '[[KL_thpt_r1_KL4, FWHM_r1_KL4],[KL_thpt_r2_KL4, FWHM_r2_KL4]] ]')
         thrupt_hdr['UNITS'] = 'Separation: EXCAM pixels. KLIP throughput: values between 0 and 1. FWHM: EXCAM pixels'
         thrupt_hdu_list = [fits.ImageHDU(data=klip_thpt, header=thrupt_hdr, name='KL_THRU')]
         
@@ -749,7 +805,7 @@ def do_psf_subtraction(input_dataset,
 
         # Add history msg
         history_msg = f'KLIP throughput measured and saved to Image class HDU List extension "KL_THRU".'
-        dataset_out.update_after_processing_step(history_msg)
+        dataset_out.update_after_processing_step(source_history_msg+history_msg)
 
     if measure_1d_core_thrupt:
         

--- a/corgidrp/l4_to_tda.py
+++ b/corgidrp/l4_to_tda.py
@@ -435,7 +435,7 @@ def update_to_tda(input_dataset):
 
 
 def find_source(input_image, psf=None, fwhm=2.8, nsigma_threshold=5.0,
-                image_without_planet=None, max_radius=None):
+                image_without_planet=None):
     """
     Detects sources in an image based on a specified SNR threshold and save their approximate pixel locations and SNRs into the header.
     
@@ -445,8 +445,6 @@ def find_source(input_image, psf=None, fwhm=2.8, nsigma_threshold=5.0,
         fwhm (float, optional): Full-width at half-maximum of the PSF in pixels.
         nsigma_threshold (float, optional): The SNR threshold for source detection.
         image_without_planet (ndarray, optional): An image without any sources (~noise map) to make snmap more accurate.
-        max_radius (float):  maximum distance in pixels from the center of the input_image data allowed for a potential source. 
-            Defaults to None, for which no maximum (besides the bounds of the input_image data) is enforced.
 
     Returns:
         corgidrp.data.Image: A copy of the input image with the detected sources and their SNRs saved in the header.
@@ -479,21 +477,15 @@ def find_source(input_image, psf=None, fwhm=2.8, nsigma_threshold=5.0,
     sn_source, xy_source = [], []
     x_center = new_image.ext_hdr['CRPIX1']
     y_center = new_image.ext_hdr['CRPIX2'] 
-    
+
     # Iteratively detect sources above the SNR threshold
     while np.nanmax(image_snmap) >= nsigma_threshold:
 
         sn = np.nanmax(image_snmap)
         xy = np.unravel_index(np.nanargmax(image_snmap), image_snmap.shape)
-        source_dist = np.sqrt((xy[0]-y_center)**2 + (xy[1]-x_center)**2)
         if sn > nsigma_threshold:
-            if max_radius is not None:
-                if source_dist <= max_radius: 
-                    sn_source.append(sn)
-                    xy_source.append(xy)
-            elif max_radius is None:
-                sn_source.append(sn)
-                xy_source.append(xy)
+            sn_source.append(sn)
+            xy_source.append(xy)
 
             # Scale and subtract the detected PSF from the image
             image_residual = psf_scalesub(image_residual, xy, psf, fwhm)

--- a/corgidrp/measure_companions.py
+++ b/corgidrp/measure_companions.py
@@ -56,7 +56,7 @@ def measure_companions(
             Defaults to the last KL mode.
         cand_locs (list of tuples, optional): Locations of known off-axis sources to measure flux. 
             Each tuple should be of the format (sep_pix, pa_degrees). If not, the function
-            will look in the header for detectios from l4_to_tda.find_source 
+            will look in the header for detections from l4_to_tda.find_source 
     
     Returns:
         result_table (astropy.table.Table): Table containing companion measurements.

--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -3634,7 +3634,7 @@ def create_psfsub_dataset(n_sci,n_ref,roll_angles,darkhole_scifiles=None,darkhol
     for i in range(n_sci+n_ref):
 
         # Create default headers
-        prihdr, exthdr = create_default_L1_headers()
+        prihdr, exthdr, errhdr, dqhdr = create_default_L3_headers()
         
         # Read in darkhole data, if provided
         if i<n_sci and not darkhole_scifiles is None:

--- a/tests/e2e_tests/l2b_to_l4_e2e.py
+++ b/tests/e2e_tests/l2b_to_l4_e2e.py
@@ -389,8 +389,8 @@ def test_l3_to_l4(e2eoutput_path):
     for i,source_distance in enumerate(expected_separations_pixels):
         assert np.isclose(source_distance, source_distances[i], atol=1)
     # check other HDU for the same info, using same KL mode truncation choice
-    source_dist1 = psf_subtracted_image[0].hdu_list['KL_THRUS'][-1][0,0]
-    source_dist2 = psf_subtracted_image[0].hdu_list['KL_THRUS'][-1][1,0]
+    source_dist1 = psf_subtracted_image.hdu_list['KL_THRUS'].data[-1][0,0]
+    source_dist2 = psf_subtracted_image.hdu_list['KL_THRUS'].data[-1][1,0]
     hdu_source_distances = np.sort([source_dist1, source_dist2])
     for i,source_distance in enumerate(expected_separations_pixels):
         assert np.isclose(source_distance, hdu_source_distances[i], atol=1)

--- a/tests/e2e_tests/l2b_to_l4_e2e.py
+++ b/tests/e2e_tests/l2b_to_l4_e2e.py
@@ -388,6 +388,12 @@ def test_l3_to_l4(e2eoutput_path):
     #Assumes that only the correct sources were detected. 
     for i,source_distance in enumerate(expected_separations_pixels):
         assert np.isclose(source_distance, source_distances[i], atol=1)
+    # check other HDU for the same info, using same KL mode truncation choice
+    source_dist1 = psf_subtracted_image[0].hdu_list['KL_THRUS'][-1][0,0]
+    source_dist2 = psf_subtracted_image[0].hdu_list['KL_THRUS'][-1][1,0]
+    hdu_source_distances = np.sort([source_dist1, source_dist2])
+    for i,source_distance in enumerate(expected_separations_pixels):
+        assert np.isclose(source_distance, hdu_source_distances[i], atol=1)
     print("Found all the sources!")
 
     #Check that the calibration filenames are appropriately associated

--- a/tests/e2e_tests/l2b_to_l4_e2e.py
+++ b/tests/e2e_tests/l2b_to_l4_e2e.py
@@ -425,5 +425,5 @@ if __name__ == "__main__":
     e2edata_dir = args.e2edata_dir
     outputdir = args.outputdir
 
-    test_l2b_to_l3(e2edata_dir, outputdir)
     test_l3_to_l4(outputdir)
+    test_l2b_to_l3(e2edata_dir, outputdir)

--- a/tests/test_find_source.py
+++ b/tests/test_find_source.py
@@ -207,6 +207,8 @@ def test_find_source(fwhm=2.8, nsigma_threshold=5.0):
         
         # Create input data with a simulated image and a sample header
         pri_hdr, _, errhdr, dqhdr = create_default_L3_headers()
+        input_dataset[0].ext_hdr['CRPIX1'] = image_copy.shape[1]/2
+        input_dataset[0].ext_hdr['CRPIX2'] = image_copy.shape[0]/2
         image_with_point_source = data.Image(image_copy,pri_hdr=pri_hdr,ext_hdr=input_dataset[0].ext_hdr)
         image_with_point_source.data = image_copy
 


### PR DESCRIPTION
## Describe your changes
I added a new HDU called 'KL_THRUS' which stores for each source found for each KL mode truncation choice the source distance, angle from north/up, KL throughput at source location, and FWHM.  There was no explicit test for the KL_THRU header (which stores the KL throughput at various distances), so I didn't add any tests of this new HDU to any test_*.py file, but I added an agreement check for it in l2b_to_l4_e2e.py.  

## Type of change
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
Issue #454 

## Checklist before requesting a review
- [ ] I have linted my code
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed