### PR TITLE
SpecFluxCal for spec coron mode

### DIFF
--- a/corgidrp/recipe_templates/l3_to_l4_psfsub_spec.json
+++ b/corgidrp/recipe_templates/l3_to_l4_psfsub_spec.json
@@ -38,7 +38,7 @@
             "name": "update_to_l4",
             "calibs": {
                 "CoreThroughputCalibration": "AUTOMATIC, OPTIONAL",
-                "FluxcalFactor": "AUTOMATIC"
+                "SpecFluxCal": "AUTOMATIC"
             }
         },
         {

--- a/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
+++ b/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
@@ -151,19 +151,12 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
     calibrations_dir = os.path.join(e2eoutput_path, 'calibrations')
     if not os.path.exists(calibrations_dir):
         os.makedirs(calibrations_dir)
-    #Create a mock flux calibration file
-    fluxcal_factor = 2e-12
-    fluxcal_factor_error = 1e-14
-    prhd, exthd, errhd, dqhd = create_default_calibration_product_headers()
-    # Set consistent header values for flux calibration factor
-    exthd['CFAMNAME'] = '3F'
-    exthd['DPAMNAME'] = 'PRISM3'
-    exthd['FSAMNAME'] = 'R1C2'
-    fluxcal_fac = corgidrp.data.FluxcalFactor(fluxcal_factor, err = fluxcal_factor_error, pri_hdr = prhd, ext_hdr = exthd, err_hdr = errhd, input_dataset = l3_dataset)
 
-    rename_files_to_cgi_format(list_of_fits=[fluxcal_fac], output_dir=calibrations_dir, level_suffix="abf_cal")
-    this_caldb.create_entry(fluxcal_fac)
+    #Using a specfluxcal calib file created using DIP data
+    specflux_cal = corgidrp.data.SpecFluxCal(os.path.join(e2edata_path,'SPEC_NOM_sims/cgi_0200001001001001001_20260319t1146350_sfl_cal.fits'))
 
+    rename_files_to_cgi_format(list_of_fits=[specflux_cal], output_dir=calibrations_dir, level_suffix="sfl_cal")
+    this_caldb.create_entry(specflux_cal)
     ###########################
     #### Make dummy CT cal ####
     ###########################
@@ -175,6 +168,7 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
     pupil_image[510:530, 510:530]=1
     # Add specific values for pupil images:
     # DPAM = PUPIL, FSAM = OPEN, LSAM=OPEN and FPAM=OPEN_12
+    prhd, exthd, errhd, dqhd = create_default_calibration_product_headers()
     exthd['DPAMNAME'] = 'PUPIL'
     exthd['LSAMNAME'] = 'OPEN'
     exthd['FSAMNAME'] = 'OPEN'


### PR DESCRIPTION
## Describe your changes
Changes the L3 to L4 spec coron e2e test and the recipe template json to use SpecFluxCal instead of FluxCalFactor


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
#823 and #837 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [ ] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [ ] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
