### PR TITLE
Handle NaNs in astrom.py centroiding and pad PSF cut-outs to uniform size

### DIFF
--- a/corgidrp/astrom.py
+++ b/corgidrp/astrom.py
@@ -73,6 +73,7 @@ def centroid_with_roi(frame, roi_radius=5, centering_initial_guess=None):
     # Use nansum to handle NaN pixels from flat field corrections
     total_flux = np.nansum(sub_frame)
     if total_flux == 0 or np.isnan(total_flux):
+        # probably should raise error if total flux is 0 or nan
         raise ValueError(f"Cannot compute centroid: ROI has zero or NaN total flux at position ({peak_x}, {peak_y})")
 
     xcen = np.nansum(x_indices * sub_frame) / total_flux

--- a/corgidrp/astrom.py
+++ b/corgidrp/astrom.py
@@ -70,13 +70,13 @@ def centroid_with_roi(frame, roi_radius=5, centering_initial_guess=None):
     x_indices += x_min
 
     # 4) Compute flux-weighted centroid in the subarray
-    total_flux = np.sum(sub_frame)
-    if total_flux == 0:
-        # Edge case: empty or zero frame
-        return peak_x, peak_y
+    # Use nansum to handle NaN pixels from flat field corrections
+    total_flux = np.nansum(sub_frame)
+    if total_flux == 0 or np.isnan(total_flux):
+        raise ValueError(f"Cannot compute centroid: ROI has zero or NaN total flux at position ({peak_x}, {peak_y})")
 
-    xcen = np.sum(x_indices * sub_frame) / total_flux
-    ycen = np.sum(y_indices * sub_frame) / total_flux
+    xcen = np.nansum(x_indices * sub_frame) / total_flux
+    ycen = np.nansum(y_indices * sub_frame) / total_flux
 
     return xcen, ycen
 

