### PR TITLE
Fix for Issue #636

### DIFF
--- a/tests/test_polarimetry.py
+++ b/tests/test_polarimetry.py
@@ -659,11 +659,12 @@ def test_calc_stokes_unocculted(n_sim=10, nsigma_tol=3.):
     """
 
     # Set the random seed for reproducibility
-    np.random.seed(42) 
+    rng_seed = 52
+    rng = np.random.default_rng(rng_seed)
 
     # --- Simulate varying polarization fractions ---
-    p_input = 0.1 + 0.2 * np.random.rand(n_sim)
-    theta_input = 10.0 + 20.0 * np.random.rand(n_sim)
+    p_input = 0.1 + 0.2 * rng.random(n_sim)
+    theta_input = 10.0 + 20.0 * rng.random(n_sim)
 
     Q_recovered = []
     Qerr_recovered = []
@@ -677,13 +678,15 @@ def test_calc_stokes_unocculted(n_sim=10, nsigma_tol=3.):
     rolls = np.full(n_repeat, 0)
 
     for p, theta in zip(p_input, theta_input):
+        new_seed = rng.integers(0, 1e6)
         # --- Generate mock L2b image ---
         dataset_polmock = mocks.create_mock_polarization_l3_dataset(
             I0=1e10,
             p=p,
             theta_deg=theta,
             roll_angles=rolls,
-            prisms=prisms
+            prisms=prisms, 
+            seed=new_seed
         )
 
         # --- Compute unocculted Stokes ---
@@ -736,7 +739,8 @@ def test_calc_stokes_unocculted(n_sim=10, nsigma_tol=3.):
         theta_deg=theta_target1,
         roll_angles=rolls,
         prisms=prisms, 
-        return_image_list=True
+        return_image_list=True,
+        seed= rng.integers(0, 1e6)
     )
     for img in dataset1_polmock_list:
         img.pri_hdr['TARGET'] = '1'
@@ -751,7 +755,8 @@ def test_calc_stokes_unocculted(n_sim=10, nsigma_tol=3.):
         theta_deg=theta_target2,
         roll_angles=rolls,
         prisms=prisms, 
-        return_image_list=True
+        return_image_list=True,
+        seed=rng.integers(0, 1e6)
     )
 
     #concatenate the lists
@@ -784,10 +789,10 @@ def test_calc_stokes_unocculted(n_sim=10, nsigma_tol=3.):
     return
 
 if __name__ == "__main__":
-    test_image_splitting()
-    test_calc_pol_p_and_pa_image()
-    test_subtract_stellar_polarization()
-    test_mueller_matrix_cal()
-    test_combine_polarization_states()
-    test_align_frames()
+    # test_image_splitting()
+    # test_calc_pol_p_and_pa_image()
+    # test_subtract_stellar_polarization()
+    # test_mueller_matrix_cal()
+    # test_combine_polarization_states()
+    # test_align_frames()
     test_calc_stokes_unocculted()


### PR DESCRIPTION
## Describe your changes
This PR fixes the bug identified in issue #636 - that test_polarimetry sometimes fails. This was due to how the test was framed - that the result was within 3-sigma of the expected value. Since it was random, on rare occasions this would fail. We thought this was fixed with a random seed, but it was being overwritten with a None in a lower level function. 

The fix here uses the first seed to generate a random number that acts as the seed to the second rng.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
Addresses Issue #636 
