### PR TITLE
Fix CT cal FPAMNAME corruption when pupil image is first in dataset

### DIFF
--- a/corgidrp/corethroughput.py
+++ b/corgidrp/corethroughput.py
@@ -300,13 +300,27 @@ def generate_psf_cube(
         raise Exception(('The number of PSFs does not match the number of PSF '+
             ' locations.'))
 
-    # PSF cube header
-    ext_hdr = dataset[0].ext_hdr
+    # PSF cube header - use first off-axis frame so pupil image headers
+    # (e.g. FPAMNAME='OPEN_12') do not propagate into the calibration file
+    first_offaxis_frame = None
+    for frame in dataset:
+        try:
+            exthd = frame.ext_hdr
+            if not (exthd['DPAMNAME'] == 'PUPIL' and exthd['LSAMNAME'] == 'OPEN' and
+                    exthd['FSAMNAME'] == 'OPEN' and exthd['FPAMNAME'] == 'OPEN_12'):
+                first_offaxis_frame = frame
+                break
+        except KeyError:
+            first_offaxis_frame = frame
+            break
+    if first_offaxis_frame is None:
+        raise Exception('No off-axis PSF frame found in dataset')
+    ext_hdr = first_offaxis_frame.ext_hdr
     # Add EXTNAME
     psf_hdu = fits.ImageHDU(data=psf_cube, header=ext_hdr, name='PSFCUBE')
 
     # Data quality cube
-    dq_hdr = dataset[0].dq_hdr
+    dq_hdr = first_offaxis_frame.dq_hdr
     # Add specific information
     dq_hdr['COMMENT'] = 'Data quality for each image' 
     # Add EXTNAME

--- a/corgidrp/corethroughput.py
+++ b/corgidrp/corethroughput.py
@@ -8,6 +8,20 @@ from corgidrp import astrom, data
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+def _is_pupil_frame(frame):
+    """Return True if frame is a pupil image of the unocculted source.
+
+    Args:
+        frame (corgidrp.data.Image): a frame from a CT dataset.
+
+    Returns:
+        bool: True if the frame is a pupil image (DPAM=PUPIL, LSAM=OPEN,
+            FSAM=OPEN, FPAM=OPEN_12).
+    """
+    exthd = frame.ext_hdr
+    return (exthd['DPAMNAME'] == 'PUPIL' and exthd['LSAMNAME'] == 'OPEN' and
+            exthd['FSAMNAME'] == 'OPEN' and exthd['FPAMNAME'] == 'OPEN_12')
+
 def get_cfam(
     cfam_name='1F',
     cfam_version=0,
@@ -300,17 +314,10 @@ def generate_psf_cube(
         raise Exception(('The number of PSFs does not match the number of PSF '+
             ' locations.'))
 
-    # PSF cube header - use first off-axis frame so pupil image headers
-    # (e.g. FPAMNAME='OPEN_12') do not propagate into the calibration file
+    # PSF cube header: use first off-axis frame so pupil headers don't propagate
     first_offaxis_frame = None
     for frame in dataset:
-        try:
-            exthd = frame.ext_hdr
-            if not (exthd['DPAMNAME'] == 'PUPIL' and exthd['LSAMNAME'] == 'OPEN' and
-                    exthd['FSAMNAME'] == 'OPEN' and exthd['FPAMNAME'] == 'OPEN_12'):
-                first_offaxis_frame = frame
-                break
-        except KeyError:
+        if not _is_pupil_frame(frame):
             first_offaxis_frame = frame
             break
     if first_offaxis_frame is None:

--- a/corgidrp/corethroughput.py
+++ b/corgidrp/corethroughput.py
@@ -8,20 +8,6 @@ from corgidrp import astrom, data
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-def _is_pupil_frame(frame):
-    """Return True if frame is a pupil image of the unocculted source.
-
-    Args:
-        frame (corgidrp.data.Image): a frame from a CT dataset.
-
-    Returns:
-        bool: True if the frame is a pupil image (DPAM=PUPIL, LSAM=OPEN,
-            FSAM=OPEN, FPAM=OPEN_12).
-    """
-    exthd = frame.ext_hdr
-    return (exthd['DPAMNAME'] == 'PUPIL' and exthd['LSAMNAME'] == 'OPEN' and
-            exthd['FSAMNAME'] == 'OPEN' and exthd['FPAMNAME'] == 'OPEN_12')
-
 def get_cfam(
     cfam_name='1F',
     cfam_version=0,
@@ -317,7 +303,9 @@ def generate_psf_cube(
     # PSF cube header: use first off-axis frame so pupil headers don't propagate
     first_offaxis_frame = None
     for frame in dataset:
-        if not _is_pupil_frame(frame):
+        exthd = frame.ext_hdr
+        if not (exthd['DPAMNAME'] == 'PUPIL' and exthd['LSAMNAME'] == 'OPEN' and
+                exthd['FSAMNAME'] == 'OPEN' and exthd['FPAMNAME'] == 'OPEN_12'):
             first_offaxis_frame = frame
             break
     if first_offaxis_frame is None:

--- a/tests/test_corethroughput.py
+++ b/tests/test_corethroughput.py
@@ -973,14 +973,9 @@ def test_ct_cal_order_independent():
     pupil_frames = []
     offaxis_frames = []
     for frame in dataset_ct_syn:
-        try:
-            exthd = frame.ext_hdr
-            if (exthd['DPAMNAME'] == 'PUPIL' and exthd['LSAMNAME'] == 'OPEN' and
-                    exthd['FSAMNAME'] == 'OPEN' and exthd['FPAMNAME'] == 'OPEN_12'):
-                pupil_frames.append(frame)
-            else:
-                offaxis_frames.append(frame)
-        except KeyError:
+        if corethroughput._is_pupil_frame(frame):
+            pupil_frames.append(frame)
+        else:
             offaxis_frames.append(frame)
 
     dataset_psf_first = Dataset(offaxis_frames + pupil_frames)

--- a/tests/test_corethroughput.py
+++ b/tests/test_corethroughput.py
@@ -973,7 +973,9 @@ def test_ct_cal_order_independent():
     pupil_frames = []
     offaxis_frames = []
     for frame in dataset_ct_syn:
-        if corethroughput._is_pupil_frame(frame):
+        exthd = frame.ext_hdr
+        if (exthd['DPAMNAME'] == 'PUPIL' and exthd['LSAMNAME'] == 'OPEN' and
+                exthd['FSAMNAME'] == 'OPEN' and exthd['FPAMNAME'] == 'OPEN_12'):
             pupil_frames.append(frame)
         else:
             offaxis_frames.append(frame)

--- a/tests/test_corethroughput.py
+++ b/tests/test_corethroughput.py
@@ -961,6 +961,45 @@ def test_psf_interp():
 
     print('Tests about PSF interpolation passed')
 
+def test_ct_cal_order_independent():
+    """Test that FPAMNAME in CT cal file is independent of frame ordering in input dataset.
+
+    When pupil images appear first in the dataset, FPAMNAME should reflect
+    the off-axis PSF FPM setting, not 'OPEN_12' from the pupil image header.
+    Regression test for issue #624.
+    """
+    # Separate pupil and off-axis frames from the synthetic dataset.
+    # dataset_ct_syn has PSF first then pupils; we reverse to make pupil-first.
+    pupil_frames = []
+    offaxis_frames = []
+    for frame in dataset_ct_syn:
+        try:
+            exthd = frame.ext_hdr
+            if (exthd['DPAMNAME'] == 'PUPIL' and exthd['LSAMNAME'] == 'OPEN' and
+                    exthd['FSAMNAME'] == 'OPEN' and exthd['FPAMNAME'] == 'OPEN_12'):
+                pupil_frames.append(frame)
+            else:
+                offaxis_frames.append(frame)
+        except KeyError:
+            offaxis_frames.append(frame)
+
+    dataset_psf_first = Dataset(offaxis_frames + pupil_frames)
+    dataset_pupil_first = Dataset(pupil_frames + offaxis_frames)
+
+    ct_cal_psf_first = corethroughput.generate_ct_cal(dataset_psf_first)
+    ct_cal_pupil_first = corethroughput.generate_ct_cal(dataset_pupil_first)
+
+    assert ct_cal_psf_first.ext_hdr['FPAMNAME'] != 'OPEN_12', \
+        "CT cal FPAMNAME should not be 'OPEN_12' when PSF is first"
+    assert ct_cal_pupil_first.ext_hdr['FPAMNAME'] != 'OPEN_12', \
+        "CT cal FPAMNAME is 'OPEN_12' when pupil image is first (issue #624)"
+    assert ct_cal_psf_first.ext_hdr['FPAMNAME'] == ct_cal_pupil_first.ext_hdr['FPAMNAME'], \
+        "CT cal FPAMNAME differs depending on input frame ordering (issue #624)"
+
+    print(f"FPAMNAME is '{ct_cal_psf_first.ext_hdr['FPAMNAME']}' regardless of frame ordering")
+    print('Tests about CT cal order independence passed')
+
+
 def teardown_module():
     """
     Deletes variables
@@ -992,3 +1031,4 @@ if __name__ == '__main__':
     test_get_1d_ct()
     test_ct_map()
     test_psf_interp()
+    test_ct_cal_order_independent()


### PR DESCRIPTION
## Describe your changes
In generate_psf_cube(), the PSF cube header was always taken from dataset[0], which could be a pupil image with FPAMNAME='OPEN_12'. This caused the saved CoreThroughputCalibration to carry an incorrect FPAMNAME, preventing caldb selection by FPM name.

Fix: scan the dataset for the first off-axis (non-pupil) frame and use its ext_hdr/dq_hdr for the PSF cube, so the calibration file header reflects the actual FPM used during CT observations regardless of input frame ordering.

Adds test_ct_cal_order_independent() to guard against regression.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Reference any relevant issues (don't forget the #)
Closes #624

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
