### PR TITLE
fixed legacy frame filter

### DIFF
--- a/corgidrp/pump_trap_calibration.py
+++ b/corgidrp/pump_trap_calibration.py
@@ -2380,7 +2380,8 @@ def tpump_analysis(input_dataset, time_head = 'TPTAU',
                 # Check if mean of a central 300x300 region is 0 (since read noise has mean of 0 and bias has already been subtracted).  If so, reject since it's a legacy frame.
                 # Don't reject it at beginning of recipe, though, since they may be used once TPUMP CAR is finalized.
                 #if np.abs(frame_data[0:1027]).max()==0:
-                central_mean_value = np.mean(frame_data[frame_data.shape[0]/2-150:frame_data.shape[0]/2+150, frame_data.shape[1]/2-150:frame_data.shape[1]/2+150])
+                halfway_row, halfway_col = int(frame_data.shape[0]/2), int(frame_data.shape[1]/2)
+                central_mean_value = np.mean(frame_data[halfway_row-150:halfway_row+150, halfway_col-150:halfway_col+150])
                 if np.abs(central_mean_value) < 10: 
                     continue #skip these frames; even if some legacy ones made it through, they wouldn't actually have any dipoles in them to find
                 timings.append(phase_time)   

--- a/corgidrp/pump_trap_calibration.py
+++ b/corgidrp/pump_trap_calibration.py
@@ -2376,9 +2376,13 @@ def tpump_analysis(input_dataset, time_head = 'TPTAU',
                     frame_data = fr.data
                 else:
                     frame_data = frame.data
-                # ignore legacy frames, which are 0 except for rows 1027 through 1037 in imaging area (rows 0-1037, cols 1088-2144)
-                if np.abs(frame_data[0:1027]).max()==0:
-                    continue 
+                # ignore legacy frames, which have no illumination (just bias and read noise) except for rows 1027 through 1037 in imaging area (rows 0-1037, cols 1088-2144)
+                # Check if mean of a central 300x300 region is 0 (since read noise has mean of 0 and bias has already been subtracted).  If so, reject since it's a legacy frame.
+                # Don't reject it at beginning of recipe, though, since they may be used once TPUMP CAR is finalized.
+                #if np.abs(frame_data[0:1027]).max()==0:
+                central_mean_value = np.mean(frame_data[frame_data.shape[0]/2-150:frame_data.shape[0]/2+150, frame_data.shape[1]/2-150:frame_data.shape[1]/2+150])
+                if np.abs(central_mean_value) < 10: 
+                    continue #skip these frames; even if some legacy ones made it through, they wouldn't actually have any dipoles in them to find
                 timings.append(phase_time)   
                 frames.append(frame_data)
 

--- a/corgidrp/pump_trap_calibration.py
+++ b/corgidrp/pump_trap_calibration.py
@@ -2128,7 +2128,7 @@ def tpump_analysis(input_dataset, time_head = 'TPTAU',
     cs_fit_thresh = 0.8, E_min = 0, E_max = 1, cs_min = 0,
     cs_max = 50, bins_E = 100, bins_cs = 10, input_T = 180,
     sample_data = False,
-    verbose=False, bin_size=10):
+    verbose=False, bin_size=10, bias_tolerance=10):
     """This function analyzes trap-pumped frames and outputs the location of
     each radiation trap (pixel and sub-electrode location within the pixel),
     everything needed to determine the release time constant at any temperature
@@ -2213,6 +2213,8 @@ def tpump_analysis(input_dataset, time_head = 'TPTAU',
         bin_size (int, optional): Side length of the square of pixels to consider for binning in illumination_correction(). If None, the square root of the smaller dimension (the smaller of the number of rows and number of cols) is used. Defaults to 10. 
             If a value bigger than the smaller dimension is input, then the size of the smaller dimension is used instead.  The optimal value for bin_size depends on the trap density, which is unknown, so in principle, 
             this function could be run several times with decreasing bin size until the maximum number of traps have been detected.
+        bias_tolerance (float, optional): Used for filtering out legacy frames. Legacy frames have no illumination except for in the last few rows, so the average of a central region of the imaging area should be close to 0 since bias was 
+            already subtracted out (and the average takes care of read noise). Even if a legacy frame slips through, it will not cause any harm to the processing since no dipoles would be found in such a frame. Defaults to 10.
     
     Returns:
         corgidrp.data.TrapCalibration: An object containing the results of the trap calibration. The trap densities are appended as an extension HDU, and several other parameters are stored as header keywords in the ext_hdr header.
@@ -2382,7 +2384,7 @@ def tpump_analysis(input_dataset, time_head = 'TPTAU',
                 #if np.abs(frame_data[0:1027]).max()==0:
                 halfway_row, halfway_col = int(frame_data.shape[0]/2), int(frame_data.shape[1]/2)
                 central_mean_value = np.mean(frame_data[halfway_row-150:halfway_row+150, halfway_col-150:halfway_col+150])
-                if np.abs(central_mean_value) < 10: 
+                if np.abs(central_mean_value) < bias_tolerance: 
                     continue #skip these frames; even if some legacy ones made it through, they wouldn't actually have any dipoles in them to find
                 timings.append(phase_time)   
                 frames.append(frame_data)


### PR DESCRIPTION
## Describe your changes
Rejection of legacy frames for trap-pumping was incorrect; it ignored bias and read noise when checking the frame values (due to a misunderstanding on my part about how legacy frames were actually made).  Fixed now so that if the mean of a 300x300 region in the center of the imaging area has a mean of 0 to within 10DN, reject the frame.  The code runs fine even without this "fix"; the fix just allows for more unnecessary frames to be rejected and reduce the amount of memory used.  At most, without this fix, at most 1200 1037x1056 frames would be held in memory and processed in the trap-pump function, whereas after this fix, at most 300 1037x1056 frames would be held in memory.  About 482 imaging-area frames is 100GB.  Tagging @mygouf for cognizance. 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
N/A

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
