### PR TITLE
allow distortion correction to handle pol data

### DIFF
--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -95,64 +95,88 @@ def distortion_correction(input_dataset, astrom_calibration):
 
         im_data = undistorted_data.data
         im_err = undistorted_data.err
-        imgsizeX, imgsizeY = im_data.shape
+        is_pol_data = len(im_data.shape) == 3 and im_data.shape[0] == 2
+        num_iterations = 2 if is_pol_data else 1 #handle pol Image (2,1024,1024) so loop twice to correct both frames
+        undistorted_image_list = []
+        undistorted_errors_list = []
 
-        # set image size to the largest axis if not square imagea
-        imgsize = np.max([imgsizeX,imgsizeY])
+        for pol_idx in range(num_iterations):
+            # extract appropriate data slice
+            if is_pol_data:
+                im_data_single = im_data[pol_idx]
+                im_err_single = im_err[:, pol_idx]
+            else:
+                im_data_single = im_data
+                im_err_single = im_err
 
-        yorig, xorig = np.indices(im_data.shape)
-        y0, x0 = imgsize//2, imgsize//2
-        yorig -= y0
-        xorig -= x0
+            imgsizeX, imgsizeY = im_data_single.shape
 
-        ### compute the distortion map based on the calibration file passed in
-        fitparams = (distortion_order + 1)**2
+            # set image size to the largest axis if not square image
+            imgsize = np.max([imgsizeX, imgsizeY])
 
-            # reshape the coefficient arrays
-        x_params = distortion_coeffs[:fitparams]
-        x_params = x_params.reshape(distortion_order+1, distortion_order+1)
+            yorig, xorig = np.indices(im_data_single.shape)
+            y0, x0 = imgsize // 2, imgsize // 2
+            yorig -= y0
+            xorig -= x0
+            ### compute the distortion map based on the calibration file passed in
+            fitparams = (distortion_order + 1)**2
 
-        total_orders = np.arange(distortion_order+1)[:,None] + np.arange(distortion_order+1)[None,:]
-        x_params = x_params / 500**(total_orders)
+                # reshape the coefficient arrays
+            x_params = distortion_coeffs[:fitparams]
+            x_params = x_params.reshape(distortion_order+1, distortion_order+1)
 
-            # evaluate the legendre polynomial at all pixel positions
-        x_corr = np.polynomial.legendre.legval2d(xorig.ravel(), yorig.ravel(), x_params)
-        x_corr = x_corr.reshape(xorig.shape)
+            total_orders = np.arange(distortion_order+1)[:,None] + np.arange(distortion_order+1)[None,:]
+            x_params = x_params / 500**(total_orders)
 
-        distmapX = x_corr - xorig
+                # evaluate the legendre polynomial at all pixel positions
+            x_corr = np.polynomial.legendre.legval2d(xorig.ravel(), yorig.ravel(), x_params)
+            x_corr = x_corr.reshape(xorig.shape)
 
-            # reshape and evaluate the same way for the y coordinates
-        y_params = distortion_coeffs[fitparams:]
-        y_params = y_params.reshape(distortion_order+1, distortion_order+1)
-        y_params = y_params /500**(total_orders)
+            distmapX = x_corr - xorig
 
-        y_corr = np.polynomial.legendre.legval2d(xorig.ravel(), yorig.ravel(), y_params)
-        y_corr = y_corr.reshape(yorig.shape)
-        distmapY = y_corr - yorig
+                # reshape and evaluate the same way for the y coordinates
+            y_params = distortion_coeffs[fitparams:]
+            y_params = y_params.reshape(distortion_order+1, distortion_order+1)
+            y_params = y_params /500**(total_orders)
 