--- a/corgidrp/corethroughput.py
+++ b/corgidrp/corethroughput.py
@@ -283,7 +283,6 @@ def generate_psf_cube(
                 continue
         except:
             pass
-        # Extract cutout centered on PSF, clipping at detector edges if necessary
         idx_0_0 = max(int(np.round(psf_loc[i_psf][1])) - n_pix_psf,0)
         idx_0_1 = min(frame.data.shape[0],
             int(np.round(psf_loc[i_psf][1])) + n_pix_psf + 1)

--- a/corgidrp/corethroughput.py
+++ b/corgidrp/corethroughput.py
@@ -294,7 +294,7 @@ def generate_psf_cube(
         cutout_data = frame.data[idx_0_0:idx_0_1, idx_1_0:idx_1_1]
         cutout_dq = frame.dq[idx_0_0:idx_0_1, idx_1_0:idx_1_1]
 
-        # PSFs near detector edges produce clipped cutouts with varying shapes
+        # PSFs near field stop boundary produce clipped cutouts with varying shapes
         # (eg not all 15x15). Pad them to uniform size so np.array() can create 
         # the PSF cube. Padded regions are filled with NaN (data) and DQ flag 1 
         # (bad pixel).

--- a/corgidrp/corethroughput.py
+++ b/corgidrp/corethroughput.py
@@ -283,14 +283,43 @@ def generate_psf_cube(
                 continue
         except:
             pass
+        # Extract cutout centered on PSF, clipping at detector edges if necessary
         idx_0_0 = max(int(np.round(psf_loc[i_psf][1])) - n_pix_psf,0)
         idx_0_1 = min(frame.data.shape[0],
             int(np.round(psf_loc[i_psf][1])) + n_pix_psf + 1)
         idx_1_0 = max(int(np.round(psf_loc[i_psf][0])) - n_pix_psf,0)
         idx_1_1 = min(frame.data.shape[1],
             int(np.round(psf_loc[i_psf][0])) + n_pix_psf + 1)
-        psf_cube += [frame.data[idx_0_0:idx_0_1, idx_1_0:idx_1_1]]
-        dq_cube += [frame.dq[idx_0_0:idx_0_1, idx_1_0:idx_1_1]]
+
+        cutout_data = frame.data[idx_0_0:idx_0_1, idx_1_0:idx_1_1]
+        cutout_dq = frame.dq[idx_0_0:idx_0_1, idx_1_0:idx_1_1]
+
+        # PSFs near detector edges produce clipped cutouts with varying shapes
+        # (eg not all 15x15). Pad them to uniform size so np.array() can create 
+        # the PSF cube. Padded regions are filled with NaN (data) and DQ flag 1 
+        # (bad pixel).
+        expected_size = 2*n_pix_psf + 1
+        if cutout_data.shape[0] != expected_size or cutout_data.shape[1] != expected_size:
+            # Create full-size arrays filled with NaN/bad-pixel flags
+            padded_data = np.full((expected_size, expected_size), np.nan, dtype=cutout_data.dtype)
+            padded_dq = np.full((expected_size, expected_size), 1, dtype=cutout_dq.dtype)
+
+            # Calculate where to place the clipped cutout within the padded array
+            # so the PSF center remains at (n_pix_psf, n_pix_psf)
+            y_offset = n_pix_psf - (int(np.round(psf_loc[i_psf][1])) - idx_0_0)
+            x_offset = n_pix_psf - (int(np.round(psf_loc[i_psf][0])) - idx_1_0)
+
+            # Insert the clipped cutout into the correct position
+            padded_data[y_offset:y_offset+cutout_data.shape[0],
+                       x_offset:x_offset+cutout_data.shape[1]] = cutout_data
+            padded_dq[y_offset:y_offset+cutout_dq.shape[0],
+                     x_offset:x_offset+cutout_dq.shape[1]] = cutout_dq
+
+            cutout_data = padded_data
+            cutout_dq = padded_dq
+
+        psf_cube += [cutout_data]
+        dq_cube += [cutout_dq]
         i_psf += 1
 
     psf_cube = np.array(psf_cube)

--- a/tests/test_corethroughput.py
+++ b/tests/test_corethroughput.py
@@ -996,6 +996,93 @@ def test_ct_cal_order_independent():
     print(f"FPAMNAME is '{ct_cal_psf_first.ext_hdr['FPAMNAME']}' regardless of frame ordering")
     print('Tests about CT cal order independence passed')
 
+def test_generate_psf_cube_edge_padding():
+    """
+    Regression test for PR #893. PSFs near the field-stop / detector edge
+    produce clipped cutouts smaller than the expected (2*n_pix_psf + 1) box.
+    Verify that generate_psf_cube pads those cutouts to a uniform size,
+    fills padded data with NaN and padded DQ with 1, keeps the PSF center
+    at (n_pix_psf, n_pix_psf), and preserves the unclipped pixel values.
+    """
+    # Build a CT-style dataset with one off-axis PSF placed near the 
+    # corner so the cutout gets clipped on both sides, plus the
+    # pupil images so generate_psf_cube can run
+    prhd, exthd, _, _ = create_default_L3_headers()
+    exthd['DRPCTIME'] = time.Time.now().isot
+    exthd['DRPVERSN'] = corgidrp.__version__
+    exthd['CFAMNAME'] = cfam_name
+    exthd['FPAM_H'] = FPAM_H_CT
+    exthd['FPAM_V'] = FPAM_V_CT
+    exthd['FSAM_H'] = FSAM_H_CT
+    exthd['FSAM_V'] = FSAM_V_CT
+
+    # Synthetic PSF is a 3x3 block near the corner which guarantees
+    # the cutout extends past the edges and gets clipped
+    psf_x, psf_y = 2, 3
+    psf_frame = np.zeros([1024, 1024])
+    psf_frame[psf_y-1:psf_y+2, psf_x-1:psf_x+2] = 1
+    psf_frame[psf_y, psf_x] = 4  # peak at center
+    err = np.ones([1024, 1024])
+
+    # Pupil image (so generate_psf_cube has something to skip too)
+    pupil_image = np.zeros([1024, 1024])
+    pupil_image[510:530, 510:530] = 1
+    exthd_pupil = exthd.copy()
+    exthd_pupil['DPAMNAME'] = 'PUPIL'
+    exthd_pupil['LSAMNAME'] = 'OPEN'
+    exthd_pupil['FSAMNAME'] = 'OPEN'
+    exthd_pupil['FPAMNAME'] = 'OPEN_12'
+
+    dataset_edge = Dataset([
+        Image(psf_frame, pri_hdr=prhd, ext_hdr=exthd, err=err),
+        Image(pupil_image, pri_hdr=prhd, ext_hdr=exthd_pupil, err=err),
+    ])
+
+    # Run generate_psf_cube with the known PSF location
+    psf_hdu, dq_hdu = corethroughput.generate_psf_cube(
+        dataset_edge, psf_loc=np.array([[psf_x, psf_y]]),
+        cfam_name=cfam_name)
+
+    # Expected box size matches the formula inside generate_psf_cube
+    n_pix_psf = int(np.ceil(
+        3 * corethroughput.get_cfam(cfam_name=cfam_name)[0].mean()
+        * 1e-9 / 2.36 * 180 / np.pi * 3600e3 / 21.8))
+    expected_size = 2 * n_pix_psf + 1
+
+    psf_cube = psf_hdu.data
+    dq_cube = dq_hdu.data
+
+    # 1) Uniform shape even though the cutout was clipped
+    assert psf_cube.shape == (1, expected_size, expected_size)
+    assert dq_cube.shape == (1, expected_size, expected_size)
+
+    # 2) Original clipped values land at the right offset, so the PSF center
+    #    stays at (n_pix_psf, n_pix_psf)
+    idx_0_0 = max(psf_y - n_pix_psf, 0)
+    idx_0_1 = min(1024, psf_y + n_pix_psf + 1)
+    idx_1_0 = max(psf_x - n_pix_psf, 0)
+    idx_1_1 = min(1024, psf_x + n_pix_psf + 1)
+    y_off = n_pix_psf - (psf_y - idx_0_0)
+    x_off = n_pix_psf - (psf_x - idx_1_0)
+    clip = psf_frame[idx_0_0:idx_0_1, idx_1_0:idx_1_1]
+    assert np.array_equal(
+        psf_cube[0, y_off:y_off + clip.shape[0],
+                    x_off:x_off + clip.shape[1]], clip)
+    # PSF peak ends up at the cube center
+    assert psf_cube[0, n_pix_psf, n_pix_psf] == 4
+
+    # 3) Padded regions are NaN in data and flagged 1 in DQ
+    mask = np.ones((expected_size, expected_size), dtype=bool)
+    mask[y_off:y_off + clip.shape[0], x_off:x_off + clip.shape[1]] = False
+    test_padded_data = np.all(np.isnan(psf_cube[0][mask]))
+    test_padded_dq = np.all(dq_cube[0][mask] == 1)
+    assert test_padded_data
+    assert test_padded_dq
+
+    print('Clipped PSF cutout is padded to uniform size with NaN/DQ=1: ', end='')
+    print_pass() if test_padded_data and test_padded_dq else print_fail()
+    print('Tests about PSF padding from clipped cut outs passed')
+
 
 def teardown_module():
     """
@@ -1029,3 +1116,4 @@ if __name__ == '__main__':
     test_ct_map()
     test_psf_interp()
     test_ct_cal_order_independent()
+    test_generate_psf_cube_edge_padding()


### PR DESCRIPTION
## Describe your changes
- Addresses #892 : Implements np.nansum() in astrom.py that handles NaNs in the ROI when computing a flux-weighted centroid. Flat fielding can identify bad pixels in that region that get set as NaN, and centroiding would previously break if it encountered them.
- Implements ability to pad PSF cut out data to so that cut outs are a standard size and the PSF cube can be made. PSFs taken for developing core throughput calibration product may be partially cut off by the field stop and would otherwise not be a standard size.  

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
