### PR TITLE
issue #825 Require input_dataset for new FluxcalFactor

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -2182,6 +2182,41 @@ class FluxcalFactor(Image):
         else:
             super().__init__(data_or_filepath, err=err, pri_hdr=pri_hdr, ext_hdr=ext_hdr, err_hdr=err_hdr)
         # if filepath passed in, just load in from disk as usual
+        
+                # if this is a new FluxcalFactors file, we need to bookkeep it in the header
+        # b/c of logic in the super.__init__, we just need to check this to see if it is a new FluxcalFactors file
+        if ext_hdr is not None:
+            if input_dataset is None:
+                raise ValueError("This appears to be a new FluxcalFactor. The dataset of input files needs to be passed \
+                                 in to the input_dataset keyword to record history of this FluxcalFactor file.")
+            else:
+                # log all the data that went into making this calibration file
+                self._record_parent_filenames(input_dataset)
+                # give it a default filename using the first input file as the base
+                # strip off everything starting at .fits
+                orig_input_filename = input_dataset[-1].filename.split(".fits")[0]
+
+            self.ext_hdr['DATATYPE'] = 'FluxcalFactor' # corgidrp specific keyword for saving to disk
+            # JM: moved the below to fluxcal.py since it varies depending on the method
+            #self.ext_hdr['BUNIT'] = 'erg/(s * cm^2 * AA)/(photoelectron/s)'
+            #self.err_hdr['BUNIT'] = 'erg/(s * cm^2 * AA)/(photoelectron/s)'
+            # add to history
+            self.ext_hdr['HISTORY'] = "Flux calibration file created"
+
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
+            self.ext_hdr['DRPVERSN'] =  corgidrp.__version__
+            self.ext_hdr['DRPCTIME'] =  time.Time.now().isot
+            # use the start date for the filename by default
+            self.filedir = "."
+            # slight hack for old mocks not in the standard filename format
+            if input_dataset is not None:
+                self.filename = "{0}_abf_cal.fits".format(orig_input_filename)
+                self.filename = re.sub('_l[0-9].', '', self.filename)
+            else:
+                self.filename = re.sub(r'\.fits$', '_abf_cal.fits', self.pri_hdr['FILENAME'])
+            self.pri_hdr['FILENAME'] = self.filename
+        
         # File format checks
         if self.data.shape != (1,):
             raise ValueError('The FluxcalFactor calibration data should be just one float value')
@@ -2212,50 +2247,10 @@ class FluxcalFactor(Image):
                 raise ValueError("File that was loaded was not a FluxcalFactor file.")
             if self.ext_hdr['DATATYPE'] != 'FluxcalFactor':
                 raise ValueError("File that was loaded was not a FluxcalFactor file.")
-        else:
-            self.ext_hdr['DRPVERSN'] =  corgidrp.__version__
-            self.ext_hdr['DRPCTIME'] =  time.Time.now().isot
             
         # make some attributes to be easier to use
         self.fluxcal_fac = self.data[0]
         self.fluxcal_err =  self.err[0]
