### PR TITLE
Fix ND Filter OD interpolation on cropped image

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -3788,21 +3788,41 @@ class NDFilterSweetSpotDataset(Image):
         if 'DATATYPE' not in self.ext_hdr or self.ext_hdr['DATATYPE'] != 'NDFilterSweetSpotDataset':
             raise ValueError("File that was loaded is not labeled as an NDFilterSweetSpotDataset file.")
 
-    def interpolate_od(self, x, y, method="nearest"):
+    def interpolate_od(self, x, y, method="nearest", image=None):
         """
-        Interpolates the data to get the OD at the requested x/y location
+        Interpolates the data to get the OD at the requested x/y location.
+
+        The calibration stores OD values at absolute EXCAM pixel coordinates
+        (i.e. coordinates in the full 1024×1024 detector frame).  When the
+        query image is a cropped sub-frame, pass it as ``image`` and the
+        function will automatically add the ``DETPIX0X``/``DETPIX0Y`` header
+        values (set by ``l2b_to_l3.crop``) to convert ``x``/``y`` from
+        cropped-frame pixel coordinates to absolute EXCAM coordinates before
+        interpolating.  If those keywords are absent the offsets default to 0,
+        so the call is also correct for full-frame (uncropped) images.
 
         Args:
-            x (float): x detector pixel location
-            y (float): y detector pixel location
-            method (str): only "nearest" supported currently
-        
+            x (float): x pixel location in the science frame's own coordinate system.
+            y (float): y pixel location in the science frame's own coordinate system.
+            method (str): only "nearest" supported currently.
+            image (corgidrp.data.Image, optional): the science Image whose pixel
+                coordinates ``x``/``y`` were measured in.  When provided,
+                ``DETPIX0X`` and ``DETPIX0Y`` are read from its extension
+                header to remap frame coordinates to absolute EXCAM coordinates.
+                Defaults to None (no remapping applied).
+
         Returns:
             float: the OD at the requested point
         """
+        detpix0x = 0
+        detpix0y = 0
+        if image is not None:
+            detpix0x = image.ext_hdr.get('DETPIX0X', 0)
+            detpix0y = image.ext_hdr.get('DETPIX0Y', 0)
+
         interpolator = LinearNDInterpolator(np.array([self.x_values, self.y_values]).T, self.od_values)
 
