### PR TITLE
Add nsigma scaling and small sample statistics correction to contrast curves

### DIFF
--- a/corgidrp/l4_to_tda.py
+++ b/corgidrp/l4_to_tda.py
@@ -750,7 +750,7 @@ def compute_flux_ratio_noise(input_dataset, NDcalibration, unocculted_star_datas
         hdr['SSCORR'] = (small_sample_correction, "Mawet+2014 small sample correction applied")
         hdr['COMMENT'] = "Flux ratio noise curve as a function of radial separation.  First row:  separation radii in pixels.  Second row:  separation radii in mas.  Remaining rows:  flux ratio noise curve values for KL mode truncations."
         frame.add_extension_hdu('FRN_CRV', data = flux_ratio_noise_curve, header=hdr)
-        history_msg = 'Calibrated flux ratio noise curve added to extension header FRN_CRV.'
+        history_msg = 'Calibrated {0}-sigma flux ratio noise curve added to extension header FRN_CRV (small_sample_correction={1}).'.format(nsigma, small_sample_correction)
     output_dataset.update_after_processing_step(history_msg)
     return output_dataset
 

--- a/corgidrp/l4_to_tda.py
+++ b/corgidrp/l4_to_tda.py
@@ -750,7 +750,7 @@ def compute_flux_ratio_noise(input_dataset, NDcalibration, unocculted_star_datas
         hdr['SSCORR'] = (small_sample_correction, "Mawet+2014 small sample correction applied")
         hdr['COMMENT'] = "Flux ratio noise curve as a function of radial separation.  First row:  separation radii in pixels.  Second row:  separation radii in mas.  Remaining rows:  flux ratio noise curve values for KL mode truncations."
         frame.add_extension_hdu('FRN_CRV', data = flux_ratio_noise_curve, header=hdr)
-        history_msg = 'Calibrated {0}-sigma flux ratio noise curve added to extension header FRN_CRV (small_sample_correction={1}).'.format(nsigma, small_sample_correction)
+        history_msg = 'Added FRN_CRV (nsigma={0}, small_sample_correction={1}).'.format(nsigma, small_sample_correction)
     output_dataset.update_after_processing_step(history_msg)
     return output_dataset
 

--- a/tests/test_flux_ratio_noise_curve.py
+++ b/tests/test_flux_ratio_noise_curve.py
@@ -509,17 +509,28 @@ def test_expected_flux_ratio_noise_pol():
 
 
 def test_flux_ratio_noise_nsigma_and_correction():
-    """Tests nsigma passthrough and small sample correction in compute_flux_ratio_noise."""
+    """Integration test for nsigma and small sample correction through the full
+    compute_flux_ratio_noise pipeline.
 
-    # Set up a minimal RDI dataset (same setup as test_expected_flux_ratio_noise)
+    Unlike test_measure_noise_nsigma_and_correction (which tests measure_noise
+    directly with synthetic noise), this test runs the full pipeline:
+      do_psf_subtraction -> compute_flux_ratio_noise
+    with mock coronagraphic data, unocculted star, and ND calibration to verify
+    that nsigma and the Mawet correction propagate correctly through the entire
+    flux ratio noise curve computation.
+    """
+
+    # --- Setup: create mock RDI coronagraphic data ---
+    # RDI (Reference Differential Imaging) uses a separate reference star observation
+    # to subtract the stellar PSF. We create 1 science frame and 1 reference frame.
     mode = 'RDI'
     nsci, nref = (1, 1)
 
-    st_amp = 100.
-    noise_amp = 1e-3
-    pl_contrast = 0.
+    st_amp = 100.       # star amplitude in the coronagraphic images
+    noise_amp = 1e-3    # background noise level
+    pl_contrast = 0.    # no planet injected — we're only measuring noise
     rolls = [0, 15., 0, 0]
-    numbasis = [1]
+    numbasis = [1]      # use 1 KL mode for KLIP subtraction
     data_shape = (101, 101)
     mock_sci_rdi, mock_ref_rdi = create_psfsub_dataset(nsci, nref, rolls,
                                             fwhm_pix=fwhm_pix,
@@ -528,12 +539,15 @@ def test_flux_ratio_noise_nsigma_and_correction():
                                             pl_contrast=pl_contrast,
                                             data_shape=data_shape)
 
+    # Core throughput calibration (how much planet flux the coronagraph transmits)
     nx, ny = (21, 21)
     cenx, ceny = (25., 30.)
     ctcal = create_ct_cal(fwhm_mas, cfam_name='1F',
                   cenx=cenx, ceny=ceny,
                   nx=nx, ny=ny)
 
+    # Run PSF subtraction with KLIP, measuring both algorithm and core throughputs
+    # so that the output frames carry KL_THRU and CT_THRU extensions.
     from corgidrp.l3_to_l4 import do_psf_subtraction
     klip_kwargs = {'numbasis': numbasis}
     psfsub_dataset_rdi = do_psf_subtraction(mock_sci_rdi, ctcal,
@@ -543,7 +557,10 @@ def test_flux_ratio_noise_nsigma_and_correction():
                                 measure_1d_core_thrupt=True,
                                 **klip_kwargs)
 
-    # Make unocculted star
+    # --- Create a synthetic unocculted star image ---
+    # This simulates an observation of the same star without the coronagraph mask,
+    # used to measure the total stellar flux (Fs). We model it as a 2D Gaussian
+    # with Poisson noise added for realism.
     x = np.arange(psfsub_dataset_rdi[0].data.shape[-1])
     y = np.arange(psfsub_dataset_rdi[0].data.shape[-2])
     X, Y = np.meshgrid(x, y)
@@ -563,7 +580,10 @@ def test_flux_ratio_noise_nsigma_and_correction():
     prihdr, exthdr, errhdr, dqhdr = create_default_L4_headers()
     star_image = data.Image(star_PSF, prihdr, exthdr)
     star_dataset = data.Dataset([star_image for i in range(len(psfsub_dataset_rdi))])
-    # Fake ND calibration
+
+    # --- Create a fake ND filter calibration ---
+    # The unocculted star is observed through a neutral density filter to avoid
+    # saturation. We use a nearly transparent ND (OD=1e-2) for simplicity.
     nd_x, nd_y = np.meshgrid(np.linspace(0, data_shape[1], 5), np.linspace(0, data_shape[0], 5))
     nd_x = nd_x.ravel()
     nd_y = nd_y.ravel()
@@ -572,15 +592,20 @@ def test_flux_ratio_noise_nsigma_and_correction():
     nd_cal = data.NDFilterSweetSpotDataset(np.array([nd_od, nd_x, nd_y]).T, pri_hdr=pri_hdr,
                                       ext_hdr=ext_hdr)
 
-    # 1. nsigma passthrough: FRN with nsigma=5 should be 5x the nsigma=1 values
+    # --- Test 1: nsigma passthrough ---
+    # The nsigma parameter flows through compute_flux_ratio_noise -> measure_noise.
+    # Without small sample correction, the flux ratio noise curve should scale linearly
+    # with nsigma, so FRN(5σ) = 5 × FRN(1σ) exactly.
     frn_1sig = compute_flux_ratio_noise(psfsub_dataset_rdi, nd_cal, star_dataset, halfwidth=3, nsigma=1)
     frn_5sig = compute_flux_ratio_noise(psfsub_dataset_rdi, nd_cal, star_dataset, halfwidth=3, nsigma=5)
     for f1, f5 in zip(frn_1sig, frn_5sig):
-        vals_1 = f1.hdu_list['FRN_CRV'].data[2:]  # skip sep rows
+        vals_1 = f1.hdu_list['FRN_CRV'].data[2:]  # rows 0-1 are separations; row 2+ are FRN values
         vals_5 = f5.hdu_list['FRN_CRV'].data[2:]
         assert vals_5 == pytest.approx(5 * vals_1, rel=1e-10)
 
-    # 2. Header metadata
+    # --- Test 2: FITS header metadata ---
+    # The NSIGMA and SSCORR keywords should be recorded in the FRN_CRV extension header
+    # so that downstream users know how the curve was computed.
     for frame in frn_5sig:
         hdr = frame.hdu_list['FRN_CRV'].header
         assert hdr['NSIGMA'] == 5
@@ -592,11 +617,13 @@ def test_flux_ratio_noise_nsigma_and_correction():
         assert hdr['NSIGMA'] == 5
         assert hdr['SSCORR'] == True
 
-    # 3. Small sample correction: FRN with correction >= FRN without (especially at inner seps)
+    # --- Test 3: small sample correction makes the curve more conservative ---
+    # The Mawet et al. (2014) correction uses the t-distribution, which always produces
+    # a threshold >= the naive Gaussian nsigma. So the corrected FRN should be >= the
+    # uncorrected FRN at every separation.
     for fc, f5 in zip(frn_corr, frn_5sig):
         vals_corr = fc.hdu_list['FRN_CRV'].data[2:]
         vals_5 = f5.hdu_list['FRN_CRV'].data[2:]
-        # Correction factor should make noise >= naive scaling
         assert np.all(vals_corr >= vals_5 - 1e-15)
 
 

--- a/tests/test_klipthrupt.py
+++ b/tests/test_klipthrupt.py
@@ -1112,45 +1112,65 @@ def test_psfsub_withklipandctmeas_rdi(coro_type,FOV,band):
 def test_measure_noise_nsigma_and_correction():
     """Tests for nsigma scaling and small sample statistics correction
     in measure_noise().
+
+    This is a unit test that directly tests measure_noise() with synthetic data.
+    It verifies:
+      - Simple nsigma scaling (noise * nsigma)
+      - Backward compatibility (default behavior unchanged)
+      - Mawet et al. (2014) small sample correction behavior
+      - Convergence of the correction at large separations
+      - Input validation (bad inputs raise errors)
+      - FWHM input flexibility (scalar vs array)
     """
     from scipy.stats import t as t_dist, norm
 
+    # --- Setup: create a synthetic frame with known Gaussian noise ---
+    # Two KL-mode slices of pure Gaussian noise (mean=0, std=1) so that
+    # the expected annular standard deviation is ~1.0 everywhere.
     cenx, ceny = (120., 130.)
     frame_shape_yx = (200, 200)
-    seps = np.arange(50., 71., 5.)
-    fwhm = 2.  # pix
+    seps = np.arange(50., 71., 5.)  # separations where we'll measure noise
+    fwhm = 2.  # PSF FWHM in pixels (used as annulus halfwidth and for small sample correction)
 
     ext_hdr = fits.Header()
     ext_hdr['STARLOCX'] = cenx
     ext_hdr['STARLOCY'] = ceny
 
     rng = np.random.default_rng(42)
-    image = rng.normal(0., 1., (2, *frame_shape_yx))
+    image = rng.normal(0., 1., (2, *frame_shape_yx))  # 2 KL mode slices
     frame = Image(image, pri_hdr=fits.Header(), ext_hdr=ext_hdr)
 
-    # 1. nsigma scaling: nsigma=5 should be 5x the nsigma=1 result
+    # --- Test 1: nsigma scaling is a pure multiplier ---
+    # Without small sample correction, nsigma=5 should produce exactly 5x the nsigma=1 result,
+    # since it's just multiplying the standard deviation by nsigma.
     noise_1sig = measure_noise(frame, seps, fwhm, nsigma=1)
     noise_5sig = measure_noise(frame, seps, fwhm, nsigma=5)
     assert noise_5sig == pytest.approx(5 * noise_1sig)
 
-    # 2. Backward compatibility: explicit nsigma=1 matches default
+    # --- Test 2: backward compatibility ---
+    # Calling without nsigma (default=1) should give the same result as nsigma=1,
+    # ensuring old code that doesn't pass nsigma still works.
     noise_default = measure_noise(frame, seps, fwhm)
     assert noise_1sig == pytest.approx(noise_default)
 
-    # 3. Small sample correction: at small separations, corrected noise > naive nsigma * std
+    # --- Test 3: small sample correction makes noise MORE conservative ---
+    # The Mawet et al. (2014) correction replaces the naive nsigma multiplier with a
+    # t-distribution threshold that's always >= nsigma for finite n (number of resolution
+    # elements). So corrected noise should be >= naive nsigma * std at every separation.
     noise_corr = measure_noise(frame, seps, fwhm, nsigma=5, fwhm=fwhm,
                                small_sample_correction=True)
-    # At small separations where n is small, corrected values should exceed naive 5*std
     for i, sep in enumerate(seps):
-        n = 2 * np.pi * sep / fwhm
+        n = 2 * np.pi * sep / fwhm  # number of independent resolution elements in annulus
         if n > 2:
-            # Correction factor should be >= nsigma (it's always larger for finite n)
+            # t-distribution threshold > Gaussian threshold for finite degrees of freedom
             assert np.all(noise_corr[i] >= noise_5sig[i] - 1e-10)
 
-    # 4. Convergence at large separations: with many resolution elements, correction ≈ nsigma * std
+    # --- Test 4: convergence at large separations ---
+    # With many resolution elements (large n), the t-distribution converges to the
+    # Gaussian, so the corrected noise should be approximately equal to the naive
+    # nsigma * std (within 5% tolerance).
     large_seps = np.array([500., 600., 700.])
-    # Use a larger frame for these separations
-    large_shape = (1500, 1500)
+    large_shape = (1500, 1500)  # need a bigger frame to fit these separations
     large_cenx, large_ceny = (750., 750.)
     ext_hdr_large = fits.Header()
     ext_hdr_large['STARLOCX'] = large_cenx
@@ -1160,31 +1180,31 @@ def test_measure_noise_nsigma_and_correction():
     noise_large_naive = measure_noise(large_frame, large_seps, fwhm, nsigma=5)
     noise_large_corr = measure_noise(large_frame, large_seps, fwhm, nsigma=5, fwhm=fwhm,
                                      small_sample_correction=True)
-    # At very large n, correction factor approaches nsigma, so ratio should be ~1
     assert noise_large_corr == pytest.approx(noise_large_naive, rel=0.05)
 
-    # 5. Validation errors
-    # fwhm=None with correction should raise ValueError
+    # --- Test 5: input validation ---
+    # Requesting small_sample_correction without providing fwhm should fail
     with pytest.raises(ValueError):
         measure_noise(frame, seps, fwhm, nsigma=5, small_sample_correction=True)
 
-    # nsigma <= 0 should raise ValueError
+    # nsigma must be positive
     with pytest.raises(ValueError):
         measure_noise(frame, seps, fwhm, nsigma=0)
     with pytest.raises(ValueError):
         measure_noise(frame, seps, fwhm, nsigma=-1)
 
-    # Wrong-length fwhm array should raise ValueError
+    # fwhm array length must match number of separations
     with pytest.raises(ValueError):
         measure_noise(frame, seps, fwhm, nsigma=5, fwhm=np.array([1., 2.]),
                       small_sample_correction=True)
 
-    # Scalar fwhm should work (broadcast)
+    # --- Test 6: fwhm input flexibility ---
+    # Scalar fwhm should be broadcast to all separations
     noise_scalar_fwhm = measure_noise(frame, seps, fwhm, nsigma=5, fwhm=2.0,
                                       small_sample_correction=True)
     assert noise_scalar_fwhm.shape == noise_5sig.shape
 
-    # Array fwhm matching seps length should work
+    # An array of identical values should give the same result as the scalar
     fwhm_arr = np.full(len(seps), 2.0)
     noise_arr_fwhm = measure_noise(frame, seps, fwhm, nsigma=5, fwhm=fwhm_arr,
                                    small_sample_correction=True)


### PR DESCRIPTION
## Describe your changes
The contrast curve was only measuring 1-sigma noise. This PR adds an `nsigma` parameter to `measure_noise()` and `compute_flux_ratio_noise()` to support n-sigma contrast curves (e.g., the standard 5-sigma detection threshold). It also adds an optional `small_sample_correction` parameter implementing the Mawet et al. (2014) correction using the Student's t-distribution, which accounts for the limited number of independent resolution elements at small angular separations. `NSIGMA` and `SSCORR` metadata are recorded in the `FRN_CRV` FITS extension header for provenance.

## Type of change

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)

Closes #366

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 