### PR TITLE
Remove engineering recipe for l1->l2a

### DIFF
--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -308,10 +308,10 @@ def guess_template(dataset):
         if 'VISTYPE' not in image.pri_hdr:
             # this is probably IIT test data. Do generic processing
             recipe_filename = "l1_to_l2b.json"
-        elif image.pri_hdr['VISTYPE'][:11] == "CGIVST_ENG_":
-            # if this is an ENG calibration visit
-            # for either pupil or image
-            recipe_filename = "l1_to_l2a_eng.json"
+        # elif image.pri_hdr['VISTYPE'][:11] == "CGIVST_ENG_":
+        #     # if this is an ENG calibration visit
+        #     # for either pupil or image
+        #     recipe_filename = "l1_to_l2a_eng.json"
         elif image.pri_hdr['VISTYPE'] == "CGIVST_CAL_BORESIGHT":
             recipe_filename = ["l1_to_l2a_basic.json", "l2a_to_l2b.json", 'l2b_to_boresight.json'] #"l1_to_boresight.json"
             chained = True


### PR DESCRIPTION
## Describe your changes
The old engineering recipe processes L1 -> L2a but saves the entire 2200x1200 frame. It sounds like we don't ever actually want this. We generally only care about L1 engineering data or L2b engineering data. By removing this logic, engineering data should flow like all other science data through L2b. 

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
