### PR TITLE
Fix photon counting e2e test failure

### DIFF
--- a/tests/e2e_tests/photon_count_e2e.py
+++ b/tests/e2e_tests/photon_count_e2e.py
@@ -127,14 +127,13 @@ def test_expected_results_e2e(e2edata_path, e2eoutput_path):
     input_non_linearity_filename = "nonlin_table_TVAC.txt"
     input_non_linearity_path = os.path.join(tests_dir, "test_data", input_non_linearity_filename)
     test_non_linearity_filename = input_non_linearity_filename.split(".")[0] + ".fits"
-    nonlin_fits_filepath = os.path.join(tests_dir, "test_data", test_non_linearity_filename)
+    nonlin_fits_filepath = os.path.join(calibrations_dir, test_non_linearity_filename)
     tvac_nonlin_data = np.genfromtxt(input_non_linearity_path, delimiter=",")
 
     pri_hdr, ext_hdr, errhdr, dqhdr = mocks.create_default_calibration_product_headers()
     new_nonlinearity = data.NonLinearityCalibration(tvac_nonlin_data,pri_hdr=pri_hdr,ext_hdr=ext_hdr,input_dataset = dummy_dataset)
     new_nonlinearity.filename = nonlin_fits_filepath
-    new_nonlinearity.pri_hdr = pri_hdr
-    new_nonlinearity.ext_hdr = ext_hdr
+    mocks.rename_files_to_cgi_format(list_of_fits=[new_nonlinearity], output_dir=calibrations_dir, level_suffix="nln_cal")
     this_caldb.create_entry(new_nonlinearity)
 
     ## Flat field


### PR DESCRIPTION
## Describe your changes
PC E2E test was not using the mock nonlin calibration it made itself. I updated the code to save and use the mock nonlin calibration that is created in the code now. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [ ] I have checked that I am merging into the right branch
- [ ] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [ ] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
