### PR TITLE
Unit tests for replace_bad_pixels on pol data

### DIFF
--- a/tests/test_badpixel_correction.py
+++ b/tests/test_badpixel_correction.py
@@ -293,7 +293,6 @@ def test_replace_bps_pol_4frames():
     if not cleaned_dataset.all_dq == pytest.approx(input_dataset_bad.all_dq):
         raise Exception("Output DQ array does not match input DQ array for pol uniform data.")
 
-    print("UT passed for pol data")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Describe your changes

Introduced two unit tests to replace_bad_pixels to check that it works on pol data (one with a single frame, another with two frames). Verified replace bad pixel returns occur as expected and shapes behave according to pol data expectations.

## Type of change

Please delete options that are not relevant (and this line).

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [X ] I have linted my code
- [X] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [ ] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