-        # apply the distortion grid to the image indeces and map the image
-        gridx, gridy = np.meshgrid(np.arange(imgsize), np.arange(imgsize))
-        gridx = gridx - distmapX
-        gridy = gridy - distmapY
-        
-        undistorted_image = scipy.ndimage.map_coordinates(im_data, [gridy, gridx])
-        
-        # undistort the errors
-        if len(im_err.shape) == 2:
-            undistorted_errors = scipy.ndimage.map_coordinates(im_err, [gridy, gridx])
+            y_corr = np.polynomial.legendre.legval2d(xorig.ravel(), yorig.ravel(), y_params)
+            y_corr = y_corr.reshape(yorig.shape)
+            distmapY = y_corr - yorig
+
+            # apply the distortion grid to the image indeces and map the image
+            gridx, gridy = np.meshgrid(np.arange(imgsize), np.arange(imgsize))
+            gridx = gridx - distmapX
+            gridy = gridy - distmapY
+
+            undistorted_image = scipy.ndimage.map_coordinates(im_data_single, [gridy, gridx])
+
+            # undistort the errors
+            if len(im_err_single.shape) == 2:
+                undistorted_errors = scipy.ndimage.map_coordinates(im_err_single, [gridy, gridx])
+            else:
+                undistorted_errors = []
+                for err in im_err_single:
+                    und_err = scipy.ndimage.map_coordinates(err, [gridy, gridx])
+                    undistorted_errors.append(und_err)
+
+            undistorted_image_list.append(undistorted_image)
+            undistorted_errors_list.append(undistorted_errors)
+        # stack results back now that individual frames are undistorted
+        if is_pol_data:
+            undistorted_image = np.stack(undistorted_image_list)    #shape (2,1024,1024)
+            undistorted_errors = [np.stack([undistorted_errors_list[0][i],
+                                             undistorted_errors_list[1][i]])
+                                  for i in range(len(undistorted_errors_list[0]))]  #shape (1,2,1024,1024)
         else:
-            undistorted_errors = []
-            for err in im_err:
-                und_err = scipy.ndimage.map_coordinates(err, [gridy, gridx])
-                
-                undistorted_errors.append(und_err)
-        
+            undistorted_image = undistorted_image_list[0] #shape (1024,1024)
+            undistorted_errors = undistorted_errors_list[0] #shape (1,1024,1024)
         undistorted_ims.append(undistorted_image)
         undistorted_errs.append(undistorted_errors)
-
     history_msg = 'Distortion correction completed'
 
-    undistorted_dataset.update_after_processing_step(history_msg, new_all_data=np.array(undistorted_ims), new_all_err=np.array(undistorted_errs))
+    undistorted_dataset.update_after_processing_step(history_msg, new_all_data=np.array(undistorted_ims),
+                                                       new_all_err=np.array(undistorted_errs))
+
 
     return undistorted_dataset
 

--- a/tests/test_distortion_correction.py
+++ b/tests/test_distortion_correction.py
@@ -38,9 +38,86 @@ def test_distortion_correction():
         assert np.nanmean(frame.data - ref_frame.data) == pytest.approx(0, abs=0.005)
         assert np.sum(np.isnan(frame.data)) == np.sum(np.isnan(ref_frame.data)) # to ensure no new bad pixels
         assert np.all(frame.dq == ref_frame.dq) # to ensure the bad pixel map didn't change
-        assert np.nanmean(frame.err - ref_frame.err) == pytest.approx(0, abs=0.00005) 
+        assert np.nanmean(frame.err - ref_frame.err) == pytest.approx(0, abs=0.00005)
 
