### PR TITLE
run e2e test with only 3D narrowband frames

### DIFF
--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -716,21 +716,25 @@ def determine_wave_zeropoint(input_dataset, template_dataset = None, xcent_guess
     # Assumed that only narrowband filter (includes sat spots) frames are taken to fit the zeropoint
     narrow_dataset, band = dataset.split_dataset(exthdr_keywords=["CFAMNAME"])
     band = np.array([s.upper() for s in band])
+    with_science = True
     if len(band) < 2:
-        raise AttributeError("there needs to be at least 1 narrowband and 1 science band prism frame in the dataset\
-                             to determine the wavelength zero point")
+        if "3D" not in band and "2C" not in band:
+            raise AttributeError("there needs to be at least 1 narrowband and 1 science band prism frame in the dataset\
+                                  to determine the wavelength zero point")
+        else:
+            with_science = False
+            warnings.warn("No science frames found in input dataset")
         
     if "3D" in band:
         sat_dataset = narrow_dataset[int(np.nonzero(band == "3D")[0].item())]
-        sci_dataset = narrow_dataset[int(np.nonzero(band != "3D")[0].item())]
+        if with_science:
+            sci_dataset = narrow_dataset[int(np.nonzero(band != "3D")[0].item())]
     elif "2C" in band:
         sat_dataset = narrow_dataset[int(np.nonzero(band == "2C")[0].item())]
-        sci_dataset = narrow_dataset[int(np.nonzero(band != "2C")[0].item())]
+        if with_science:
+            sci_dataset = narrow_dataset[int(np.nonzero(band != "2C")[0].item())]
     else:
         raise AttributeError("No narrowband frames found in input dataset")
-    
-    if len(sci_dataset) == 0:
-        raise AttributeError("No science frames found in input dataset")
     
     if xcent_guess is not None and ycent_guess is not None:
         n = len(sat_dataset)
@@ -754,7 +758,7 @@ def determine_wave_zeropoint(input_dataset, template_dataset = None, xcent_guess
         y0 = np.mean(spot_centroids.yfit) + (yoff_bb - yoff_nb)
     x0err = np.sqrt(np.sum(spot_centroids.xfit_err**2)/len(spot_centroids.xfit_err))
     y0err = np.sqrt(np.sum(spot_centroids.yfit_err**2)/len(spot_centroids.yfit_err))
-    if return_all:
+    if return_all or with_science == False:
         sci_dataset = dataset
 
     for frame in sci_dataset:

--- a/tests/e2e_tests/spec_linespread_e2e.py
+++ b/tests/e2e_tests/spec_linespread_e2e.py
@@ -57,43 +57,33 @@ def run_spec_linespread_e2e_test(e2edata_path, e2eoutput_path):
         
         # Load test data
         datadir = os.path.join(os.path.dirname(__file__), '../test_data/spectroscopy')
-        file_path_science = os.path.join(datadir, "g0v_vmag6_spc-spec_band3_unocc_CFAM3_R1C2SLIT_PRISM3_offset_array.fits")
         file_path_spot = os.path.join(datadir, "g0v_vmag6_spc-spec_band3_unocc_CFAM3d_R1C2SLIT_PRISM3_offset_array.fits")
 
-        assert os.path.exists(file_path_science), f'Test file not found: {file_path_science}'
         assert os.path.exists(file_path_spot), f'Test file not found: {file_path_spot}'
 
-        psf_array_science = fits.getdata(file_path_science, ext=0)
-        psf_array_spot = fits.getdata(file_path_spot, ext=0)[12]
-        
+        psf_array_spot = fits.getdata(file_path_spot, ext=0)
         # Create dataset with mock headers and noise
         pri_hdr, ext_hdr, errhdr, dqhdr, biashdr = create_default_L2b_headers()
         ext_hdr["DPAMNAME"] = 'PRISM3'
         ext_hdr["FSAMNAME"] = 'R1C2'
-        # add a fake satellite spot image from a small band simulation
-        image_spot = Image(psf_array_spot, pri_hdr = pri_hdr.copy(), ext_hdr = ext_hdr.copy(),
-                           err =np.zeros_like(psf_array_spot),
-                           dq=np.zeros_like(psf_array_spot, dtype=int))
-        image_spot.ext_hdr["CFAMNAME"] = "3D"
         # Add random noise for reproducibility
         np.random.seed(5)
         read_noise = 200
-        noisy_data_array = (np.random.poisson(np.abs(psf_array_science) / 2) + 
-                            np.random.normal(loc=0, scale=read_noise, size=psf_array_science.shape))
+        noisy_data_array = (np.random.poisson(np.abs(psf_array_spot) / 2) + 
+                            np.random.normal(loc=0, scale=read_noise, size=psf_array_spot.shape))
         
         # Create Image objects
         psf_images = []
-        for i in range(2):
-            image = Image(
+        for i in range(int(len(psf_array_spot)/2)):
+            image_spot = Image(
                 data_or_filepath=np.copy(noisy_data_array[i]),
                 pri_hdr=pri_hdr.copy(),
                 ext_hdr=ext_hdr.copy(),
                 err=np.zeros_like(noisy_data_array[i]),
                 dq=np.zeros_like(noisy_data_array[i], dtype=int)
             )
-            image.ext_hdr["CFAMNAME"] = "3"
-            psf_images.append(image)
-        psf_images.append(image_spot)
+            image_spot.ext_hdr["CFAMNAME"] = "3D"
+            psf_images.append(image_spot)
         
         # Save images to disk with timestamped filenames
         def get_formatted_filename(pri_hdr, dt, suffix="l2b"):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -515,9 +515,9 @@ def test_determine_zeropoint():
         )
         psf_images.append(image)
 
-    #test it as non-coronagraphic observation of only psf narrowband, so no science frames
+    #test it as non-coronagraphic observation of only psf narrowband, so no science frames, a warning should be raised
     input_dataset2 = Dataset(psf_images)
-    with pytest.raises(AttributeError):
+    with pytest.warns(UserWarning):
         dataset = l3_to_l4.determine_wave_zeropoint(input_dataset2)
     
     #only 1 fake science dataset frame


### PR DESCRIPTION
## Describe your changes
determine wavelength zero point can now handle datasets with only narrow band frames, raising only a warning, returning the frames as if science frames.
Also applied in e2e test spec_linespread_e2e.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
#568

## Checklist before requesting a review
- [x] I have linted my code
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [x] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed