### PR TITLE
Update err and dq arrays in split by polarization step function

### DIFF
--- a/corgidrp/l2b_to_l3.py
+++ b/corgidrp/l2b_to_l3.py
@@ -221,7 +221,8 @@ def split_image_by_polarization_state(input_dataset,
         
         # construct new datacube for data, err, and dq
         im_data_new = np.zeros(shape=(2, image_size, image_size))
-        im_err_new = np.zeros(shape=(2, image_size, image_size))
+        # make sure to keep the additional dimension for err array
+        im_err_new = np.zeros(shape=(im_err.shape[0], 2, image_size, image_size))
         im_dq_new = np.zeros(shape=(2, image_size, image_size))
 
         # define coordinates
@@ -232,26 +233,26 @@ def split_image_by_polarization_state(input_dataset,
         y_right = y + start_right[1]
         # fill in the first dimension, corresponding to 0 or 45 degree polarization
         im_data_new[0,:,:] = im_data[start_left[1]:start_left[1] + image_size, start_left[0]:start_left[0] + image_size]
-        im_err_new[0,:,:] = im_err[start_left[1]:start_left[1] + image_size, start_left[0]:start_left[0] + image_size]
+        im_err_new[:,0,:,:] = im_err[:, start_left[1]:start_left[1] + image_size, start_left[0]:start_left[0] + image_size]
         im_dq_new[0,:,:] = im_dq[start_left[1]:start_left[1] + image_size, start_left[0]:start_left[0] + image_size]
         # fill in the second dimension, corresponding to the 90 or 135 degree polarization
         im_data_new[1,:,:] = im_data[start_right[1]:start_right[1] + image_size, start_right[0]:start_right[0] + image_size]
-        im_err_new[1,:,:] = im_err[start_right[1]:start_right[1] + image_size, start_right[0]:start_right[0] + image_size]
+        im_err_new[:,1,:,:] = im_err[:, start_right[1]:start_right[1] + image_size, start_right[0]:start_right[0] + image_size]
         im_dq_new[1,:,:] = im_dq[start_right[1]:start_right[1] + image_size, start_right[0]:start_right[0] + image_size]
         # mark anything on the other side of the center line dividing the two images as NaN to avoid including the other image
         if prism == 'POL0':
             im_data_new[0, x_left >= image_center_x] = np.nan
             im_data_new[1, x_right <= image_center_x] = np.nan
-            im_err_new[0, x_left >= image_center_x] = np.nan
-            im_err_new[1, x_right <= image_center_x] = np.nan
+            im_err_new[:, 0, x_left >= image_center_x] = np.nan
+            im_err_new[:, 1, x_right <= image_center_x] = np.nan
             # update dq with corresponding flag for bad pixel
             im_dq_new[0, x_left >= image_center_x] = 1
             im_dq_new[1, x_right <= image_center_x] = 1
         else:
             im_data_new[0, y_left - image_center_y <= x_left - image_center_x] = np.nan
             im_data_new[1, y_right - image_center_y >= x_right - image_center_x] = np.nan
-            im_err_new[0, y_left - image_center_y <= x_left - image_center_x] = np.nan
-            im_err_new[1, y_right - image_center_y >= x_right - image_center_x] = np.nan
+            im_err_new[:, 0, y_left - image_center_y <= x_left - image_center_x] = np.nan
+            im_err_new[:, 1, y_right - image_center_y >= x_right - image_center_x] = np.nan
             im_dq_new[0, y_left - image_center_y <= x_left - image_center_x] = 1
             im_dq_new[1, y_right - image_center_y >= x_right - image_center_x] = 1           
 

--- a/corgidrp/l2b_to_l3.py
+++ b/corgidrp/l2b_to_l3.py
@@ -185,6 +185,8 @@ def split_image_by_polarization_state(input_dataset,
     
     for image in updated_dataset:
         im_data = image.data
+        im_err = image.err
+        im_dq = image.dq
         image_y, image_x = im_data.shape
         prism = image.ext_hdr['DPAMNAME']
         # make sure input image is polarized
@@ -217,8 +219,10 @@ def split_image_by_polarization_state(input_dataset,
         or start_right[1] + image_size >= image_x or start_right[1] + image_size >= image_y:
             raise ValueError('Image bounds exceed that of the input data, please decrease the image size')
         
-        # construct new datacube
+        # construct new datacube for data, err, and dq
         im_data_new = np.zeros(shape=(2, image_size, image_size))
+        im_err_new = np.zeros(shape=(2, image_size, image_size))
+        im_dq_new = np.zeros(shape=(2, image_size, image_size))
 
         # define coordinates
         y, x = np.indices([image_size, image_size])
@@ -228,18 +232,33 @@ def split_image_by_polarization_state(input_dataset,
         y_right = y + start_right[1]
         # fill in the first dimension, corresponding to 0 or 45 degree polarization
         im_data_new[0,:,:] = im_data[start_left[1]:start_left[1] + image_size, start_left[0]:start_left[0] + image_size]
+        im_err_new[0,:,:] = im_err[start_left[1]:start_left[1] + image_size, start_left[0]:start_left[0] + image_size]
+        im_dq_new[0,:,:] = im_dq[start_left[1]:start_left[1] + image_size, start_left[0]:start_left[0] + image_size]
         # fill in the second dimension, corresponding to the 90 or 135 degree polarization
         im_data_new[1,:,:] = im_data[start_right[1]:start_right[1] + image_size, start_right[0]:start_right[0] + image_size]
+        im_err_new[1,:,:] = im_err[start_right[1]:start_right[1] + image_size, start_right[0]:start_right[0] + image_size]
+        im_dq_new[1,:,:] = im_dq[start_right[1]:start_right[1] + image_size, start_right[0]:start_right[0] + image_size]
         # mark anything on the other side of the center line dividing the two images as NaN to avoid including the other image
         if prism == 'POL0':
             im_data_new[0, x_left >= image_center_x] = np.nan
             im_data_new[1, x_right <= image_center_x] = np.nan
+            im_err_new[0, x_left >= image_center_x] = np.nan
+            im_err_new[1, x_right <= image_center_x] = np.nan
+            # update dq with corresponding flag for bad pixel
+            im_dq_new[0, x_left >= image_center_x] = 1
+            im_dq_new[1, x_right <= image_center_x] = 1
         else:
             im_data_new[0, y_left - image_center_y <= x_left - image_center_x] = np.nan
-            im_data_new[1, y_right - image_center_y >= x_right - image_center_x] = np.nan         
+            im_data_new[1, y_right - image_center_y >= x_right - image_center_x] = np.nan
+            im_err_new[0, y_left - image_center_y <= x_left - image_center_x] = np.nan
+            im_err_new[1, y_right - image_center_y >= x_right - image_center_x] = np.nan
+            im_dq_new[0, y_left - image_center_y <= x_left - image_center_x] = 1
+            im_dq_new[1, y_right - image_center_y >= x_right - image_center_x] = 1           
 
-        #update data
+        #update data, err, and dq
         image.data = im_data_new
+        image.err = im_err_new
+        image.dq = im_dq_new
 
     history_msg = 'images split by polarization state'
     updated_dataset.update_after_processing_step(history_msg)


### PR DESCRIPTION
## Describe your changes
- Fixed bug in split by polarization step function, err and dq arrays are now cropped and resized accordingly along with the data array. 
- Added new tests to ensure the output err and dq are of the right size and that the cropped fits files can be saved and loaded with no issues

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
#565 

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed