### PR TITLE
Fix EACQ_ROW assignment to use psfcenty

### DIFF
--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -3876,7 +3876,7 @@ def create_psfsub_dataset(n_sci,n_ref,roll_angles,darkhole_scifiles=None,darkhol
         exthdr['STARLOCX'] = psfcentx
         exthdr['STARLOCY'] = psfcenty
         exthdr['EACQ_COL'] = psfcentx
-        exthdr['EACQ_ROW'] = psfcentx
+        exthdr['EACQ_ROW'] = psfcenty
         exthdr['PLTSCALE'] = pixscale # This is in milliarcseconds!
         exthdr["HIERARCH DATA_LEVEL"] = 'L3'
         


### PR DESCRIPTION
## Describe your changes

Replaced exthdr['EACQ_ROW'] = psfcentx by Replaced exthdr['EACQ_ROW'] = psfcenty

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)

#691 

## Checklist before requesting a review
- [ ] I have linted my code
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [ ] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
