### PR TITLE
Improving walker logic

### DIFF
--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -348,8 +348,12 @@ def guess_template(dataset):
             recipe_filename = ["l1_to_l2a_basic.json", "l2a_to_l2b.json", 'l2b_to_corethroughput.json']
             chained = True
         elif image.pri_hdr['VISTYPE'] == 'CGIVST_CAL_SPEC_TGTREF':
-            recipe_filename = ["l1_to_l2a_basic.json","l2a_to_l2b_spec.json","l2b_to_l3.json","l3_to_l4_noncoron_spec.json"]
-            chained = True
+            if image.ext_hdr['FPAMNAME'] == 'OPEN':               #L1 -> spec dispersion calibration
+                recipe_filename = ["l1_to_l2a_basic.json","l2a_to_l2b_spec.json","l2b_to_spec_prism_disp.json"]
+                chained = True
+            else:
+                recipe_filename = ["l1_to_l2a_basic.json","l2a_to_l2b_spec.json","l2b_to_l3.json","l3_to_l4_noncoron_spec.json"]
+                chained = True
         elif image.pri_hdr['VISTYPE'] == 'CGIVST_CAL_TGTREF_PHOT' and image.ext_hdr['DPAMNAME'] not in ['POL0','POL45']:
             recipe_filename = ["l1_to_l2a_basic.json","l2a_to_l2b.json","l2b_to_l3.json","l3_to_l4_nopsfsub.json"]
             chained = True
@@ -400,6 +404,9 @@ def guess_template(dataset):
             recipe_filename = "l2b_to_polcal.json"
         elif image.ext_hdr['DPAMNAME'] == 'POL0' or image.ext_hdr['DPAMNAME'] == 'POL45':
             recipe_filename = "l2b_to_l3_pol.json"
+        elif 'TDD' not in image.pri_hdr['VISTYPE']:
+            warnings.warn("Only VISTYPE TDD and certain cal frames should be processed beyond L2b. Double-check which frames are being processed from L2b -> L3.")
+            recipe_filename = "l2b_to_l3.json"
         else:
             recipe_filename = "l2b_to_l3.json"
     # L3 -> L4 data processing

--- a/tests/e2e_tests/l1_to_l3_spec_e2e.py
+++ b/tests/e2e_tests/l1_to_l3_spec_e2e.py
@@ -274,6 +274,7 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
             if 'ISPC' in fits_file[1].header:
                 fits_file[1].header['ISPC'] = int(fits_file[1].header['ISPC'])
             print(fits_file[1].header['EXPTIME'])
+            fits_file[0].header['VISTYPE'] = 'CGIVST_TDD_OBS'
             if fits_file[1].header['EXPTIME'] >= 100:
                 fits_file[1].data = fits_file[1].data/10.
                 fits_file[1].header['EXPTIME'] = fits_file[1].header['EXPTIME']/10.


### PR DESCRIPTION
1) For on-sky spec dispersion calibration go from L1 -> spec dispersion. 
2) Add a warning while processing frames beyond L2b

## Describe your changes


## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
