### PR TITLE
fix test_dark_sub_multi_config failure

### DIFF
--- a/tests/test_dark_sub.py
+++ b/tests/test_dark_sub.py
@@ -207,6 +207,8 @@ def test_dark_sub_multi_config():
         # Frame data equal to the synthesized dark so the result should be ~0
         frame_data = (noise_maps.FPN_map + noise_maps.CIC_map * em_gain + noise_maps.DC_map * exptime * em_gain) / em_gain
         prihdr, exthdr, errhdr, dqhdr, _ = mocks.create_default_L2a_headers()
+        # Give each frame a unique FILENAME so darks for different configs don't collide on disk
+        prihdr['FILENAME'] = "mock_g{0}_t{1}_l2a.fits".format(em_gain, exptime)
         img = data.Image(frame_data, pri_hdr=prihdr, ext_hdr=exthdr, err_hdr=errhdr, dq_hdr=dqhdr)
         img.ext_hdr['EMGAIN_C'] = em_gain
         img.ext_hdr['EXPTIME'] = exptime


### PR DESCRIPTION
## Describe your changes
For each mock image, make sure they have different file names, so that the resulting darks that are created also have different file names. I think this should fix the unit test failing on develop.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [ ] I have checked that I am merging into the right branch
- [ ] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [ ] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
