### PR TITLE
Pol Flatfield Selection Logic

### DIFF
--- a/corgidrp/caldb.py
+++ b/corgidrp/caldb.py
@@ -48,6 +48,8 @@ labels = {data.Dark: "Dark",
           data.BadPixelMap: "BadPixelMap",
           data.DetectorNoiseMaps: "DetectorNoiseMaps",
           data.FlatField : "FlatField",
+          data.FlatFieldPOL0 : "FlatField",
+          data.FlatFieldPOL45 : "FlatField",
           data.DetectorParams : "DetectorParams",
           data.AstrometricCalibration : "AstrometricCalibration",
           data.TrapCalibration : "TrapCalibration",
@@ -381,9 +383,14 @@ class CalDB:
             result_index = np.abs(options["MJD"] - frame_dict["MJD"]).argmin()
             calib_filepath = options.iloc[result_index, 0]
         elif dtype_label in ['FlatField'] and frame_dict['DPAMNAME'] in ['POL0', 'POL45']:
-            # filter by DPAM
-            options = self.filter_calib(calibdf, "DPAMNAME", frame_dict['DPAMNAME'], err_if_none=False)
+            # filter by the datatype here: 
+            if dtype == data.FlatFieldPOL0:
+                options = self.filter_calib(calibdf, "DPAMNAME", "POL0", err_if_none=False)
+                
+            elif dtype == data.FlatFieldPOL45:
+                options = self.filter_calib(calibdf, "DPAMNAME", "POL45", err_if_none=False)
 
+            dtype = data.FlatField
             # select the one closest in time
             result_index = np.abs(options["MJD"] - frame_dict["MJD"]).argmin()
             calib_filepath = options.iloc[result_index, 0]

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -3936,6 +3936,14 @@ def format_ftimeutc(ftime_str):
     return formatted_time
 
 
+class FlatFieldPOL0:
+    def __init__(self, ref: FlatField):
+        self.ref = ref
+
+class FlatFieldPOL45:
+    def __init__(self, ref: FlatField):
+        self.ref = ref
+
 datatypes = { "Image" : Image,
               "Dark" : Dark,
               "NonLinearityCalibration" : NonLinearityCalibration,
@@ -3943,6 +3951,8 @@ datatypes = { "Image" : Image,
               "BadPixelMap" : BadPixelMap,
               "DetectorNoiseMaps": DetectorNoiseMaps,
               "FlatField" : FlatField,
+              "FlatFieldPOL0" : FlatFieldPOL0,
+              "FlatFieldPOL45" : FlatFieldPOL45,
               "DetectorParams" : DetectorParams,
               "AstrometricCalibration" : AstrometricCalibration,
               "TrapCalibration" : TrapCalibration,

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -235,7 +235,7 @@ def flat_division_pol(input_dataset, flat_fieldPOL0, flat_fieldPOL45):
         where_zero = np.where(flat_field.data == 0)
         flatdiv_dq = copy.deepcopy(flatdiv_dataset.all_dq)
         for i in range(len(flatdiv_dataset)):
-        flatdiv_dq[i][where_zero] = np.bitwise_or(flatdiv_dataset[i].dq[where_zero], 4)
+            flatdiv_dq[i][where_zero] = np.bitwise_or(flatdiv_dataset[i].dq[where_zero], 4)
 
         # propagate the error of the master flat frame
         if hasattr(flat_field, "err"):

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -201,7 +201,8 @@ def flat_division_pol(input_dataset, flat_fieldPOL0, flat_fieldPOL45):
 
     Args:
         input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)
-        flat_field (corgidrp.data.FlatField): a master flat field to divide by
+        flat_fieldPOL0 (corgidrp.data.FlatField): a master flat field to divide by
+        flat_fieldPOL45 (corgidrp.data.FlatField): a master flat field to divide by
 
     Returns:
         corgidrp.data.Dataset: a version of the input dataset with the flat field divided out
@@ -215,12 +216,12 @@ def flat_division_pol(input_dataset, flat_fieldPOL0, flat_fieldPOL45):
     #Ouptut file container. 
     output_frames = []
 
-    for flatdiv_dataset in split_dataset_list:
+    for flatdiv_dataset, val in zip(split_dataset_list, unique_vals):
 
         #Get the right flat: 
-        if unique_vals[0][0] == 'POL0':
+        if val == 'POL0':
             flat_field = flat_fieldPOL0
-        elif unique_vals[0][0] == 'POL45':
+        elif val == 'POL45':
             flat_field = flat_fieldPOL45
         else: #Throw error
             raise Exception('DPAMNAME value in input dataset should be either POL0 or POL45 for the flat division step function with polarization-dependent flats.')

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -193,6 +193,69 @@ def flat_division(input_dataset, flat_field):
 
     return flatdiv_dataset
 
+
+def flat_division_pol(input_dataset, flat_fieldPOL0, flat_fieldPOL45):
+    """
+
+    Divide the dataset by the master flat field.
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)
+        flat_field (corgidrp.data.FlatField): a master flat field to divide by
+
+    Returns:
+        corgidrp.data.Dataset: a version of the input dataset with the flat field divided out
+    """
+
+     # copy of the dataset
+    flatdiv_dataset0 = input_dataset.copy()
+
+    split_dataset_list, unique_vals = flatdiv_dataset0.split_dataset(exthdr_keywords=['DPAMNAME'])
+
+    #Ouptut file container. 
+    output_frames = []
+
+    for flatdiv_dataset in split_dataset_list:
+
+        #Get the right flat: 
+        if unique_vals[0][0] == 'POL0':
+            flat_field = flat_fieldPOL0
+        elif unique_vals[0][0] == 'POL45':
+            flat_field = flat_fieldPOL45
+        else: #Throw error
+            raise Exception('DPAMNAME value in input dataset should be either POL0 or POL45 for the flat division step function with polarization-dependent flats.')
+        
+        #Divide by the master flat
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=RuntimeWarning) # catch divide by zero
+            flatdiv_cube = flatdiv_dataset.all_data /  flat_field.data
+
+        #Find where the flat_field is 0 and set a DQ flag: 
+        where_zero = np.where(flat_field.data == 0)
+        flatdiv_dq = copy.deepcopy(flatdiv_dataset.all_dq)
+        for i in range(len(flatdiv_dataset)):
+        flatdiv_dq[i][where_zero] = np.bitwise_or(flatdiv_dataset[i].dq[where_zero], 4)
+
+        # propagate the error of the master flat frame
+        if hasattr(flat_field, "err"):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=RuntimeWarning) # catch divide by zero
+                flatdiv_dataset.rescale_error(1/flat_field.data, "FlatField")
+                flatdiv_dataset.add_error_term(flatdiv_dataset.all_data*flat_field.err[0]/(flat_field.data**2), "FlatField_error")
+        else:
+            raise Warning("no error attribute in the FlatField")
+
+        history_msg = "Flat calibration done using Flat field {0}".format(flat_field.filename)
+
+        # update the output dataset with this new flat calibrated data and update the history
+        flatdiv_dataset.update_after_processing_step(history_msg,new_all_data=flatdiv_cube, new_all_dq = flatdiv_dq)
+
+        output_frames.extend(flatdiv_dataset.frames)
+
+    output_dataset = data.Dataset(output_frames)
+
+    return output_dataset
+
 def frame_select(input_dataset, bpix_frac=1., allowed_bpix=0, overexp=False, tt_rms_thres=None, tt_bias_thres=None, discard_bad=True):
     """
 

--- a/corgidrp/photon_counting.py
+++ b/corgidrp/photon_counting.py
@@ -147,6 +147,20 @@ def get_pc_mean(input_dataset, pc_master_dark=None, T_factor=None, pc_ecount_max
     # import psutil 
     # process = psutil.Process()
 
+    split_dataset, unique_vals = input_dataset.split_dataset(exthdr_keywords=['DPAMNAME'])
+
+    if len(unique_vals) > 1: 
+        output_frames = []
+        for dataset in split_dataset:
+            pc_mean_dataset = get_pc_mean(dataset, pc_master_dark=pc_master_dark, T_factor=T_factor, pc_ecount_max=pc_ecount_max, 
+                                          niter=niter, mask_filepath=mask_filepath, safemode=safemode, inputmode=inputmode, 
+                                          bin_size=bin_size, dataset_copy=dataset_copy)
+            output_frames.extend(list(pc_mean_dataset.frames))
+        output_dataset = data.Dataset(output_frames)
+        return output_dataset
+
+ 
+
     if not isinstance(niter, (int, np.integer)) or niter < 1:
             raise PhotonCountException('niter must be an integer greater than '
                                         '0')

--- a/corgidrp/photon_counting.py
+++ b/corgidrp/photon_counting.py
@@ -147,6 +147,9 @@ def get_pc_mean(input_dataset, pc_master_dark=None, T_factor=None, pc_ecount_max
     # import psutil 
     # process = psutil.Process()
 
+    # the following chunck of code checks if the dataset needs to be divided up into multiple datasets
+    # currently this addresses the case of pol mode where we don't want to combine pol0 and pol45 frames together
+    # this iplementation does this by splitting the dataset and recurisvely calling this function to operate on each sub dataset
     split_dataset, unique_vals = input_dataset.split_dataset(exthdr_keywords=['DPAMNAME'])
 
     if len(unique_vals) > 1: 
@@ -157,8 +160,8 @@ def get_pc_mean(input_dataset, pc_master_dark=None, T_factor=None, pc_ecount_max
                                           bin_size=bin_size, dataset_copy=dataset_copy)
             output_frames.extend(list(pc_mean_dataset.frames))
         output_dataset = data.Dataset(output_frames)
-        return output_dataset
-
+        return output_dataset # returns the output of the recursive pc-combined datasets
+    # end recursion logic. the code below operates on a single dataet.
  
 
     if not isinstance(niter, (int, np.integer)) or niter < 1:

--- a/corgidrp/recipe_templates/l2a_to_l2b_pol.json
+++ b/corgidrp/recipe_templates/l2a_to_l2b_pol.json
@@ -51,7 +51,7 @@
             "name" : "flat_division_pol",
             "calibs" : {
                 "FlatFieldPOL0" : "AUTOMATIC",
-                "FlatFieldPOL45": "AUTOMATIC",
+                "FlatFieldPOL45": "AUTOMATIC"
             }
         },
         {

--- a/corgidrp/recipe_templates/l2a_to_l2b_pol.json
+++ b/corgidrp/recipe_templates/l2a_to_l2b_pol.json
@@ -1,0 +1,70 @@
+{
+    "name" : "l2a_to_l2b",
+    "template" : true,
+    "drpconfig" : {
+        "track_individual_errors" : false
+    },
+    "inputs" : [],
+    "outputdir" : "",
+    "steps" : [
+        {
+            "name" : "frame_select"
+        },
+        {
+            "name" : "convert_to_electrons",
+            "calibs" : {
+                "KGain" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "em_gain_division"
+        },
+        {
+            "name" : "add_shot_noise_to_err",
+            "calibs" : {
+                "KGain" : "AUTOMATIC",
+                "DetectorParams" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "dark_subtraction",
+            "calibs" : {
+                "DetectorNoiseMaps" : "AUTOMATIC"
+            },
+            "keywords" : {
+                "outputdir" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "desmear",
+            "calibs" : {
+                "DetectorParams" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "cti_correction",
+            "calibs" : {
+                "TrapCalibration" : "AUTOMATIC,OPTIONAL"
+            }
+        },
+        {
+            "name" : "flat_division_pol",
+            "calibs" : {
+                "FlatFieldPOL0" : "AUTOMATIC",
+                "FlatFieldPOL45": "AUTOMATIC",
+            }
+        },
+        {
+            "name" : "correct_bad_pixels",
+            "calibs" : {
+                "BadPixelMap" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "update_to_l2b"
+        },
+        {
+            "name" : "save"
+        }
+    ]
+}

--- a/corgidrp/recipe_templates/l2a_to_l2b_pol_pc_3.json
+++ b/corgidrp/recipe_templates/l2a_to_l2b_pol_pc_3.json
@@ -1,0 +1,41 @@
+{
+    "name" : "l2a_to_l2b_pc_3",
+    "template" : true,
+    "drpconfig" : {
+        "track_individual_errors" : false
+    },
+    "inputs" : [],
+    "outputdir" : "",
+    "steps" : [
+        {
+            "name" : "desmear",
+            "calibs" : {
+                "DetectorParams" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "cti_correction",
+            "calibs" : {
+                "TrapCalibration" : "AUTOMATIC,OPTIONAL"
+            }
+        },
+        {
+            "name" : "flat_division",
+            "calibs" : {
+                "FlatField" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "correct_bad_pixels",
+            "calibs" : {
+                "BadPixelMap" : "AUTOMATIC"
+            }
+        },
+        {
+            "name" : "update_to_l2b"
+        },
+        {
+            "name" : "save"
+        }
+    ]
+}

--- a/corgidrp/recipe_templates/l2a_to_l2b_pol_pc_3.json
+++ b/corgidrp/recipe_templates/l2a_to_l2b_pol_pc_3.json
@@ -20,9 +20,10 @@
             }
         },
         {
-            "name" : "flat_division",
+            "name" : "flat_division_pol",
             "calibs" : {
-                "FlatField" : "AUTOMATIC"
+                "FlatFieldPOL0" : "AUTOMATIC",
+                "FlatFieldPOL45": "AUTOMATIC"
             }
         },
         {

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -268,7 +268,7 @@ def _fill_in_calib_files(step, this_caldb, ref_frame):
 
             # try to look up the best calibration, but it could raise an error
             try:
-                best_cal_file = this_caldb.get_calib(ref_frame, calib_dtype)
+                best_cal_file = this_caldb.fd(ref_frame, calib_dtype)
                 best_cal_filepath = best_cal_file.filepath
             except ValueError as e:
                 if "OPTIONAL" in step["calibs"][calib].upper():
@@ -372,11 +372,19 @@ def guess_template(dataset):
             # Check if this is spectroscopy data (DPAMNAME == PRISM3, not sure of VISTYPE yet)
             is_spectroscopy = image.ext_hdr.get('DPAMNAME', '') == 'PRISM3'
             
+            is_polarimetry = image.ext_hdr.get('DPAMNAME', '') in ['POL0', 'POL45']
+
             if is_spectroscopy:
                 if image.ext_hdr['ISPC'] == 1:
                     recipe_filename = ["l2a_to_l2b_pc_spec_1.json", "l2a_to_l2b_pc_spec_2.json", "l2a_to_l2b_pc_spec_3.json"] #"l2a_to_l2b_pc_spec.json"
                 else:
                     recipe_filename = "l2a_to_l2b_spec.json"
+            elif is_polarimetry:
+                if image.ext_hdr['ISPC'] == 1:
+                    recipe_filename = ["l2a_to_l2b_pc_1.json", "l2a_to_l2b_pc_2.json", "l2a_to_l2b_pc_pol_3.json"] #"l2a_to_l2b_pc_pol.json"
+                    chained = True
+                else: 
+                    recipe_filename = "l2a_to_l2b_pol.json"
             else:
                 if image.ext_hdr['ISPC'] == 1:
                     recipe_filename = ["l2a_to_l2b_pc_1.json", "l2a_to_l2b_pc_2.json", "l2a_to_l2b_pc_3.json"] #l2a_to_l2b_pc.json 

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -35,6 +35,7 @@ all_steps = {
     "add_shot_noise_to_err" : corgidrp.l2a_to_l2b.add_shot_noise_to_err,
     "dark_subtraction" : corgidrp.l2a_to_l2b.dark_subtraction,
     "flat_division" : corgidrp.l2a_to_l2b.flat_division,
+    "flat_division_pol" : corgidrp.l2a_to_l2b.flat_division_pol,
     "frame_select" : corgidrp.l2a_to_l2b.frame_select,
     "convert_to_electrons" : corgidrp.l2a_to_l2b.convert_to_electrons,
     "em_gain_division" : corgidrp.l2a_to_l2b.em_gain_division,
@@ -268,7 +269,7 @@ def _fill_in_calib_files(step, this_caldb, ref_frame):
 
             # try to look up the best calibration, but it could raise an error
             try:
-                best_cal_file = this_caldb.fd(ref_frame, calib_dtype)
+                best_cal_file = this_caldb.get_calib(ref_frame, calib_dtype)
                 best_cal_filepath = best_cal_file.filepath
             except ValueError as e:
                 if "OPTIONAL" in step["calibs"][calib].upper():
@@ -381,7 +382,7 @@ def guess_template(dataset):
                     recipe_filename = "l2a_to_l2b_spec.json"
             elif is_polarimetry:
                 if image.ext_hdr['ISPC'] == 1:
-                    recipe_filename = ["l2a_to_l2b_pc_1.json", "l2a_to_l2b_pc_2.json", "l2a_to_l2b_pc_pol_3.json"] #"l2a_to_l2b_pc_pol.json"
+                    recipe_filename = ["l2a_to_l2b_pc_1.json", "l2a_to_l2b_pc_2.json", "l2a_to_l2b_pol_pc_3.json"] #"l2a_to_l2b_pc_pol.json"
                     chained = True
                 else: 
                     recipe_filename = "l2a_to_l2b_pol.json"
@@ -614,8 +615,12 @@ def run_recipe(recipe, save_recipe_file=True):
 
                     # load the calibration files in from disk
                     for calib in step["calibs"]:
-                        calib_dtype = data.datatypes[calib]
                         if step["calibs"][calib] is not None:
+                            # special case for pol flat because it has multiple files
+                            if calib == "FlatFieldPOL0" or calib == "FlatFieldPOL45":
+                                calib_dtype = data.datatypes['FlatField']
+                            else: 
+                                calib_dtype = data.datatypes[calib]
                             cal_file = calib_dtype(step["calibs"][calib])
                         else:
                             cal_file = None

--- a/tests/e2e_tests/l1_to_l3_pol_e2e.py
+++ b/tests/e2e_tests/l1_to_l3_pol_e2e.py
@@ -153,9 +153,20 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     # Flat field
     with fits.open(flat_path) as hdulist:
         flat_dat = hdulist[0].data
-    flat = data.FlatField(flat_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=mock_input_dataset)
-    mocks.rename_files_to_cgi_format(list_of_fits=[flat], output_dir=calibrations_dir, level_suffix="flt_cal")
-    this_caldb.create_entry(flat)
+    #Mock up some important header things
+    ext_hdr_flat0 = ext_hdr.copy()
+    ext_hdr_flat0['DPAMNAME'] = 'POL0'
+    pri_hdr_flat45 = pri_hdr.copy()
+    pri_hdr_visitID = str(int(pri_hdr['VISITID']) + 1)  #Change the visit id so the filename will be different
+    pri_hdr_flat45['VISITID'] = pri_hdr_visitID
+    ext_hdr_flat45 = ext_hdr.copy()
+    ext_hdr_flat45['DPAMNAME'] = 'POL45'
+    flat0 = data.FlatField(flat_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=mock_input_dataset)
+    flat45 = data.FlatField(flat_dat, pri_hdr=pri_hdr_flat45, ext_hdr=ext_hdr_flat45, input_dataset=mock_input_dataset)
+    mocks.rename_files_to_cgi_format(list_of_fits=[flat0, flat45], output_dir=calibrations_dir, level_suffix="flt_cal")
+    this_caldb.create_entry(flat0)
+    this_caldb.create_entry(flat45)
+
 
     # Bad pixel map
     with fits.open(bp_path) as hdulist:
@@ -182,7 +193,8 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     logger.info(f"  - DetectorNoiseMaps: {noise_map.filename}")
     if sample_l1_files:
         logger.info(f"  - Dark: {dark_cal.filename}")
-    logger.info(f"  - FlatField: {flat.filename}")
+    logger.info(f"  - FlatField POL0: {flat0.filename}")
+    logger.info(f"  - FlatField POL45: {flat45.filename}")
     logger.info(f"  - BadPixelMap: {bp_map.filename}")
     logger.info(f"  - AstrometricCalibration: {astrom_cal.filename}")
     logger.info('')
@@ -244,10 +256,20 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     logger.info('='*80)
     
     # Step 1: L1 -> L2b
-    logger.info('Step 1: Running L1 to L2b recipe...')
+    logger.info('Step 1: Running L1 to L2a recipe...')
     with warnings.catch_warnings():  
         warnings.filterwarnings('ignore', category=UserWarning)# prevent UserWarning: Number of frames which made the DetectorNoiseMaps product is less than the number of frames in input_dataset
-        walker.walk_corgidrp(input_data_filelist, "", l3_outputdir, template="l1_to_l2b.json")
+        walker.walk_corgidrp(input_data_filelist, "", l3_outputdir)
+
+    l2a_files = [f for f in os.listdir(l3_outputdir) if f.endswith('_l2a.fits')]
+    l2a_filelist = [os.path.join(l3_outputdir, f) for f in l2a_files]
+    logger.info(f'L1 to L2a complete. Generated {len(l2a_filelist)} L2a files.')
+    logger.info('')
+
+    logger.info('Step 1: Running L2a to L2b polarimetry recipe...')
+    with warnings.catch_warnings():  
+        warnings.filterwarnings('ignore', category=UserWarning)# prevent UserWarning: Number of frames which made the DetectorNoiseMaps product is less than the number of frames in input_dataset
+        walker.walk_corgidrp(l2a_filelist, "", l3_outputdir)
     
     l2b_files = [f for f in os.listdir(l3_outputdir) if f.endswith('_l2b.fits')]
     l2b_filelist = [os.path.join(l3_outputdir, f) for f in l2b_files]
@@ -439,8 +461,8 @@ if __name__ == "__main__":
     # to edit the file. The arguments use the variables in this file as their
     # defaults allowing the use to edit the file if that is their preferred
     # workflow.
-    e2edata_dir = '/Users/kevinludwick/Documents/DRP_E2E_Test_Files_v2/E2E_Test_Data'
-    outputdir = thisfile_dir
+    e2edata_dir = '/Users/maxmb/Data/corgi/E2E_Test_Data/'
+    outputdir = '/Users/maxmb/Data/corgi/e2e_output/'
 
     ap = argparse.ArgumentParser(description="run the l1->l3 polarimetry end-to-end test with recipe chaining")
     ap.add_argument("-tvac", "--e2edata_dir", default=e2edata_dir,

--- a/tests/e2e_tests/l1_to_l3_pol_e2e.py
+++ b/tests/e2e_tests/l1_to_l3_pol_e2e.py
@@ -101,6 +101,7 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     signal_array = np.linspace(0, 50)
     noise_array = np.sqrt(signal_array)
     ptc = np.column_stack([signal_array, noise_array])
+    ext_hdr['RN'] = 100
     kgain = data.KGain(kgain_val, ptc=ptc, pri_hdr=pri_hdr, ext_hdr=ext_hdr, 
                       input_dataset=mock_input_dataset)
     mocks.rename_files_to_cgi_format(list_of_fits=[kgain], output_dir=calibrations_dir, level_suffix="krn_cal")
@@ -266,7 +267,7 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     logger.info(f'L1 to L2a complete. Generated {len(l2a_filelist)} L2a files.')
     logger.info('')
 
-    logger.info('Step 1: Running L2a to L2b polarimetry recipe...')
+    logger.info('Step 2: Running L2a to L2b polarimetry recipe...')
     with warnings.catch_warnings():  
         warnings.filterwarnings('ignore', category=UserWarning)# prevent UserWarning: Number of frames which made the DetectorNoiseMaps product is less than the number of frames in input_dataset
         walker.walk_corgidrp(l2a_filelist, "", l3_outputdir)
@@ -276,8 +277,8 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     logger.info(f'L1 to L2b complete. Generated {len(l2b_filelist)} L2b files.')
     logger.info('')
     
-    # Step 2: L2b -> L3 
-    logger.info('Step 2: Running L2b to L3 polarimetry recipe...')
+    # Step 3: L2b -> L3 
+    logger.info('Step 3: Running L2b to L3 polarimetry recipe...')
     walker.walk_corgidrp(l2b_filelist, "", l3_outputdir)
     logger.info('L2b to L3 complete.')
     logger.info('')


### PR DESCRIPTION
## Describe your changes
Setting up the infratructure to accept POL0 and POL45 as one input dataset at the L2a level. PR includes a new step function, new recipe and some internal datatypes (that won't ever get saved). 

The PR also adjust get_pc_mean to allow for pol data. 

## Type of change
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Reference any relevant issues (don't forget the #)
Addresses Issue #531 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