+
+def test_distortion_correction_pol():
+    """
+    Unit test of the distortion correction function for polarization data.
+    Tests that the function can handle (2, 1024, 1024) input and return (2, 1024, 1024) output.
+    """
+
+    # Create a bad pixel map for testing
+    datashape = (2, 1024, 1024)  # pol data shape
+    bpixmap = np.zeros(datashape)
+
+    ## CREATE UNDISTORTED POL DATASET
+    field_path = os.path.join(os.path.dirname(__file__), "test_data", "JWST_CALFIELD2020.csv")
+    no_distortion_dataset_base = mocks.create_astrom_data(field_path, bpix_map=bpixmap[0], sim_err_map=True)
+
+    # Stack to create (2, 1024, 1024)
+    no_distortion_dataset_base.frames[0].data = np.stack([no_distortion_dataset_base.frames[0].data,
+                                                          no_distortion_dataset_base.frames[0].data])
+    original_err = no_distortion_dataset_base.frames[0].err
+    no_distortion_dataset_base.frames[0].err = np.stack([original_err, original_err], axis=1)
+    no_distortion_dataset_base.frames[0].dq = np.stack([no_distortion_dataset_base.frames[0].dq,
+                                                        no_distortion_dataset_base.frames[0].dq])
+    no_distortion_dataset_base.all_data = np.array([frame.data for frame in no_distortion_dataset_base.frames])
+    no_distortion_dataset_base.all_err = np.array([frame.err for frame in no_distortion_dataset_base.frames])
+    no_distortion_dataset_base.all_dq = np.array([frame.dq for frame in no_distortion_dataset_base.frames])
+
+    # CREATE DISTORTED POL DATASET
+    distortion_coeffs_path = os.path.join(os.path.dirname(__file__), "test_data", "distortion_expected_coeffs.csv")
+    distortion_coeffs = np.genfromtxt(distortion_coeffs_path)
+    distortion_dataset_base = mocks.create_astrom_data(field_path, distortion_coeffs_path=distortion_coeffs_path,
+                                                       bpix_map=bpixmap[0], sim_err_map=True)
+
+    # Stack to create (2, 1024, 1024)
+    distortion_dataset_base.frames[0].data = np.stack([distortion_dataset_base.frames[0].data,
+                                                       distortion_dataset_base.frames[0].data])
+    original_err = distortion_dataset_base.frames[0].err
+    distortion_dataset_base.frames[0].err = np.stack([original_err, original_err], axis=1)
+    distortion_dataset_base.frames[0].dq = np.stack([distortion_dataset_base.frames[0].dq,
+                                                     distortion_dataset_base.frames[0].dq])
+    distortion_dataset_base.all_data = np.array([frame.data for frame in distortion_dataset_base.frames])
+    distortion_dataset_base.all_err = np.array([frame.err for frame in distortion_dataset_base.frames])
+    distortion_dataset_base.all_dq = np.array([frame.dq for frame in distortion_dataset_base.frames])
+
+    # VERIFY INPUT SHAPE
+    assert distortion_dataset_base.frames[0].data.shape == (2, 1024, 1024)
+    # Create astrom cal
+    astromcal_data = np.concatenate((np.array([80.553428801, -69.514096821, 21.8, 45, 0, 0]), distortion_coeffs),
+                                    axis=0)
+    astrom_cal = data.AstrometricCalibration(astromcal_data,
+                                             pri_hdr=distortion_dataset_base[0].pri_hdr,
+                                             ext_hdr=distortion_dataset_base[0].ext_hdr,
+                                             input_dataset=distortion_dataset_base)
+
+    # CALL DISTORTION CORRECTION WITH (2, 1024, 1024) DATA
+    undistorted_dataset = distortion_correction(distortion_dataset_base, astrom_cal)
+    # VERIFY OUTPUT SHAPE
+    assert undistorted_dataset.frames[0].data.shape == (2, 1024, 1024), \
+        f"Expected output shape (2, 1024, 1024), got {undistorted_dataset.frames[0].data.shape}"
+
+    # NOW VERIFY EACH POL MODE IS BEING PROCESSED CORRECTED BY FUNCTION
+    for pol_idx in range(2):
+        # Data comparison
+        undistorted_pol = undistorted_dataset.frames[0].data[pol_idx]
+        reference_pol = no_distortion_dataset_base.frames[0].data[pol_idx]
+        diff_mean = np.nanmean(undistorted_pol - reference_pol)
+        assert diff_mean == pytest.approx(0, abs=0.005)  # mean difference should be ~0
+        assert np.sum(np.isnan(undistorted_pol)) == np.sum(np.isnan(reference_pol))  # no new bad pixels
+        # DQ comparison
+        undistorted_dq = undistorted_dataset.frames[0].dq[pol_idx]
+        reference_dq = no_distortion_dataset_base.frames[0].dq[pol_idx]
+        assert np.all(undistorted_dq == reference_dq)  # bad pixel map shouldn't change
+        # Error comparison
+        undistorted_err = undistorted_dataset.frames[0].err[:, pol_idx]
+        reference_err = no_distortion_dataset_base.frames[0].err[:, pol_idx]
+        err_diff_mean = np.nanmean(undistorted_err - reference_err)
+        assert err_diff_mean == pytest.approx(0, abs=0.00005)  # error mean difference should be ~0
 
 
 if __name__ == "__main__":
     test_distortion_correction()
+    test_distortion_correction_pol()


### PR DESCRIPTION
## Describe your changes

Handles issue #598. Distortion correction can now handle pol data shapes, which have Image shape of (2,1024,1024). This is checked and handled inside the function. Created a separate unit test function for this case. Saved FITS files to check that changes have been implemented to pol data.

## Type of change
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
[#598](https://github.com/roman-corgi/corgidrp/issues/598)

## Checklist before requesting a review
- [X] I have linted my code
- [X] I have verified that all unit tests pass in a clean environment and added new unit tests, as needed
- [X] I have verified that all docstrings are properly formatted and added new documentation, as needed
- [ ] I have filled out the Unit Test Definition Table on confluence, as needed