-
-        # if this is a new FluxcalFactors file, we need to bookkeep it in the header
-        # b/c of logic in the super.__init__, we just need to check this to see if it is a new FluxcalFactors file
-        if ext_hdr is not None:
-            if input_dataset is None:
-                if 'DRPNFILE' not in ext_hdr:
-                    # error check. this is required in this case
-                    raise ValueError("This appears to be a new FluxcalFactor. The dataset of input files needs to be passed \
-                                     in to the input_dataset keyword to record history of this FluxcalFactor file.")
-                else:
-                    pass
-            else:
-                # log all the data that went into making this calibration file
-                self._record_parent_filenames(input_dataset)
-                # give it a default filename using the first input file as the base
-                # strip off everything starting at .fits
-                orig_input_filename = input_dataset[-1].filename.split(".fits")[0]
-
-            self.ext_hdr['DATATYPE'] = 'FluxcalFactor' # corgidrp specific keyword for saving to disk
-            # JM: moved the below to fluxcal.py since it varies depending on the method
-            #self.ext_hdr['BUNIT'] = 'erg/(s * cm^2 * AA)/(photoelectron/s)'
-            #self.err_hdr['BUNIT'] = 'erg/(s * cm^2 * AA)/(photoelectron/s)'
-            # add to history
-            self.ext_hdr['HISTORY'] = "Flux calibration file created"
-
-            # Enforce data level = CAL
-            self.ext_hdr['DATALVL']    = 'CAL'
-
-            # use the start date for the filename by default
-            self.filedir = "."
-            # slight hack for old mocks not in the standard filename format
-            if input_dataset is not None:
-                self.filename = "{0}_abf_cal.fits".format(orig_input_filename)
-                self.filename = re.sub('_l[0-9].', '', self.filename)
-            else:
-                self.filename = re.sub(r'\.fits$', '_abf_cal.fits', self.pri_hdr['FILENAME'])
-            self.pri_hdr['FILENAME'] = self.filename
 
 class SpecFluxCal(Image):
     """
@@ -2290,7 +2285,37 @@ class SpecFluxCal(Image):
     def __init__(self, data_or_filepath, err = None, dq = None, pri_hdr=None, ext_hdr=None, err_hdr = None, input_dataset = None):
        # run the image class contructor
         super().__init__(data_or_filepath, err=err, dq = dq, pri_hdr=pri_hdr, ext_hdr=ext_hdr, err_hdr=err_hdr)
-        # if filepath passed in, just load in from disk as usual
+        # if this is a new SpecFluxCal file, we need to bookkeep it in the header
+        # b/c of logic in the super.__init__, we just need to check this to see if it is a new SpecFluxCal file
+        if ext_hdr is not None:
+            if input_dataset is None:
+                raise ValueError("This appears to be a new SpecFluxCal. The dataset of input files needs to be passed \
+                                     in to the input_dataset keyword to record history of this SpecFluxCal file.")
+            else:
+                # log all the data that went into making this calibration file
+                self._record_parent_filenames(input_dataset)
+                # give it a default filename using the first input file as the base
+                # strip off everything starting at .fits
+                orig_input_filename = input_dataset[-1].filename.split(".fits")[0]
+  
+            self.ext_hdr['DATATYPE'] = 'SpecFluxCal' # corgidrp specific keyword for saving to disk
+            self.ext_hdr['BUNIT'] = 'erg/(s * cm^2 * AA)/(photoelectron/s/bin)'
+            self.err_hdr['BUNIT'] = 'erg/(s * cm^2 * AA)/(photoelectron/s/bin)'
+            # add to history
+            self.ext_hdr['HISTORY'] = "Spectral flux calibration file created"
+
+            # Enforce data level = CAL
+            self.ext_hdr['DATALVL']    = 'CAL'
+            self.ext_hdr['DRPVERSN'] =  corgidrp.__version__
+            self.ext_hdr['DRPCTIME'] =  time.Time.now().isot
+            
+            # use the start date for the filename by default
+            self.filedir = "."
+            # slight hack for old mocks not in the standard filename format
+            self.filename = "{0}_sfl_cal.fits".format(orig_input_filename)
+            self.filename = re.sub('_l[0-9].', '', self.filename)
+            self.pri_hdr['FILENAME'] = self.filename
+
         # File format checks
         if self.data.shape[0] != 2:
             raise ValueError('The spectral flux calibration data should be a 2D array')
@@ -2307,9 +2332,6 @@ class SpecFluxCal(Image):
                 raise ValueError("File that was loaded was not a SpecFluxCal file.")
             if self.ext_hdr['DATATYPE'] != 'SpecFluxCal':
                 raise ValueError("File that was loaded was not a SpecFluxCal file.")
-        else:
-            self.ext_hdr['DRPVERSN'] =  corgidrp.__version__
-            self.ext_hdr['DRPCTIME'] =  time.Time.now().isot
             
         # make some attributes to be easier to use
         self.nd_filter = "ND0" #no neutral density filter in beam, TBC
@@ -2329,12 +2351,8 @@ class SpecFluxCal(Image):
         # b/c of logic in the super.__init__, we just need to check this to see if it is a new SpecFluxCal file
         if ext_hdr is not None:
             if input_dataset is None:
-                if 'DRPNFILE' not in ext_hdr:
-                    # error check. this is required in this case
-                    raise ValueError("This appears to be a new SpecFluxCal. The dataset of input files needs to be passed \
+                raise ValueError("This appears to be a new SpecFluxCal. The dataset of input files needs to be passed \
                                      in to the input_dataset keyword to record history of this SpecFluxCal file.")
-                else:
-                    pass
             else:
                 # log all the data that went into making this calibration file
                 self._record_parent_filenames(input_dataset)
@@ -2350,7 +2368,9 @@ class SpecFluxCal(Image):
 
             # Enforce data level = CAL
             self.ext_hdr['DATALVL']    = 'CAL'
-
+            self.ext_hdr['DRPVERSN'] =  corgidrp.__version__
+            self.ext_hdr['DRPCTIME'] =  time.Time.now().isot
+            
             # use the start date for the filename by default
             self.filedir = "."
             # slight hack for old mocks not in the standard filename format

--- a/tests/e2e_tests/l1_to_l4_pol_e2e.py
+++ b/tests/e2e_tests/l1_to_l4_pol_e2e.py
@@ -259,25 +259,19 @@ def run_l1_to_l4_e2e_test(l1_datadir, l4_outputdir, processed_cal_path, logger):
     #Create a mock flux calibration file (POL0)
     fluxcal_factor = 2e-12
     fluxcal_factor_error = 1e-14
-    prhd, exthd, errhd, dqhd = mocks.create_default_L3_headers()
+    fluxcal_fac = mocks.make_mock_fluxcal_factor(fluxcal_factor, err = fluxcal_factor_error, cfam_name = '1F', dpam_name = 'POL0')
     # Set consistent header values for flux calibration factor
-    exthd['CFAMNAME'] = '1F'
-    exthd['DPAMNAME'] = 'POL0'
-    exthd['FPAMNAME'] = 'HLC12_C2R1'
-    exthd['DRPNFILE'] = 0  # mock calibration, no input files
-    fluxcal_fac = data.FluxcalFactor(fluxcal_factor, err = fluxcal_factor_error, pri_hdr = prhd, ext_hdr = exthd, err_hdr = errhd)
-
+    fluxcal_fac.ext_hdr['FPAMNAME'] = 'HLC12_C2R1'
+    
     mocks.rename_files_to_cgi_format(list_of_fits=[fluxcal_fac], output_dir=calibrations_dir, level_suffix="abf_cal")
     this_caldb.create_entry(fluxcal_fac)
-
+    
     # POL45 absolute flux cal
-    prhd_pol45 = prhd.copy()
-    prhd_pol45['VISITID'] = str(int(prhd['VISITID']) + 1)
-    exthd_pol45 = exthd.copy()
-    exthd_pol45['DPAMNAME'] = 'POL45'
-    fluxcal_fac_pol45 = data.FluxcalFactor(
-        fluxcal_factor, err=fluxcal_factor_error, pri_hdr=prhd_pol45, ext_hdr=exthd_pol45, err_hdr=errhd.copy()
-    )
+    fluxcal_fac_pol45 = mocks.make_mock_fluxcal_factor(fluxcal_factor, err = fluxcal_factor_error, cfam_name = '1F', dpam_name = 'POL45')
+    fluxcal_fac_pol45.ext_hdr['FPAMNAME'] = 'HLC12_C2R1'
+    
+    fluxcal_fac_pol45.pri_hdr["VISITID"] = str(int(prhd['VISITID']) + 1)
+
     mocks.rename_files_to_cgi_format(list_of_fits=[fluxcal_fac_pol45], output_dir=calibrations_dir, level_suffix="abf_cal")
     this_caldb.create_entry(fluxcal_fac_pol45)
 
@@ -688,8 +682,8 @@ if __name__ == "__main__":
     # to edit the file. The arguments use the variables in this file as their
     # defaults allowing the use to edit the file if that is their preferred
     # workflow.
-    e2edata_dir = '/Users/jmilton/Documents/CGI/E2E_Test_Data2'
-    outputdir = '/Users/jmilton/Github/corgidrp/tests/e2e_tests'
+    e2edata_dir = '/home/schreiber/DataCopy/E2E_Test_Data'
+    outputdir = thisfile_dir
 
     ap = argparse.ArgumentParser(description="run the l1->l4 polarimetry end-to-end test with recipe chaining")
     ap.add_argument("-tvac", "--e2edata_dir", default=e2edata_dir,

--- a/tests/e2e_tests/l3_to_l4_pol_e2e.py
+++ b/tests/e2e_tests/l3_to_l4_pol_e2e.py
@@ -152,33 +152,25 @@ def test_l3_to_l4_pol_e2e(e2edata_path, e2eoutput_path):
     #Create a mock flux calibration file
     fluxcal_factor = 2e-12
     fluxcal_factor_error = 1e-14
-    prhd, exthd, errhd, dqhd = mocks.create_default_L3_headers()
+    fluxcal_fac = mocks.make_mock_fluxcal_factor(fluxcal_factor, err = fluxcal_factor_error, cfam_name = '1F', dpam_name = 'POL0')
     # Set consistent header values for flux calibration factor
-    exthd['CFAMNAME'] = '1F'
-    exthd['DPAMNAME'] = 'POL0'
-    exthd['FPAMNAME'] = 'HLC12_C2R1'
-    exthd['DRPNFILE'] = 0  # mock calibration, no input files
-    fluxcal_fac = data.FluxcalFactor(fluxcal_factor, err = fluxcal_factor_error, pri_hdr = prhd, ext_hdr = exthd, err_hdr = errhd)
-
+    fluxcal_fac.ext_hdr['FPAMNAME'] = 'HLC12_C2R1'
+  
     mocks.rename_files_to_cgi_format(list_of_fits=[fluxcal_fac], output_dir=calibrations_dir, level_suffix="abf_cal")
     this_caldb.create_entry(fluxcal_fac)
-
+    
     # Create a POL45 flux calibration file
-    prhd_pol45 = prhd.copy()
+    fluxcal_fac_pol45 = mocks.make_mock_fluxcal_factor(fluxcal_factor, err = fluxcal_factor_error, cfam_name = '1F', dpam_name = 'POL45')
+    fluxcal_fac_pol45.ext_hdr['FPAMNAME'] = 'HLC12_C2R1'
     # offset FILETIME by 1 second to avoid filename collision
     from datetime import datetime, timedelta
-    ft_str = prhd_pol45['FILETIME']
+    ft_str = fluxcal_fac_pol45.pri_hdr['FILETIME'].split("+")[0]
     try:
         ft = datetime.strptime(ft_str, '%Y-%m-%dT%H:%M:%S.%f')
     except ValueError:
         ft = datetime.strptime(ft_str, '%Y-%m-%dT%H:%M:%S')
-    prhd_pol45['FILETIME'] = (ft + timedelta(seconds=1)).isoformat()
-    exthd_pol45 = exthd.copy()
-    exthd_pol45['DPAMNAME'] = 'POL45'
-    fluxcal_fac_pol45 = data.FluxcalFactor(
-        fluxcal_factor, err=fluxcal_factor_error,
-        pri_hdr=prhd_pol45, ext_hdr=exthd_pol45, err_hdr=errhd
-    )
+    fluxcal_fac_pol45.pri_hdr['FILETIME'] = (ft + timedelta(seconds=1)).isoformat()
+
     mocks.rename_files_to_cgi_format(
         list_of_fits=[fluxcal_fac_pol45],
         output_dir=calibrations_dir,
@@ -492,7 +484,7 @@ def test_l3_to_l4_pol_e2e(e2edata_path, e2eoutput_path):
 
 if __name__ == "__main__":
     #e2edata_dir = "/Users/macuser/Roman/corgidrp_develop/calibration_notebooks/TVAC"
-    e2edata_dir = '/Users/jmilton/Documents/CGI/E2E_Test_Data2'
+    e2edata_dir = '/home/schreiber/DataCopy/E2E_Test_Data'
     outputdir = thisfile_dir
 
     ap = argparse.ArgumentParser(description="run the l1->l2b->boresight end-to-end test")


### PR DESCRIPTION
## Describe your changes
In some cases FluxcalFactor could be instantiated without input_dataset. This is changed, and l3/1_to_l4_pol e2e tests are adjusted.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
#825

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
