### PR TITLE
make noise column in add_shot_noise_to_err() include read noise

### DIFF
--- a/corgidrp/calibrate_kgain.py
+++ b/corgidrp/calibrate_kgain.py
@@ -790,7 +790,7 @@ def calibrate_kgain(dataset_kgain,
     
     # prepare PTC array
     ptc_list = [compiled_binned_averages, 
-                current_binned_total_deviations]
+                compiled_binned_total_deviations]
     ptc = np.column_stack(ptc_list)
 
     invalid_krn_keywords = data.typical_cal_invalid_keywords + ['EXPTIME', 'EMGAIN_C', 'EMGAIN_A', 'HVCBIAS']

--- a/corgidrp/calibrate_kgain.py
+++ b/corgidrp/calibrate_kgain.py
@@ -790,7 +790,7 @@ def calibrate_kgain(dataset_kgain,
     
     # prepare PTC array
     ptc_list = [compiled_binned_averages, 
-             compiled_binned_shot_deviations]
+                current_binned_total_deviations]
     ptc = np.column_stack(ptc_list)
 
     invalid_krn_keywords = data.typical_cal_invalid_keywords + ['EXPTIME', 'EMGAIN_C', 'EMGAIN_A', 'HVCBIAS']

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -10,11 +10,13 @@ from corgidrp.detector import detector_areas, ENF
 
 def add_shot_noise_to_err(input_dataset, kgain, detector_params):
     """
-    Propagate the Poisson/shot noise determined from the image signal to the error map. 
+    Propagate the Poisson/shot noise determined from the image signal to the error map. Also 
+    includes the effect of read noise.
     Estimation of photon/poisson/shot noise by interpolation of the photon transfer curve,
     added excess noise in case of em_gain > 1.
     Especially useful when a dataset has very few frames so that the shot noise is not
-    accurately obtained by averaging the frames.
+    accurately obtained by averaging the frames, nor is the read noise effectively mitigated through 
+    averaging.
 
     Args:
        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)


### PR DESCRIPTION
Read noise is present in the frame, so when you add_shot_noise_to_err() interpolates the noise based on the frame data, you are actually including the read noise in the signal input, whereas the PTC data currently assumes no read noise in the signal. Since read noise has 0 mean, this is approximately correct, but not so much for few frames in a dataset (for which add_shot_noise_to_err() is intended), but separating read noise from shot noise would involve averaging frames, which is the very thing this step function is avoiding b/c there are few frames presumably. So this PR makes that error column in the PTC include read noise. 

## Describe your changes
Replaced column in PTC for shot noise with shot + read noise (already computed in calibrate_kgain).  The issue 405 mentioned adding a 3rd column in the PTC for shot + read noise, but the only use of the 2nd column (shot noise) was in the add_shot_noise_to_err() function, so I just replaced the column instead, which also avoids a change to data format for the k gain cal product.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
#405 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
