### PR TITLE
Enable dark subtraction on dataset with multiple detector settings

### DIFF
--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -68,13 +68,16 @@ def dark_subtraction(input_dataset, noisemaps=None, dark=None, detector_regions=
 
     Perform dark subtraction of a dataset using the corresponding dark frame.  The dark frame can be either a synthesized master dark (made for any given EM gain and exposure time)
     or for a traditional master dark (average of darks taken at the EM gain and exposure time of the corresponding observation).  The function gives preference for the traditional master dark if provided.
-    If the frames are photon-counted (PC) and a PC dark is provided, the subtraction will not happen here but instead in the PC function pc_mean(), later in the pipeline.  
+    If the frames are photon-counted (PC) and a PC dark is provided, the subtraction will not happen here but instead in the PC function pc_mean(), later in the pipeline.
     The master dark is also saved if it is of the synthesized type after it is built.
+    When noisemaps is provided (and dark is not), the dataset may contain frames with multiple distinct
+    EMGAIN and exposure time configurations; a separate synthesized dark is built for each configuration.
 
     Args:
         input_dataset (corgidrp.data.Dataset): a dataset of Images that need dark subtraction (L2a-level)
-        noisemaps (corgidrp.data.DetectorNoiseMaps): If not None and if dark input not provided, a synthesized master dark is created using this DetectorNoiseMaps object 
-            for the EM gain and exposure time used in the frames in input_dataset.
+        noisemaps (corgidrp.data.DetectorNoiseMaps): If not None and if dark input not provided, a synthesized master dark is created using this DetectorNoiseMaps object
+            for the EM gain and exposure time used in the frames in input_dataset.  Multiple EMGAIN/EXPTIME
+            configurations within input_dataset are supported in this mode.
         dark (corgidrp.data.Dark or corgidrp.data.DetectorNoiseMaps): If dark is of the corgidrp.data.Dark type, dark subtraction will be done with this input whether noisemaps is specified or not.
         detector_regions: (dict):  A dictionary of detector geometry properties.  Keys should be as found in detector_areas in detector.py. Defaults to detector_areas in detector.py.
         outputdir (string): Filepath for output directory where to save the master dark if it is a synthesized master dark.  Defaults to current directory.
@@ -87,7 +90,18 @@ def dark_subtraction(input_dataset, noisemaps=None, dark=None, detector_regions=
     if input_dataset[0].ext_hdr['BUNIT'] != "detected electron":
         if input_dataset[0].ext_hdr['ISPC'] == 0: #i.e., analog
             raise ValueError ("input dataset must have unit 'detected electron' for dark subtraction, not {0}".format(input_dataset[0].ext_hdr['BUNIT']))
-    _, unique_vals = input_dataset.split_dataset(exthdr_keywords=['EXPTIME', 'EMGAIN_C', 'KGAINPAR'])
+    sub_datasets, unique_vals = input_dataset.split_dataset(exthdr_keywords=['EXPTIME', 'EMGAIN_C', 'KGAINPAR'])
+
+    # When synthesizing darks from noisemaps, multiple detector configurations are supported:
+    # split by configuration, process each subset, and recombine.
+    if type(noisemaps) is data.DetectorNoiseMaps and dark is None and len(unique_vals) > 1:
+        output_frames = []
+        for sub_dataset in sub_datasets:
+            sub_result = dark_subtraction(sub_dataset, noisemaps=noisemaps,
+                                          detector_regions=detector_regions, outputdir=outputdir)
+            output_frames.extend(sub_result.frames)
+        return data.Dataset(output_frames)
+
     if len(unique_vals) > 1:
         raise Exception('Input dataset should contain frames of the same exposure time, commanded EM gain, and k gain.')
 
@@ -112,6 +126,12 @@ def dark_subtraction(input_dataset, noisemaps=None, dark=None, detector_regions=
         dark = build_synthesized_dark(input_dataset, noisemaps, detector_regions=detector_regions, full_frame=full_frame)
         if outputdir is None:
             outputdir = '.' #current directory
+        # Embed gain and exposure time in the filename so that darks from different
+        # detector configurations (e.g., multiple recursive calls) do not overwrite each other.
+        dark_basename = dark.filename.replace('.fits', '')
+        dark.filename = "{0}_g{1:g}_t{2:g}s.fits".format(
+            dark_basename, dark.ext_hdr['EMGAIN_C'], dark.ext_hdr['EXPTIME'])
+        dark.pri_hdr['FILENAME'] = dark.filename
         dark.save(filedir=outputdir)
     elif type(dark) is data.Dark: # dark is used whether noisemaps is provided or not 
         if 'PC_STAT' in dark.ext_hdr:

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -126,12 +126,12 @@ def dark_subtraction(input_dataset, noisemaps=None, dark=None, detector_regions=
         dark = build_synthesized_dark(input_dataset, noisemaps, detector_regions=detector_regions, full_frame=full_frame)
         if outputdir is None:
             outputdir = '.' #current directory
-        # Embed gain and exposure time in the filename so that darks from different
-        # detector configurations (e.g., multiple recursive calls) do not overwrite each other.
-        dark_basename = dark.filename.replace('.fits', '')
-        dark.filename = "{0}_g{1:g}_t{2:g}s.fits".format(
-            dark_basename, dark.ext_hdr['EMGAIN_C'], dark.ext_hdr['EXPTIME'])
-        dark.pri_hdr['FILENAME'] = dark.filename
+        # Base the dark filename on the input science frame, replacing the data-level
+        # marker so the dark can be traced back to the data it was built from.
+        input_filename = input_dataset[-1].filename or input_dataset[-1].pri_hdr.get('FILENAME', '')
+        if '_l2a.' in input_filename:
+            dark.filename = input_filename.replace('_l2a.', '_drk_cal.')
+            dark.pri_hdr['FILENAME'] = dark.filename
         dark.save(filedir=outputdir)
     elif type(dark) is data.Dark: # dark is used whether noisemaps is provided or not 
         if 'PC_STAT' in dark.ext_hdr:

--- a/tests/test_dark_sub.py
+++ b/tests/test_dark_sub.py
@@ -185,5 +185,71 @@ def test_dark_sub():
 
     corgidrp.track_individual_errors = old_err_tracking
 
+def test_dark_sub_multi_config():
+    """
+    Verify that dark_subtraction handles a dataset with multiple EMGAIN/EXPTIME
+    configurations when noisemaps is provided, and that the traditional-dark path
+    still rejects multi-config input.
+    """
+    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
+    if not os.path.exists(calibdir):
+        os.mkdir(calibdir)
+
+    configs = [
+        {"EMGAIN_C": 10, "EXPTIME": 4},
+        {"EMGAIN_C": 20, "EXPTIME": 8},
+    ]
+
+    frames = []
+    for cfg in configs:
+        em_gain = cfg["EMGAIN_C"]
+        exptime = cfg["EXPTIME"]
+        # Frame data equal to the synthesized dark so the result should be ~0
+        frame_data = (noise_maps.FPN_map + noise_maps.CIC_map * em_gain + noise_maps.DC_map * exptime * em_gain) / em_gain
+        prihdr, exthdr, errhdr, dqhdr, _ = mocks.create_default_L2a_headers()
+        img = data.Image(frame_data, pri_hdr=prihdr, ext_hdr=exthdr, err_hdr=errhdr, dq_hdr=dqhdr)
+        img.ext_hdr['EMGAIN_C'] = em_gain
+        img.ext_hdr['EXPTIME'] = exptime
+        img.ext_hdr['KGAINPAR'] = 7.
+        img.ext_hdr['BUNIT'] = 'detected electron'
+        frames.append(img)
+
+    multi_config_dataset = data.Dataset(frames)
+
+    # use a fresh empty directory so every dark saved by the call is attributable to it
+    darkout = os.path.join(os.path.dirname(__file__), "testcalib_multiconfig")
+    if os.path.exists(darkout):
+        shutil.rmtree(darkout)
+    os.mkdir(darkout)
+
+    # noisemaps path: must succeed and produce ~0 result for each frame
+    result = l2a_to_l2b.dark_subtraction(multi_config_dataset, noisemaps=noise_maps, outputdir=darkout)
+    assert len(result) == len(frames)
+    for frame in result.frames:
+        # exclude telemetry row (last row) from the mean check
+        assert np.mean(frame.data[:-1, :]) == pytest.approx(0, abs=1e-2)
+
+    # one synthesized dark file must have been saved per configuration
+    saved_dark_files = [f for f in os.listdir(darkout) if "_drk_cal" in f and f.endswith(".fits")]
+    assert len(saved_dark_files) == len(configs)
+
+    # each saved dark must carry the EXPTIME and EMGAIN_C of one of the input configs
+    saved_configs = set()
+    for dark_file in saved_dark_files:
+        saved_dark = data.Dark(os.path.join(darkout, dark_file))
+        saved_configs.add((saved_dark.ext_hdr['EXPTIME'], saved_dark.ext_hdr['EMGAIN_C']))
+    expected_configs = {(cfg['EXPTIME'], cfg['EMGAIN_C']) for cfg in configs}
+    assert saved_configs == expected_configs
+
+    # traditional dark path: must still raise for multi-config datasets
+    dark_dataset = mocks.create_dark_calib_files(filedir=calibdir)
+    detector_params_local = data.DetectorParams({})
+    from corgidrp.darks import build_trad_dark
+    traditional_dark = build_trad_dark(dark_dataset, detector_params_local, full_frame=True)
+    with pytest.raises(Exception):
+        l2a_to_l2b.dark_subtraction(multi_config_dataset, dark=traditional_dark, outputdir=calibdir)
+
+
 if __name__ == "__main__":
     test_dark_sub()
+    test_dark_sub_multi_config()


### PR DESCRIPTION
## Describe your changes
Enables dark subtraction with detector noise map on dataset with mutiple settings (exptime, gain). Saves each synthetic dark using the input science dataset filenames as the base (and change ending to `drk_cal.fits`). This naming convention is to ensure each synthetic dark as a unique filename. 

## Type of change

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
Closes #803 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
