### PR TITLE
cal_stokes_unocculted_#517 v1

### DIFF
--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -4634,8 +4634,8 @@ def create_mock_IQUV_image(n=64, m=64, fwhm=20, amp=1.0, pfrac=0.1, bg=0.0):
         dq_hdr=Header(),
     )
 
-def create_mock_stokes_image_l3(
-        image_size=256,
+def create_mock_polarization_l3_dataset(
+        image_size=1024,
         fwhm=100.0,
         I0=1e4,
         badpixel_fraction=1e-3,

--- a/corgidrp/pol.py
+++ b/corgidrp/pol.py
@@ -4,67 +4,85 @@ import numpy as np
 from corgidrp.data import Image
 from corgidrp.fluxcal import aper_phot
 
-def aper_phot_pol(ds, i, encircled_radius, pos):
+def aper_phot_pol(image, phot_kwargs):
     """
-    Perform aperture photometry on one channel of a 2-channel polarimetric image.
+    Perform aperture photometry on both channels of a 2-channel polarimetric image.
+
+    Each input image contains two orthogonally polarized beams (e.g., ordinary and extraordinary).
+    This function measures the flux and its uncertainty in both channels using aperture photometry.
 
     Args:
-        ds (Image): Polarimetric Image object with 2-channel data.
-        i (int): Channel index (0 or 1).
-        encircled_radius (float): Aperture radius in pixels.
-        pos (array_like): (y, x) coordinates of the aperture center.
+        image (Image): Polarimetric Image object with shape (2, ny, nx).
+            Must contain `data`, `err`, and `dq` attributes.
+        phot_kwargs (dict): Keyword arguments passed to `aper_phot`, defining
+            aperture radius, centering method, background subtraction, etc.
 
     Returns:
-        tuple: (flux, flux_err) measured in the aperture.
+        tuple[list, list]:
+            (flux, flux_err) lists of fluxes and uncertainties for both polarization channels.
     """
-    ds_copy = ds.copy()
-    ds_copy.data = ds_copy.data[i]
-    ds_copy.err = ds_copy.err[0][i].reshape(np.append([1], [ds_copy.data.shape]))
-    ds_copy.dq  = ds_copy.dq[i]
+    flux = []
+    flux_err = []
+    for i in range(2):
+        im_copy = image.copy()
+        im_copy.data = im_copy.data[i]
+        im_copy.err = im_copy.err[0][i].reshape(np.append([1], [im_copy.data.shape]))
+        im_copy.dq  = im_copy.dq[i]
 
-    return aper_phot(ds_copy, encircled_radius,
-                     centering_method='xy',
-                     centering_initial_guess=pos)
+        f, f_e = aper_phot(im_copy, **phot_kwargs)
+
+        flux.append(f)
+        flux_err.append(f_e)
+
+    return flux, flux_err
 
 def calc_stokes_unocculted(dataset,
-                           encircled_radius=3., pos=None,
-                           onskystokes=False):
+                           phot_kwargs=None,
+                           image_center_x=512, image_center_y=512):
     """
-    Compute the uncalibrated Stokes parameters (I, Q/I, U/I) from L3 polarimetric datacubes.
+    Compute uncalibrated Stokes parameters (I, Q/I, U/I) from unocculted L3 polarimetric datacubes.
 
-    Each dataset contains multiple images taken with particular Wollaston prisms
-    (e.g., POL0 or POL45). Each image has two analyzer orientations
-    (e.g., 0 and 90 degrees for POL0, 45 and 135 degrees for POL45). 
-    For each image and its roll angle, the function performs aperture photometry
-    on both channels and computes the uncalibrated Stokes parameters. 
-    The calculation can be done either as a simple left-right difference (instrument coordinates)
-    or using a weighted least-squares fit to account for sky rotation (sky coordinates).
+    Each element in `dataset` represents a single observation taken with a specific Wollaston prism
+    (e.g., POL0 or POL45), which splits the incoming light into two orthogonally polarized beams.
+    This function performs aperture photometry on each beam and computes the corresponding Stokes
+    parameters in the instrument frame.
 
     Args:
-        dataset (list of Image): List of L polarimetric datacubes. Each entry
-            must have `.data`, `.err`, and `.dq` arrays, and FITS headers with
-            keywords 'ROLL' and 'DPAMNAME'.
-        encircled_radius (float, optional): Aperture radius in pixels. Default is 3.0.
-        pos (array_like, optional): (y, x) coordinates of the aperture center.
-            Defaults to the center of the first image.
-        onskystokes (bool, optional): If True, compute Stokes in sky coordinates
-            using weighted least squares. If False, return instrument coordinates
-            (left-right difference).
+        dataset (list of Image):
+            List of L3 polarimetric images, each containing `.data`, `.err`, `.dq`, and FITS headers
+            with keywords 'ROLL' and 'DPAMNAME'.
+        phot_kwargs (dict, optional):
+            Keyword arguments passed to `aper_phot`. If not provided, a default aperture setup is used.
+        image_center_x (float, optional):
+            X-coordinate of the aperture center in pixels. Default is 512.
+        image_center_y (float, optional):
+            Y-coordinate of the aperture center in pixels. Default is 512.
 
     Returns:
-        Image: A `corgidrp.data.Image` instance containing:
-            - data (ndarray, shape=(3,)): [I, Q/I, U/I]
-            - err (ndarray, shape=(3,)): propagated uncertainties
-            - dq (ndarray, shape=(3,)): quality flags (zeros)
-            - pri_hdr, ext_hdr, err_hdr, dq_hdr: corresponding FITS headers
+        Image:
+            A `corgidrp.data.Image` instance containing:
+            - `data` (ndarray, shape=(3,)): [I, Q/I, U/I]
+            - `err`  (ndarray, shape=(3,)): propagated uncertainties
+            - `dq`   (ndarray, shape=(3,)): data quality flags (zeros)
+            - FITS headers (pri_hdr, ext_hdr, err_hdr, dq_hdr) propagated from the first input image.
 
     Raises:
-        ValueError: If an image has an unknown prism name.
+        ValueError:
+            If an input image contains an unrecognized prism name in 'DPAMNAME'.
     """
-
-    # --- Aperture setup ---
-    if pos is None:
-        pos = np.array(dataset[0].data.shape[1:]) / 2
+    # Ensure xy centering method is used with estimated centers for aperture photometry
+    if phot_kwargs is None:
+        phot_kwargs = {
+            'encircled_radius': 5,
+            'frac_enc_energy': 1.0,
+            'method': 'subpixel',
+            'subpixels': 5,
+            'background_sub': False,
+            'r_in': 5,
+            'r_out': 10,
+            'centroid_roi_radius': 5,
+            'centering_initial_guess': [image_center_x, image_center_y]
+        }
 
     prism_map = {'POL0': [0., 90.], 'POL45': [45., 135.]}
 
@@ -72,19 +90,16 @@ def calc_stokes_unocculted(dataset,
 
     # --- Photometry loop ---
     for ds in dataset:
-        roll = ds.pri_hdr.get('ROLL')
         prism = ds.ext_hdr.get('DPAMNAME')
         if prism not in prism_map:
             raise ValueError(f"Unknown prism: {prism}")
-
-        for i, phi in enumerate(prism_map[prism]):
-            flux, flux_err = aper_phot_pol(ds, i, encircled_radius, pos)
-            fluxes.append(flux)
-            flux_errs.append(flux_err)
-            if onskystokes:
-                thetas.append(np.radians(roll + phi))
-            else:
-                thetas.append(np.radians(phi))
+        
+        flux, flux_err = aper_phot_pol(ds, phot_kwargs)
+        fluxes.append(flux)
+        flux_errs.append(flux_err)
+        
+        for phi in prism_map[prism]:
+            thetas.append(np.radians(phi))
 
     fluxes = np.array(fluxes)
     flux_errs = np.array(flux_errs)
@@ -93,49 +108,38 @@ def calc_stokes_unocculted(dataset,
     # Prevent division by zero
     flux_errs[flux_errs == 0] = np.min(flux_errs[flux_errs > 0])
 
-    if onskystokes:
-        # --- Weighted least squares ---
-        A = np.vstack([np.ones_like(thetas),
-                       np.cos(2 * thetas),
-                       np.sin(2 * thetas)]).T
-        W = np.diag(1.0 / flux_errs**2)
-        cov = np.linalg.inv(A.T @ W @ A)
-        params = cov @ (A.T @ W @ fluxes)
-        I_val, Q_val, U_val = params
-        I_err, Q_err, U_err = np.sqrt(np.diag(cov))
+    # --- Instrument coordinates: left - right ---
+    n_images = len(dataset)
+    fluxes = fluxes.reshape([n_images, 2])
+    flux_errs = flux_errs.reshape([n_images, 2])
+    thetas = thetas.reshape([n_images, 2])
+    I_vals = np.sum(fluxes, axis=1)
+    I_errs = np.sqrt(np.sum(flux_errs**2, axis=1))
+        
+    QU_vals = fluxes[:,0] - fluxes[:,1]  # left - right
+        
+    # Weighted means across all prisms
+    wI = 1.0 / I_errs**2
+    I_val = np.sum(I_vals * wI) / np.sum(wI)
+    I_err = 1.0 / np.sqrt(np.sum(wI))
+
+    idx_0 = np.where(np.degrees(thetas[:,0]) == 0)[0]
+    if idx_0.size > 0:
+        Q_vals = QU_vals[idx_0]
+        Q_val = np.sum(Q_vals * wI[idx_0]) / np.sum(wI[idx_0])
+        Q_err = 1.0 / np.sqrt(np.sum(wI[idx_0]))
     else:
-        # --- Instrument coordinates: left - right ---
-        n_images = len(dataset)
-        fluxes = fluxes.reshape([n_images, 2])
-        flux_errs = flux_errs.reshape([n_images, 2])
-        thetas = thetas.reshape([n_images, 2])
-        I_vals = np.sum(fluxes, axis=1)
-        I_errs = np.sqrt(np.sum(flux_errs**2, axis=1))
-        
-        QU_vals = fluxes[:,0] - fluxes[:,1]  # left - right
-        
-        # Weighted means across all prisms
-        wI = 1.0 / I_errs**2
-        I_val = np.sum(I_vals * wI) / np.sum(wI)
-        I_err = 1.0 / np.sqrt(np.sum(wI))
+        Q_val = 0.
+        Q_err = 0.
 
-        idx_0 = np.where(np.degrees(thetas[:,0]) == 0)[0]
-        if idx_0.size > 0:
-            Q_vals = QU_vals[idx_0]
-            Q_val = np.sum(Q_vals * wI[idx_0]) / np.sum(wI[idx_0])
-            Q_err = 1.0 / np.sqrt(np.sum(wI[idx_0]))
-        else:
-            Q_val = 0.
-            Q_err = 0.
-
-        idx_45 = np.where(np.degrees(thetas[:,0]) == 45)[0]
-        if idx_45.size > 0:
-            U_vals = QU_vals[idx_45]
-            U_val = np.sum(U_vals * wI[idx_45]) / np.sum(wI[idx_45])
-            U_err = 1.0 / np.sqrt(np.sum(wI[idx_45]))
-        else:
-            U_val = 0.
-            U_err = 0.
+    idx_45 = np.where(np.degrees(thetas[:,0]) == 45)[0]
+    if idx_45.size > 0:
+        U_vals = QU_vals[idx_45]
+        U_val = np.sum(U_vals * wI[idx_45]) / np.sum(wI[idx_45])
+        U_err = 1.0 / np.sqrt(np.sum(wI[idx_45]))
+    else:
+        U_val = 0.
+        U_err = 0.
 
     # Fractional polarization
     Q_frac = Q_val / I_val

--- a/tests/test_polarimetry.py
+++ b/tests/test_polarimetry.py
@@ -207,12 +207,11 @@ def test_calc_stokes_unocculted(n_sim=100, nsigma_tol=3.):
     
     # prisms and rolls
     prisms = np.append(np.tile('POL0', n_repeat//2), np.tile('POL45', n_repeat//2))
-    #rolls = np.append(np.tile([-15, 15], n_repeat//4), np.tile([-15, 15], n_repeat//4)) ; onskystokes = True
-    rolls = np.full(n_repeat, 0) ; onskystokes = False
+    rolls = np.full(n_repeat, 0)
 
     for p, theta in zip(p_input, theta_input):
         # --- Generate mock L2b image ---
-        dataset_polmock = mocks.create_mock_stokes_image_l3(
+        dataset_polmock = mocks.create_mock_polarization_l3_dataset(
             I0=1e10,
             p=p,
             theta_deg=theta,
@@ -221,7 +220,7 @@ def test_calc_stokes_unocculted(n_sim=100, nsigma_tol=3.):
         )
 
         # --- Compute unocculted Stokes ---
-        Image_stokes_unocculted = calc_stokes_unocculted(dataset_polmock, onskystokes=onskystokes)
+        Image_stokes_unocculted = calc_stokes_unocculted(dataset_polmock)
 
         Q_obs = Image_stokes_unocculted.data[1]
         U_obs = Image_stokes_unocculted.data[2]


### PR DESCRIPTION
## Describe your changes

This PR adds `calc_stokes_unocculted`, a function that computes the Stokes vector (Q/I, U/I) from L3b polarimetric datacubes using aperture photometry, for unocculted polarimetric standard stars.

Key features:
- Handles different prism orientations (POL0, POL45) and telescope roll angles.
- Returns Stokes parameters with propagated errors.

A test is included:
- Generates mock polarimetric images using `create_mock_polimage`.
- Recovers polarization fractions (p) and verifies that the error is small.

## Type of change

Please delete options that are not relevant (and this line).

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)

#517

## Checklist before requesting a review
- [ ] I have linted my code
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [ ] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed