### PR TITLE
FIx to improper cropping #683

### DIFF
--- a/tests/e2e_tests/l1_to_l3_spec_e2e.py
+++ b/tests/e2e_tests/l1_to_l3_spec_e2e.py
@@ -1,5 +1,5 @@
 import argparse
-import os
+import os, sys
 import json
 import pytest
 import numpy as np
@@ -48,9 +48,9 @@ def fix_headers(
             naxis2 = exthdr.get('NAXIS2', 1024)
             
             # Fix EACQ_ROW/COL if missing, 0, or outside frame bounds
-            if 'EACQ_ROW' not in exthdr or exthdr['EACQ_ROW'] == 0 or exthdr['EACQ_ROW'] >= naxis2:
+            if 'EACQ_ROW' not in exthdr or exthdr['EACQ_ROW'] == 0 or exthdr['EACQ_ROW'] >= naxis2 // 2:
                 exthdr['EACQ_ROW'] = naxis2 // 2
-            if 'EACQ_COL' not in exthdr or exthdr.get('EACQ_COL', 0) == 0 or exthdr.get('EACQ_COL', 0) >= naxis1:
+            if 'EACQ_COL' not in exthdr or exthdr.get('EACQ_COL', 0) == 0 or exthdr.get('EACQ_COL', 0) >= naxis1 // 2:
                 exthdr['EACQ_COL'] = naxis1 // 2
 
             # Set RN (read noise) if missing, empty, or not a number - only for L2a data (required for photon counting)
@@ -272,9 +272,18 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     # fix headers
     fix_headers(input_data_filelist)
 
+    ### Adhoc fix to extremely high exposure time (>100s) in satspot files, better fixes would involve using full-well capacity (fwc) instead
+    for file in input_data_filelist:
+        with fits.open(file, mode='update') as fits_file:
+            print(fits_file[1].header['EXPTIME'])
+            if fits_file[1].header['EXPTIME'] >= 100:
+                fits_file[1].data = fits_file[1].data/10.
+                fits_file[1].header['EXPTIME'] = fits_file[1].header['EXPTIME']/10.
+                print('Changed exposure time',fits_file[1].header['EXPTIME'])
+
     # Validate all input images
     input_dataset = data.Dataset(input_data_filelist)
-    
+
     for i, (frame, filepath) in enumerate(zip(input_dataset, input_data_filelist)):
         frame_info = f"L1 Input Frame {i}"
         
@@ -585,8 +594,9 @@ if __name__ == "__main__":
     # to edit the file. The arguments use the variables in this file as their
     # defaults allowing the use to edit the file if that is their preferred
     # workflow.
-    e2edata_dir = '/Users/maxwellmb/Data/corgi/corgidrp/e2e_test_data'#'/Users/jmilton/Documents/CGI/E2E_Test_Data2'
-    outputdir = " /Users/maxwellmb/Data/corgi/corgidrp/e2e_test_output/"
+    e2edata_dir = '/home/ababuraj/roman/E2E_Test_Data'#'/Users/jmilton/Documents/CGI/E2E_Test_Data2'
+    thisfile_dir = os.path.dirname(__file__)
+    outputdir = thisfile_dir
 
     ap = argparse.ArgumentParser(description="run the l1->l3 spectroscopy end-to-end test with recipe chaining")
     ap.add_argument("-tvac", "--e2edata_dir", default=e2edata_dir,


### PR DESCRIPTION
Improper cropping in the e2e test is fixed. Also implemented an ad-hoc fix to the satspot files, where exposure times >100s were leading to saturated regions in satspot file L3 outputs.

## Describe your changes


## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
