### PR TITLE
Update sorting.py

### DIFF
--- a/corgidrp/sorting.py
+++ b/corgidrp/sorting.py
@@ -21,12 +21,12 @@ def extract_datetime(datetime_str):
     return output
 
 def sort_remove_frames(dataset_in_list, cal_type, actual_visit=True):
-    '''For a given EM gain, this function groups frames consecutive in time stamp into 
-    groups with the same exposure time.  Then it finds the two sets with the same 
-    exposure time that are the most separated in time.  It then examines any other sets 
-    with repeated exposure times, keeps the set of those with the most frames, and 
+    '''For a given EM gain, this function groups frames consecutive in time stamp into
+    groups with the same exposure time.  Then it finds the two sets with the same
+    exposure time that are the most separated in time.  It then examines any other sets
+    with repeated exposure times, keeps the set of those with the most frames, and
     discards the rest.
-     
+
     Args:
       dataset_in_list (list of corgidrp.Dataset): list of datasets with all the frames to be sorted.
       cal_type (string): the calibration type. Case insensitive.
@@ -34,9 +34,9 @@ def sort_remove_frames(dataset_in_list, cal_type, actual_visit=True):
         'k-gain' or 'kgain' for K-gain calibration
         'non-lin(earity)', 'nonlin(earity)' for non-linearity calibration, where
         the letters within parenthesis are optional.
-      actual_visit (bool): if True, the dataset is expected to be a dataset from an actual visit (frames taken in the specific order for the visit), 
+      actual_visit (bool): if True, the dataset is expected to be a dataset from an actual visit (frames taken in the specific order for the visit),
         as opposed to a generic collection of files from which we might extract files that satisfy the requirements of the calibration script. Default is True.
-        
+
     Returns:
       inds_leave_out (list): list of indices of frames to be left out of the final
         dataset.
@@ -44,10 +44,10 @@ def sort_remove_frames(dataset_in_list, cal_type, actual_visit=True):
         left out of the final dataset.
       exptime_cons (list): list of exposure times for the sets, including the ones to be excluded.
       count_cons (list): list of number of frames for each exposure time set, including the ones to be excluded.