-        return interpolator(x, y)
+        return interpolator(x + detpix0x, y + detpix0y)
 
 class NDSpectroscopy(Image):
     """

--- a/corgidrp/l4_to_tda.py
+++ b/corgidrp/l4_to_tda.py
@@ -725,9 +725,10 @@ def compute_flux_ratio_noise(input_dataset, NDcalibration, unocculted_star_datas
         star_x = star_xs[star_ind]
         star_y = star_ys[star_ind]
         #TODO perhaps incorporate into ERR in future, and incorporate error in psf_phot argument above (must be non-zero, though)
-        star_err = psf_phot.results['flux_err'][star_ind] 
-        # OD (optical density) of the ND filter at the star location:
-        ND_od = NDcalibration.interpolate_od(star_x, star_y)
+        star_err = psf_phot.results['flux_err'][star_ind]
+        # OD (optical density) of the ND filter at the star location.
+        # Pass star_fr so interpolate_od can remap cropped-frame coords to absolute EXCAM.
+        ND_od = NDcalibration.interpolate_od(star_x, star_y, image=star_fr)
         # integral under the fitted 2-D Gaussian for the unocculted star,
         # corrected for ND filter attenuation: true_flux = measured_flux * 10**OD
         Fs = 10**ND_od * psf_phot.results['flux_fit'][star_ind]

--- a/corgidrp/measure_companions.py
+++ b/corgidrp/measure_companions.py
@@ -69,7 +69,8 @@ def measure_companions(
     
     # correct host star counts for ND if ND cal is provided: true_flux = measured_flux * 10**OD
     if nd_cal is not None:
-        od_val = nd_cal.interpolate_od(x_host, y_host)
+        # Pass host_star_image so interpolate_od can remap cropped-frame coords to absolute EXCAM.
+        od_val = nd_cal.interpolate_od(x_host, y_host, image=host_star_image)
         host_star_peakflux *= 10**od_val
     
 

--- a/tests/test_flux_ratio_noise_curve.py
+++ b/tests/test_flux_ratio_noise_curve.py
@@ -627,7 +627,75 @@ def test_flux_ratio_noise_nsigma_and_correction():
         assert np.all(vals_corr >= vals_5 - 1e-15)
 
 
+def test_detpix_coordinate_remap():
+    """Regression test for issue #880: verify that DETPIX0X/Y is used to convert
+    cropped-frame star coordinates to absolute EXCAM coordinates before ND interpolation.
+
+    When the unocculted star frame is a small cutout (DETPIX0X/Y != 0), the star's
+    position in the frame differs from its absolute detector position.  The ND
+    calibration is stored in absolute EXCAM coordinates, so the two must be reconciled
+    before calling interpolate_od.  Without the fix, interpolate_od returns NaN because
+    the query point (e.g. (15, 17)) falls outside the calibration box (~(477, 479)).
+    """
+    mode = 'RDI'
+    nsci, nref = (1, 1)
+    rolls = [0, 15., 0, 0]
+    numbasis = [1]
+    data_shape = (101, 101)
+    mock_sci_rdi, mock_ref_rdi = create_psfsub_dataset(nsci, nref, rolls,
+                                            fwhm_pix=fwhm_pix,
+                                            st_amp=100.,
+                                            noise_amp=1e-3,
+                                            pl_contrast=0.,
+                                            data_shape=data_shape)
+    ctcal = create_ct_cal(fwhm_mas, cfam_name='1F', cenx=25., ceny=30., nx=21, ny=21)
+    psfsub_dataset_rdi = do_psf_subtraction(mock_sci_rdi, ctcal,
+                                reference_star_dataset=mock_ref_rdi,
+                                fileprefix='test_KL_THRU_detpix',
+                                measure_klip_thrupt=True,
+                                measure_1d_core_thrupt=True,
+                                numbasis=numbasis)
+
+    # Star at (x0=15, y0=17) inside the 101x101 cutout
+    x0, y0, sig_x, sig_y = 15, 17, 4, 4
+    x = np.arange(data_shape[1])
+    y = np.arange(data_shape[0])
+    X, Y = np.meshgrid(x, y)
+    XY = np.vstack([X.ravel(), Y.ravel()])
+    def gauss_spot(xy, A, x0, y0, sx, sy):
+        (x, y) = xy
+        return A * np.e**(-((x-x0)**2/(2*sx**2) + (y-y0)**2/(2*sy**2)))
+    star_PSF = np.reshape(gauss_spot(XY, 100, x0, y0, sig_x, sig_y), X.shape)
+    np.random.seed(42)
+    star_PSF += np.random.poisson(lam=star_PSF.mean(), size=star_PSF.shape)
+
+    prihdr, exthdr, errhdr, dqhdr = create_default_L4_headers()
+    # Simulate a crop: the frame's (0,0) pixel corresponds to absolute EXCAM (462, 462)
+    detpix0x, detpix0y = 462, 462
+    exthdr['DETPIX0X'] = detpix0x
+    exthdr['DETPIX0Y'] = detpix0y
+    star_image = data.Image(star_PSF, prihdr, exthdr)
+    star_dataset = data.Dataset([star_image for _ in range(len(psfsub_dataset_rdi))])
+
+    # ND calibration covers absolute EXCAM coords around (477, 479) = (15+462, 17+462)
+    nd_x, nd_y = np.meshgrid(np.linspace(440, 520, 5), np.linspace(440, 520, 5))
+    nd_x = nd_x.ravel()
+    nd_y = nd_y.ravel()
+    nd_od_val = 2
+    nd_od = np.ones(nd_y.shape) * nd_od_val
+    pri_hdr, ext_hdr, errhdr_nd, dqhdr_nd, biashdr = mocks.create_default_L2b_headers()
+    nd_cal = data.NDFilterSweetSpotDataset(np.array([nd_od, nd_x, nd_y]).T,
+                                           pri_hdr=pri_hdr, ext_hdr=ext_hdr)
+
+    frn_dataset = compute_flux_ratio_noise(psfsub_dataset_rdi, nd_cal, star_dataset, halfwidth=3)
+    for frame in frn_dataset:
+        frn_vals = frame.hdu_list['FRN_CRV'].data[2:]
+        assert not np.any(np.isnan(frn_vals)), \
+            "FRN curve contains NaN — coordinate remapping via DETPIX0X/Y likely failed"
+
+
 if __name__ == '__main__':
     test_expected_flux_ratio_noise()
     test_expected_flux_ratio_noise_pol()
     test_flux_ratio_noise_nsigma_and_correction()
+    test_detpix_coordinate_remap()


### PR DESCRIPTION
## Describe your changes
 - Bug fix (issue #880): NDFilterSweetSpotDataset.interpolate_od() now accepts an optional image argument; when provided it reads DETPIX0X/DETPIX0Y from the image header to convert cropped-frame pixel coordinates to absolute EXCAM coordinates before interpolating, preventing nan returns for L4 cutout frames.
 - compute_flux_ratio_noise and measure_companions pass the relevant Image object into interpolate_od() to account for the cropped image
 - unit test added test added: test_detpix_coordinate_remap checks that an ND interpolation error is not thrown

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Reference any relevant issues (don't forget the #)
Closes #880

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