-      filepath_list (list): list of file paths for the frames, including the ones to be excluded.    
+      filepath_list (list): list of file paths for the frames, including the ones to be excluded.
     '''
-    
-    
+
+
     # Frames must be taken consecutively
     cal_frame_time_list = []
     exptime_list = []
@@ -104,10 +104,10 @@ def sort_remove_frames(dataset_in_list, cal_type, actual_visit=True):
     # Beyond this boundary would mean going into the territory of EM gain calibration frames
     ########
     # Find the longest set of consecutive positive values in boundary_wo_indices
-    boundary_wo_indices = np.where(np.diff(exptime_cons_wo_repeats) < 0)[0] 
-    if len(boundary_wo_indices) > 0:  
-        if len(boundary_wo_indices) == 1: 
-            # if the boundary is nearer to the beginning 
+    boundary_wo_indices = np.where(np.diff(exptime_cons_wo_repeats) < 0)[0]
+    if len(boundary_wo_indices) > 0:
+        if len(boundary_wo_indices) == 1:
+            # if the boundary is nearer to the beginning
             if len(exptime_cons_wo_repeats) - 1 - boundary_wo_indices[0] > boundary_wo_indices[0] - 1:
                 boundary_index = None
                 lower_boundary_wo_index = boundary_wo_indices[0]
@@ -118,7 +118,7 @@ def sort_remove_frames(dataset_in_list, cal_type, actual_visit=True):
                 boundary_exptime = exptime_cons_wo_repeats[boundary_wo_index]
                 boundary_index = np.where(exptime_cons == boundary_exptime)[0][0] # only one occurence since not a repeated set
                 lower_boundary_index = 0
-        else: 
+        else:
             # Find largest run of consecutive indices
             boundary_diffwo_index = np.argmax(np.diff(boundary_wo_indices))+1
             lower_boundary_diffwo_index = boundary_diffwo_index - 1
@@ -128,9 +128,9 @@ def sort_remove_frames(dataset_in_list, cal_type, actual_visit=True):
             lower_boundary_exptime = exptime_cons_wo_repeats[lower_boundary_wo_index]
             boundary_index = np.where(exptime_cons == boundary_exptime)[0][0] # only one occurence since not a repeated set
             lower_boundary_index = np.where(exptime_cons == lower_boundary_exptime)[0][0]
-        
+
     else:
-        boundary_index = None 
+        boundary_index = None
         lower_boundary_index = 0
 
     set1 = None
@@ -173,8 +173,8 @@ def sort_remove_frames(dataset_in_list, cal_type, actual_visit=True):
                 if arr_within_boundary.size > 1: # otherwise, not a repeated set effectively
                     del_rep_inds = np.where(count_cons[arr_within_boundary] != np.max(count_cons[arr_within_boundary]))[0]
                     if len(del_rep_inds) == 0: # then all within arr have the same number of frames
-                        # then just pick one 
-                        del_rep_inds = np.array([arr_within_boundary[0]]) 
+                        # then just pick one
+                        del_rep_inds = np.array([arr_within_boundary[0]])
                 else:
                     del_rep_inds = np.array([]) # append nothing
             del_rep_inds_tot = np.append(del_rep_inds_tot, del_rep_inds)
@@ -202,7 +202,7 @@ def sort_remove_frames(dataset_in_list, cal_type, actual_visit=True):
                 for k in range(time_ind1, time_ind2+1):
                         ind_remove = np.where(cal_frame_time_list == cal_frame_time_list_sorted[k])[0][0]
                         inds_leave_out.append(ind_remove)
-        # also remove repeated sets if k gain since no drift correction employed for k gain calibration 
+        # also remove repeated sets if k gain since no drift correction employed for k gain calibration
         # (and so that no exposure time is more heavily weighted than another)
         del_rep_inds_tot = np.append(del_rep_inds_tot, set2)
         time_ind1 = np.sum(count_cons[0:set2]).astype(int) # first of exposure time set
@@ -215,9 +215,9 @@ def sort_remove_frames(dataset_in_list, cal_type, actual_visit=True):
 
 def sort_pupilimg_frames(
     dataset_in,
-    cal_type='', 
+    cal_type='',
     actual_visit=True):
-    """ 
+    """
     Sorting algorithm that given a dataset will output a dataset with the
     frames used to generate a mean frame and the frames used to calibrate
     the calibration type: k-gain. non-linearity.
@@ -229,15 +229,15 @@ def sort_pupilimg_frames(
     Args:
       dataset_in (corgidrp.Dataset): dataset with all the frames to be sorted.
         By default, it is expected to contain all the frames from the PUPILIMG
-        visit files associated with a calibration campaign.  
-        Function works if data in Datset is None (useful for large RAM-heavy Dataset), 
-        and data is loaded in at the end.  
+        visit files associated with a calibration campaign.
+        Function works if data in Datset is None (useful for large RAM-heavy Dataset),
+        and data is loaded in at the end.
       cal_type (string): the calibration type. Case insensitive.
         Accepted values are:
         'k-gain' or 'kgain' for K-gain calibration
         'non-lin(earity)', 'nonlin(earity)' for non-linearity calibration, where
         the letters within parenthesis are optional.
-      actual_visit (bool): if True, the dataset is expected to be a dataset from an actual visit (frames taken in the specific order for the visit), 
+      actual_visit (bool): if True, the dataset is expected to be a dataset from an actual visit (frames taken in the specific order for the visit),
         as opposed to a generic collection of files from which we might extract files that satisfy the requirements of the calibration script. Default is True.
 
     Returns:
@@ -251,11 +251,13 @@ def sort_pupilimg_frames(
             if 'PUPIL' not in val.upper():
                 raise Exception(f'Expected DPAMNAME to contain PUPIL, but found {val}.')
         del split_dpam
-        split_cfam, vals = dataset_in.split_dataset(exthdr_keywords=['CFAMNAME'])
-        for val in vals:
-            if 'DARK' in val.upper():
-                raise Exception(f'CFAMNAME should not be DARK.')
-        del split_cfam
+        frames_to_keep = []
+        for frame in dataset_in: # rejecting all DARK frames, which are only used for EM gain cal
+            if ('DARK' not in frame.ext_hdr['CFAMNAME'].upper()):
+                frames_to_keep.append(frame)
+        if len(frames_to_keep) == 0:
+            raise Exception("Input dataset appears to have no files relevant for k gain/nonlin calibration.")
+        dataset_in = data.Dataset(frames_to_keep) #overwrite
     split_datetime_ds, _ = dataset_in.split_dataset(exthdr_keywords=['DATETIME'])
     for ds in split_datetime_ds:
         if len(ds) > 1:
@@ -266,21 +268,43 @@ def sort_pupilimg_frames(
     # Mean frame: split by EXPTIME
     idx_unity = np.where(np.array(split_cmdgain[1])==1)[0][0]
     split_exptime = split_cmdgain[0][idx_unity].split_dataset(exthdr_keywords=['EXPTIME'])
+    if actual_visit:
+        # sorter can find frames that satisfy sorting constraints from different aux files which are not intended to be grouped together
+        # Require sets of frames to be from one AUXFILE (the largest such set) if possible.
+        # keep the AUXFILE set with all the same EMGAIN_C value of 1 which is biggest
+        aux_sets, aux_vals = dataset_in.split_dataset(prihdr_keywords=['AUXFILE'])
+        aux_val_to_use = None
+        aux_set_size = 0 # initialize
+        for ind, s in enumerate(aux_sets):
+            s_sets, s_vals = s.split_dataset(exthdr_keywords=["EMGAIN_C"])
+            if len(s_sets) == 1 and s_vals[0] == 1.0:
+                if aux_val_to_use is not None and len(s) <= aux_set_size:
+                    continue
+                else:
+                    aux_val_to_use = aux_vals[ind]
+                    aux_set_to_use = aux_sets[ind]
+                    aux_set_size = len(s)
+        if aux_val_to_use is None:
+            raise ValueError('Actual visit must have an AUXFILE with all frames of unity EM gain.')
+        # frames coming from the AUXFILE with all unity-gain frames:
+        exptime_sets = aux_set_to_use.split_dataset(exthdr_keywords=['EXPTIME'])
+    else: 
+        exptime_sets = split_exptime
     # Get the set with the most frames
-    n_frames_list = np.zeros(len(split_exptime[0]))
-    for i_sub, subset in enumerate(split_exptime[0]):
-        n_frames_list[i_sub] = len(split_exptime[0][i_sub])
+    n_frames_list = np.zeros(len(exptime_sets[0]))
+    for i_sub, subset in enumerate(exptime_sets[0]):
+        n_frames_list[i_sub] = len(exptime_sets[0][i_sub])
     # Choice: choose the subset with the maximum number of frames
     idx_mean_frame = np.argmax(n_frames_list)
     frame_time_list = []
-    for dataset in split_exptime[0]:
+    for dataset in exptime_sets[0]:
         for frame in dataset:
             frame_time_list += [extract_datetime(frame.ext_hdr['DATETIME'])]
     frame_time_sort = sorted(frame_time_list)
     mean_frame_time_list = []
-    for frame in split_exptime[0][idx_mean_frame]:
+    for frame in exptime_sets[0][idx_mean_frame]:
         mean_frame_time_list += [extract_datetime(frame.ext_hdr['DATETIME'])]
-    # Choose the frames with consecutive time stamp values 
+    # Choose the frames with consecutive time stamp values
     mean_frame_time_sort = np.array(mean_frame_time_list)
     mean_frame_time_sort.sort()
     count_cons = [1]
@@ -297,18 +321,19 @@ def sort_pupilimg_frames(
     idx_mean_frame_last = np.sum(count_cons[0:idx_mean_frame_cons+1]).astype(int)
     idx_mean_frame_first = idx_mean_frame_last - count_cons[idx_mean_frame_cons]
     frame_id_mean_frame = mean_frame_time_sort[idx_mean_frame_first:idx_mean_frame_last]
+    
     mean_frame_list = []
-
     n_mean_frame = 0
-    for frame in split_exptime[0][idx_mean_frame]:
+    mean_frames = exptime_sets[0][idx_mean_frame] 
+    for frame in mean_frames:
         if extract_datetime(frame.ext_hdr['DATETIME']) in frame_id_mean_frame:
             exptime_mean_frame = frame.ext_hdr['EXPTIME']
             # Update keyword OBSNAME
             frame.pri_hdr['OBSNAME'] = 'MNFRAME'
             mean_frame_list += [frame]
             n_mean_frame += 1
-            
-    sorting_summary = (f'Mean frame has {n_mean_frame} unity frames with' + 
+
+    sorting_summary = (f'Mean frame has {n_mean_frame} unity frames with' +
         f' exposure time {exptime_mean_frame} seconds. ')
 
     # K-gain and non-linearity
@@ -321,58 +346,63 @@ def sort_pupilimg_frames(
         raise Exception('Unrecognized calibration type (expected k-gain, non-lin)')
 
     # Remove MNFRAME frames from unity gain frames
-    split_exptime[0].remove(split_exptime[0][idx_mean_frame])
-    split_exptime[1].remove(split_exptime[1][idx_mean_frame])
-    # in the datasets, use the AUXFILE with the most frames
-    unity_gain_exptimes_auxs = []
-    for dataset in split_exptime[0]:
-        subs, vals = dataset.split_dataset(prihdr_keywords=['AUXFILE'])
-        subs_lengths = [len(sub) for sub in subs]
-        if len(subs_lengths) == 0:
-            unity_gain_exptimes_auxs.append(dataset)  # no AUXFILE value, so use the dataset as is
-        else:
-            dominant_ind = np.argmax(subs_lengths)
-            unity_gain_exptimes_auxs.append(subs[dominant_ind])
-    inds_leave_out, del_rep_inds_tot, exptime_cons, count_cons, unity_gain_filepath_list = sort_remove_frames(unity_gain_exptimes_auxs, cal_type=cal_type, actual_visit=actual_visit)
+    mean_frames_datetime_list = []
+    for frame in mean_frames:
+        mean_frames_datetime_list.append(frame.ext_hdr['DATETIME'])
+    if actual_visit: 
+        inds_to_remove = []
+        for ind, f in enumerate(aux_set_to_use):
+            if extract_datetime(f.ext_hdr['DATETIME']) in frame_id_mean_frame:
+                inds_to_remove.append(ind)
+        aux_set_to_use.frames = np.delete(aux_set_to_use.frames, np.array(inds_to_remove))
+        aux_set_to_use.all_data = np.delete(aux_set_to_use.all_data, np.array(inds_to_remove))
+        aux_set_to_use.all_err = np.delete(aux_set_to_use.all_err, np.array(inds_to_remove))
+        aux_set_to_use.all_dq = np.delete(aux_set_to_use.all_dq, np.array(inds_to_remove))
+    else:
+        split_exptime[0].remove(split_exptime[0][idx_mean_frame])
+
+    # K gain frames in same AUXFILE used for mean frame
+    inds_leave_out, del_rep_inds_tot, exptime_cons, count_cons, unity_gain_filepath_list = sort_remove_frames([aux_set_to_use], cal_type=cal_type, actual_visit=actual_visit)
     if actual_visit and (inds_leave_out is None or del_rep_inds_tot is None):
         raise Exception('No repeated exposure time sets found within the frames for k gain calibration.')
     elif not actual_visit and (cal_type.lower() == 'k-gain' or cal_type.lower() == 'kgain'):
         # then keep them all
         inds_leave_out = []
         del_rep_inds_tot = []
-    
+
     # Sort unity gain filenames
-    # Update OBSNAME and take profit to check files are in the list
+    # Update OBSNAME and check files are in the list
     n_kgain = 0
     cal_frame_list = []
     index = -1 #initiate
-    for subset in unity_gain_exptimes_auxs:
-        for i in range(len(subset)):
-            index += 1
-            frame = subset.frames[i]
-            if frame.filepath in unity_gain_filepath_list:
-                if index in inds_leave_out:
-                    continue
-                vistype = frame.pri_hdr['VISTYPE']
-                frame.pri_hdr['OBSNAME'] = 'KGAIN'
-                cal_frame_list += [frame]
-                n_kgain += 1
-
+    # for subset in unity_gain_wo_mean_frames:
+    for i in range(len(aux_set_to_use)):
+        index += 1
+        frame = aux_set_to_use.frames[i]
+        if frame.filepath in unity_gain_filepath_list:
+            if index in inds_leave_out:
+                continue
+            vistype = frame.pri_hdr['VISTYPE']
+            frame.pri_hdr['OBSNAME'] = 'KGAIN'
+            cal_frame_list += [frame]
+            n_kgain += 1
+    kgain_exptimes = np.delete(exptime_cons, np.array(del_rep_inds_tot).astype(int)).astype(float)
+    kgain_frame_numbers = np.delete(count_cons, np.array(del_rep_inds_tot).astype(int)).astype(int)
     sorting_summary += (f'K-gain has {n_kgain} unity frames with exposure ' +
-        f'times {list(np.delete(exptime_cons, np.array(del_rep_inds_tot).astype(int)))} seconds with ' +
-        f'{list(np.delete(count_cons, np.array(del_rep_inds_tot).astype(int)))} frames each. ')
+        f'times {kgain_exptimes.tolist()} seconds with ' +
+        f'{kgain_frame_numbers.tolist()} frames each. ')
 
     # Non-unity gain frames for Non-linearity
     if cal_type.lower()[0:7] == 'non-lin' or cal_type.lower()[0:6] == 'nonlin':
         # Non-unity gain frames
         split_cmdgain[0].remove(split_cmdgain[0][idx_unity])
         split_cmdgain[1].remove(split_cmdgain[1][idx_unity])
-        
+
         n_nonlin = 0
         nonlin_emgain = []
         for idx_gain_set, gain_set in enumerate(split_cmdgain[0]):
             nonunity_split_exptime = gain_set.split_dataset(exthdr_keywords=['EXPTIME'])
-            # in the datasets, use the AUXFILE with the most frames
+            # in the datasets, use the AUXFILE with the most frames unless the specific AUXFILE name available
             exptimes_auxs = []
             for dataset in nonunity_split_exptime[0]:
                 subs, vals = dataset.split_dataset(prihdr_keywords=['AUXFILE'])
@@ -400,12 +430,12 @@ def sort_pupilimg_frames(
                         n_nonlin += 1
             nonlin_emgain += [split_cmdgain[1][idx_gain_set]]
 
-            sorting_summary += (f'Non-linearity has {n_nonlin} frames with gains ' +
-                f'{nonlin_emgain}')
-        
+        sorting_summary += (f'Non-linearity has {n_nonlin} frames with gains ' +
+            f'{nonlin_emgain}') 
+
     history = (f'Dataset to calibrate {cal_type.upper()}. A sorting algorithm ' +
-        'based on the constraints that NFRAMES, EXPTIME and CMDGAIN have when collecting ' +
-        'calibration data for K-gain, Non-linearity and EM-gain vs DAC '
+        'based on the constraints that the number of frames, EXPTIME and EMGAIN_C have when collecting ' +
+        'calibration data for k gain, non-linearity and EM gain vs DAC '
         f"was applied to an input dataset from {vistype} visit files." +
         f'The result: {sorting_summary}')
     print(history)

--- a/corgidrp/sorting.py
+++ b/corgidrp/sorting.py
@@ -362,7 +362,12 @@ def sort_pupilimg_frames(
         split_exptime[0].remove(split_exptime[0][idx_mean_frame])
 
     # K gain frames in same AUXFILE used for mean frame
-    inds_leave_out, del_rep_inds_tot, exptime_cons, count_cons, unity_gain_filepath_list = sort_remove_frames([aux_set_to_use], cal_type=cal_type, actual_visit=actual_visit)
+    if actual_visit:
+        unity_gain_exptimes_auxs = [aux_set_to_use]
+    else:
+        unity_gain_exptimes_auxs = split_exptime[0]
+    inds_leave_out, del_rep_inds_tot, exptime_cons, count_cons, unity_gain_filepath_list = sort_remove_frames(unity_gain_exptimes_auxs, cal_type=cal_type, actual_visit=actual_visit)
+    
     if actual_visit and (inds_leave_out is None or del_rep_inds_tot is None):
         raise Exception('No repeated exposure time sets found within the frames for k gain calibration.')
     elif not actual_visit and (cal_type.lower() == 'k-gain' or cal_type.lower() == 'kgain'):
@@ -376,16 +381,17 @@ def sort_pupilimg_frames(
     cal_frame_list = []
     index = -1 #initiate
     # for subset in unity_gain_wo_mean_frames:
-    for i in range(len(aux_set_to_use)):
-        index += 1
-        frame = aux_set_to_use.frames[i]
-        if frame.filepath in unity_gain_filepath_list:
-            if index in inds_leave_out:
-                continue
-            vistype = frame.pri_hdr['VISTYPE']
-            frame.pri_hdr['OBSNAME'] = 'KGAIN'
-            cal_frame_list += [frame]
-            n_kgain += 1
+    for sub in unity_gain_exptimes_auxs:
+        for i in range(len(sub)):
+            index += 1
+            frame = sub.frames[i]
+            if frame.filepath in unity_gain_filepath_list:
+                if index in inds_leave_out:
+                    continue
+                vistype = frame.pri_hdr['VISTYPE']
+                frame.pri_hdr['OBSNAME'] = 'KGAIN'
+                cal_frame_list += [frame]
+                n_kgain += 1
     kgain_exptimes = np.delete(exptime_cons, np.array(del_rep_inds_tot).astype(int)).astype(float)
     kgain_frame_numbers = np.delete(count_cons, np.array(del_rep_inds_tot).astype(int)).astype(int)
     sorting_summary += (f'K-gain has {n_kgain} unity frames with exposure ' +

--- a/tests/e2e_tests/kgain_e2e.py
+++ b/tests/e2e_tests/kgain_e2e.py
@@ -146,6 +146,8 @@ def test_l1_to_kgain(e2edata_path, e2eoutput_path):
         with fits.open(filepath, mode='update') as hdul:
             if hdul[0].header.get('VISTYPE') in (None, 'N/A', 'PUPILIMG'):
                 hdul[0].header['VISTYPE'] = 'CGIVST_CAL_PUPIL_IMAGING'
+            if hdul[1].header['EMGAIN_C'] == 1.0:
+                hdul[0].header['AUXFILE'] = 'KGAIN' # something to differentiate from the default
 
     # Initialize a connection to the calibration database
     tmp_caldb_csv = os.path.join(corgidrp.config_folder, 'tmp_e2e_test_caldb.csv')

--- a/tests/e2e_tests/nonlin_e2e.py
+++ b/tests/e2e_tests/nonlin_e2e.py
@@ -108,6 +108,9 @@ def test_nonlin_cal_e2e(
             prihdr = fits_file[0].header
             prihdr['VISTYPE'] = 'CGIVST_CAL_PUPIL_IMAGING'
             prihdr['PHTCNT'] = "False"
+            exthdr = fits_file[1].header
+            if exthdr['EMGAIN_C'] == 1.0:
+                prihdr['AUXFILE'] = 'KGAIN' # something to differentiate from the default
 
     # Non-linearity calibration file used to compare the output from CORGIDRP:
     # We are going to make a new nonlinear calibration file using

--- a/tests/e2e_tests/nonlin_kgain_e2e.py
+++ b/tests/e2e_tests/nonlin_kgain_e2e.py
@@ -21,7 +21,9 @@ thisfile_dir = os.path.dirname(__file__)  # this file's folder
 def set_vistype_for_tvac(
     list_of_fits,
     ):
-    """ Adds proper values to VISTYPE for non-linearity calibration.
+    """ Adds proper values to VISTYPE for non-linearity calibration.  Also 
+    Adjusts AUXFILE appropriately for as expected from the CAR so that the 
+    sorting function gets metadata as it expects.
 
     This function is unnecessary with future data because data will have
     the proper values in VISTYPE. Hence, the "tvac" string in its name.
@@ -36,10 +38,11 @@ def set_vistype_for_tvac(
         # Adjust VISTYPE
         if prihdr['VISTYPE'] == 'N/A':
             prihdr['VISTYPE'] = 'CGIVST_CAL_PUPIL_IMAGING'
-            prihdr['VISTYPE'] = 'CGIVST_CAL_PUPIL_IMAGING'
         exthdr = fits_file[1].header
         if exthdr['EMGAIN_A'] == 1:
             exthdr['EMGAIN_A'] = -1 #for new SSC-updated TVAC files which have EMGAIN_A by default as 1 regardless of the commanded EM gain
+        if exthdr['EMGAIN_C'] == 1.0:
+            prihdr['AUXFILE'] = 'KGAIN' # something to differentiate the default
         # Update FITS file
         fits_file.writeto(file, overwrite=True)
 
@@ -118,6 +121,7 @@ def test_nonlin_and_kgain_e2e(
     pupilimg_l1_list = check.fix_hdrs_for_tvac(pupilimg_l1_list, input_data_dir)
 
     # Set TVAC data to have VISTYPE=CGIVST_CAL_PUPIL_IMAGING (flight data should have these values)
+    # Also set AUXFILE appropriately
     set_vistype_for_tvac(pupilimg_l1_list)
 
    # now get any default cal files that might be needed; if any reside in the folder that are not 
@@ -168,7 +172,7 @@ if __name__ == "__main__":
     # defaults allowing the use to edit the file if that is their preferred
     # workflow.
 
-    e2edata_dir = '/Users/jmilton/Documents/CGI/E2E_Test_Data2'#"/Users/kevinludwick/Library/CloudStorage/Box-Box/CGI_TVAC_Data/Working_Folder/"#'/home/jwang/Desktop/CGI_TVAC_Data/'
+    e2edata_dir = '/Users/kevinludwick/Documents/DRP_E2E_Test_Files_v2/E2E_Test_Data'#'/Users/jmilton/Documents/CGI/E2E_Test_Data2'#"/Users/kevinludwick/Library/CloudStorage/Box-Box/CGI_TVAC_Data/Working_Folder/"#'/home/jwang/Desktop/CGI_TVAC_Data/'
     #e2edata_dir = "/Users/kevinludwick/Library/CloudStorage/Box-Box/CGI_TVAC_Data/Working_Folder/"
     OUTPUT_DIR = thisfile_dir
 

--- a/tests/test_sort_pupilimg_frames.py
+++ b/tests/test_sort_pupilimg_frames.py
@@ -295,7 +295,7 @@ def setup_module():
     # Values for mean frame
     cmdgain_mean_frame, exptime_mean_frame = get_cmdgain_exptime_mean_frame(
         exptime_sec=EXPTIME_MEAN_FRAME,
-        nframes=NFRAMES_MEAN_FRAME,
+        nframes=NFRAMES_MEAN_FRAME
         )
     
     if len(cmdgain_mean_frame) != len(exptime_mean_frame):
@@ -306,7 +306,7 @@ def setup_module():
     # Values for K-gain
     cmdgain_kgain, exptime_kgain = get_cmdgain_exptime_kgain(
         exptime_sec=EXPTIME_KGAIN,
-        nframes=NFRAMES_KGAIN,
+        nframes=NFRAMES_KGAIN
         )
     if len(cmdgain_kgain) != len(exptime_kgain):
         raise Exception('Inconsistent lengths in k-gain')
@@ -317,7 +317,7 @@ def setup_module():
     cmdgain_nonlin_wo_change, exptime_nonlin_wo_change = get_cmdgain_exptime_nonlin(
         exptime_sec=EXPTIME_NONLIN,
         nonunity_em=CMDGAIN_NONLIN,
-        change_exptime=False,
+        change_exptime=False
         )
     if len(cmdgain_nonlin_wo_change) != len(exptime_nonlin_wo_change):
         raise Exception('Inconsistent lengths in non-linearity')
@@ -327,7 +327,7 @@ def setup_module():
     cmdgain_nonlin_w_change, exptime_nonlin_w_change = get_cmdgain_exptime_nonlin(
         exptime_sec=EXPTIME_NONLIN,
         nonunity_em=CMDGAIN_NONLIN,
-        change_exptime=True,
+        change_exptime=True
         )
     if len(cmdgain_nonlin_w_change) != len(exptime_nonlin_w_change):
         raise Exception('Inconsistent lengths in non-linearity')
@@ -338,7 +338,7 @@ def setup_module():
     cmdgain_emgain, exptime_emgain = get_cmdgain_exptime_emgain(
         em_emgain = EM_EMGAIN,
         exptime_emgain_sec = EXPTIME_EMGAIN_SEC,
-        nframes = NFRAMES_EMGAIN,
+        nframes = NFRAMES_EMGAIN
         )
     if len(cmdgain_emgain) != len(exptime_emgain):
         raise Exception(f'Inconsistent lengths in em-gain vs dac')
@@ -369,7 +369,8 @@ def setup_module():
             exptime_sec=exptime_mean_frame[i_f],
             frameid=idx_frame,
             previous_exptime=0 if i_f == 0 else exptime_mean_frame[i_f-1],
-            previous_timestamp=previous_timestamp
+            previous_timestamp=previous_timestamp,
+            auxfile='KGAIN'
             )
         previous_timestamp = fits.getheader(filename, 1)['DATETIME']
         timestamps += [previous_timestamp]
@@ -384,7 +385,8 @@ def setup_module():
             exptime_sec=exptime_kgain[i_f],
             frameid=idx_frame,
             previous_exptime=exptime_mean_frame[-1] if i_f == 0 else exptime_kgain[i_f-1],
-            previous_timestamp=previous_timestamp
+            previous_timestamp=previous_timestamp,
+            auxfile='KGAIN'
             )
         previous_timestamp = fits.getheader(filename, 1)['DATETIME']
         timestamps += [previous_timestamp]
@@ -399,7 +401,8 @@ def setup_module():
             exptime_sec=exptime_emgain[i_f],
             frameid=idx_frame,
             previous_exptime=exptime_kgain[-1] if i_f == 0 else exptime_emgain[i_f-1],
-            previous_timestamp=previous_timestamp
+            previous_timestamp=previous_timestamp,
+            auxfile='EMGAIN'
             )
         previous_timestamp = fits.getheader(filename, 1)['DATETIME']
         timestamps += [previous_timestamp]
@@ -432,7 +435,8 @@ def setup_module():
             exptime_sec=exptime_nonlin_wo_change[i_f],
             frameid=idx_frame,
             previous_exptime=exptime_emgain[-1] if i_f == 0 else exptime_nonlin_wo_change[i_f-1],
-            previous_timestamp=previous_timestamp
+            previous_timestamp=previous_timestamp,
+            auxfile='NONLIN'
             )
         previous_timestamp = fits.getheader(filename, 1)['DATETIME']
         timestamps += [previous_timestamp]
@@ -447,7 +451,8 @@ def setup_module():
             exptime_sec=exptime_nonlin_w_change[i_f],
             frameid=idx_frame,
             previous_exptime=exptime_emgain[-1] if i_f == 0 else exptime_nonlin_w_change[i_f-1],
-            previous_timestamp=previous_timestamp
+            previous_timestamp=previous_timestamp,
+            auxfile='NONLIN'
             )
         previous_timestamp = fits.getheader(filename, 1)['DATETIME']
         timestamps += [previous_timestamp]


### PR DESCRIPTION
## Describe your changes
Currently, on develop, sorting.py includes some frames intended for EM gain cal into the k gain frames selected.  This wasn't caught before b/c the full list of frames specified by the CAR wasn't simulated before.  This PR fixes that and retrieves the right number of frames intended for k gain and nonlin (and doesn't use any EM gain cal frames).

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
N/A

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
