### PR TITLE
Spec wave zeropoint accounts for satspot background

### DIFF
--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -2011,7 +2011,7 @@ def combine_spec(input_dataset, collapse="mean", num_frames_scaling=True):
                     'Z10AVG', 'Z11AVG', 'Z12AVG', 'Z13AVG', 'Z14AVG',
                     'Z2RES', 'Z3RES', 'Z4RES', 'Z5RES', 'Z6RES', 'Z7RES', 'Z8RES', 'Z9RES',
                     'Z10RES', 'Z11RES',
-                    'Z2VAR', 'Z3VAR','WAVELEN0','WV0_X','WV0_Y','WV0_XERR','WV0_YERR','WV0_DIMX', 'WV0_DIMY']) 
+                    'Z2VAR', 'Z3VAR','WAVELEN0','WV0_X','WV0_Y','WV0_XERR','WV0_YERR']) 
     #combine frames                       
     dataset = combine_subexposures(dataset, collapse=collapse, num_frames_scaling=num_frames_scaling, combine_other_hdus=True)
     #certain headers are added in combine_subexposures, we manually add them in

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -939,6 +939,7 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
     if not dpamname.startswith("PRISM"):
         raise AttributeError("This is not a spectroscopic observation. but {0}").format(dpamname)
     if dataset.frames[0].ext_hdr["FPAMNAME"] == 'OPEN_34':
+        print("The dataset has FPAMNAME = OPEN_34, identicating that this is a non-coronagraphic spectroscopy observation, setting subtract_no_offset_frames = False")
         subtract_no_offset_frames = False
 
     # Assumed that only narrowband filter (includes sat spots) frames are taken to fit the zeropoint
@@ -1044,7 +1045,7 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
             frame.ext_hdr["WV0_DIMY"] = offset_dataset[0].ext_hdr['NAXIS2']
             science_frames.append(frame)
 
-        all_science_frames = np.concatenate([np.array(all_science_frames),np.array(science_frames)])
+        all_science_frames += science_frames
 
     sci_dataset = data.Dataset(all_science_frames)
 

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -2010,7 +2010,7 @@ def combine_spec(input_dataset, collapse="mean", num_frames_scaling=True):
                     'Z10AVG', 'Z11AVG', 'Z12AVG', 'Z13AVG', 'Z14AVG',
                     'Z2RES', 'Z3RES', 'Z4RES', 'Z5RES', 'Z6RES', 'Z7RES', 'Z8RES', 'Z9RES',
                     'Z10RES', 'Z11RES',
-                    'Z2VAR', 'Z3VAR']) 
+                    'Z2VAR', 'Z3VAR','WAVELEN0','WV0_X','WV0_Y','WV0_XERR','WV0_YERR','WV0_DIMX', 'WV0_DIMY']) 
     #combine frames                       
     dataset = combine_subexposures(dataset, collapse=collapse, num_frames_scaling=num_frames_scaling, combine_other_hdus=True)
     #certain headers are added in combine_subexposures, we manually add them in

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -966,63 +966,40 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
     
 
     if subtract_no_offset_frames:
-        # First we split satspot dataset into ref/target satspot as their exposure times might be different
-        satspot_dataset, exptime = sat_dataset.split_dataset(exthdr_keywords=["EXPTIME"])
+        all_satspot_frames = []
 
-        ref_sat_dataset = satspot_dataset[int(np.nonzero(exptime == exptime[0])[0].item())]
-        refstar_satspot_frames = []
-        for frame in ref_sat_dataset:
-            refstar_satspot_frames.append(frame)
-        # Split sat spot frames into the three acquisition groups by SCTSRT order.
-        # Data collection order: N no-offset frames, N +offset frames, N -offset frames.
-        if len(refstar_satspot_frames) % 3 != 0:
-            raise ValueError(f"Expected the number of refstar SATSPOTS=1 frames to be divisible by 3 "
-                f"(no-offset / +offset / -offset groups), but got {len(refstar_satspot_frames)}.")
-        if all('SCTSRT' in f.ext_hdr for f in refstar_satspot_frames):
-            refstar_satspot_frames_sorted = sorted(refstar_satspot_frames, key=lambda f: f.ext_hdr['SCTSRT'])
-        else:
-            refstar_satspot_frames_sorted = sorted(refstar_satspot_frames, key=lambda f: f.filename)
-        n_per_group = len(refstar_satspot_frames_sorted) // 3
-        no_offset_frames = refstar_satspot_frames_sorted[:n_per_group]
-        refstar_offset_frames = refstar_satspot_frames_sorted[n_per_group:]
-        
-        img_no_offset = np.nanmedian(data.Dataset(no_offset_frames).all_data, axis=0)
-        for frame in data.Dataset(refstar_offset_frames):
-            frame.data = frame.data - img_no_offset
+        # First we split satspot dataset according to VISITID
+        satspot_dataset, visitid = sat_dataset.split_dataset(prihdr_keywords=["VISITID"])
+        visitid = np.array(visitid)
 
-        if len(exptime) == 1:
-            offset_dataset = data.Dataset(refstar_offset_frames)
-                
-        elif len(exptime) > 1:
-            target_sat_dataset = satspot_dataset[int(np.nonzero(exptime == exptime[1])[0].item())]
-            target_satspot_frames = []
-            for frame in target_sat_dataset:
-                target_satspot_frames.append(frame)
+        for visid in visitid:
+            satspot_subset = satspot_dataset[int(np.nonzero(visitid == visid)[0].item())]
+            satspot_frames = []
+            for frame in satspot_subset:
+                satspot_frames.append(frame)
             # Split sat spot frames into the three acquisition groups by SCTSRT order.
             # Data collection order: N no-offset frames, N +offset frames, N -offset frames.
-            if len(target_satspot_frames) % 3 != 0:
-                raise ValueError(f"Expected the number of targetstar SATSPOTS=1 frames to be divisible by 3 "
-                    f"(no-offset / +offset / -offset groups), but got {len(target_satspot_frames)}.")
-            if all('SCTSRT' in f.ext_hdr for f in target_satspot_frames):
-                target_satspot_frames_sorted = sorted(target_satspot_frames, key=lambda f: f.ext_hdr['SCTSRT'])
+            if len(satspot_frames) % 3 != 0:
+                raise ValueError(f"Expected the number of refstar SATSPOTS=1 frames to be divisible by 3 "
+                    f"(no-offset / +offset / -offset groups), but got {len(satspot_frames)}.")
+            if all('SCTSRT' in f.ext_hdr for f in satspot_frames):
+                satspot_frames_sorted = sorted(satspot_frames, key=lambda f: f.ext_hdr['SCTSRT'])
             else:
-                target_satspot_frames_sorted = sorted(target_satspot_frames, key=lambda f: f.filename)
-            n_per_group = len(target_satspot_frames_sorted) // 3
-            no_offset_frames = target_satspot_frames_sorted[:n_per_group]
-            target_offset_frames = target_satspot_frames_sorted[n_per_group:]
-                
+                satspot_frames_sorted = sorted(satspot_frames, key=lambda f: f.filename)
+            n_per_group = len(satspot_frames_sorted) // 3
+            no_offset_frames = satspot_frames_sorted[:n_per_group]
+            offset_frames = satspot_frames_sorted[n_per_group:]
+            
             img_no_offset = np.nanmedian(data.Dataset(no_offset_frames).all_data, axis=0)
-            for frame in data.Dataset(target_offset_frames):
+            for frame in data.Dataset(offset_frames):
                 frame.data = frame.data - img_no_offset
 
-            offset_dataset = data.Dataset(np.concatenate([np.array(refstar_offset_frames),np.array(target_offset_frames)]))
+            all_satspot_frames = np.concatenate([np.array(all_satspot_frames),np.array(offset_frames)])
+
+        offset_dataset = data.Dataset(all_satspot_frames)
 
     else:
-        sat_spot_frames = []
-        for frame in sat_dataset:
-            sat_spot_frames.append(frame)
-        offset_frames = sat_spot_frames
-        offset_dataset = data.Dataset(offset_frames)
+        offset_dataset = sat_dataset
 
     if xcent_guess is not None and ycent_guess is not None:
         n = len(offset_dataset)

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -918,7 +918,7 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
         spec_filter_offset (corgidrp.data.SpecFilterOffset): instance of SpecFilterOffset calibration class
         template_dataset (corgidrp.data.Dataset): dataset of the template PSF, if None, a simulated PSF from the data/spectroscopy/template 
                                                   path is taken
-        subtract_no_offset_frame (bool, optional): If True, the ''SATSPOTS=1'' frames are assumed to follow the three-group acquisition structure 
+        subtract_no_offset_frames (bool, optional): If True, the ''SATSPOTS=1'' frames are assumed to follow the three-group acquisition structure 
         (no-offset / +offset / -offset). The no-offset median is subtracted from the offset median before star-center estimation to suppress static speckles and 
         astrophysical sources. If False, all ''SATSPOTS=1'' frames are used directly as the offset (spot-bearing) median with no background subtraction and no 
         three-group structure assumed. Defaults to True.

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -939,7 +939,7 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
     if not dpamname.startswith("PRISM"):
         raise AttributeError("This is not a spectroscopic observation. but {0}").format(dpamname)
     if dataset.frames[0].ext_hdr["FPAMNAME"] == 'OPEN_34':
-        print("The dataset has FPAMNAME = OPEN_34, identicating that this is a non-coronagraphic spectroscopy observation, setting subtract_no_offset_frames = False")
+        warnings.warn("The dataset has FPAMNAME = OPEN_34, identicating that this is a non-coronagraphic spectroscopy observation, setting subtract_no_offset_frames = False")
         subtract_no_offset_frames = False
 
     # Assumed that only narrowband filter (includes sat spots) frames are taken to fit the zeropoint

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -964,15 +964,17 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
     else:
         raise AttributeError("No narrowband frames found in input dataset")
     
+    # Split satspot/science dataset according to VISITID
+    satspot_dataset, visitid = sat_dataset.split_dataset(prihdr_keywords=["VISITID"])
+    if with_science:
+        science_dataset, visitid = sci_dataset.split_dataset(prihdr_keywords=["VISITID"])
+    visitid = np.array(visitid)
 
-    if subtract_no_offset_frames:
-        all_satspot_frames = []
+    all_science_frames = []
 
-        # First we split satspot dataset according to VISITID
-        satspot_dataset, visitid = sat_dataset.split_dataset(prihdr_keywords=["VISITID"])
-        visitid = np.array(visitid)
-
-        for visid in visitid:
+    for visid in visitid:
+        if subtract_no_offset_frames:
+            
             satspot_subset = satspot_dataset[int(np.nonzero(visitid == visid)[0].item())]
             satspot_frames = []
             for frame in satspot_subset:
@@ -989,53 +991,63 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
             n_per_group = len(satspot_frames_sorted) // 3
             no_offset_frames = satspot_frames_sorted[:n_per_group]
             offset_frames = satspot_frames_sorted[n_per_group:]
-            
+ 
             img_no_offset = np.nanmedian(data.Dataset(no_offset_frames).all_data, axis=0)
             for frame in data.Dataset(offset_frames):
                 frame.data = frame.data - img_no_offset
 
-            all_satspot_frames = np.concatenate([np.array(all_satspot_frames),np.array(offset_frames)])
+            offset_dataset = data.Dataset(offset_frames)
 
-        offset_dataset = data.Dataset(all_satspot_frames)
+        else:
+            satspot_subset = satspot_dataset[int(np.nonzero(visitid == visid)[0].item())]
+            offset_dataset = satspot_subset
 
-    else:
-        offset_dataset = sat_dataset
-
-    if xcent_guess is not None and ycent_guess is not None:
-        n = len(offset_dataset)
-        initial_cent = {"xcent": np.repeat(xcent_guess, n),
-                        "ycent": np.repeat(ycent_guess, n)}
-    else:
-        initial_cent = None
-    spot_centroids = compute_psf_centroid(dataset = offset_dataset, template_dataset = template_dataset, initial_cent = initial_cent)
+        if xcent_guess is not None and ycent_guess is not None:
+            n = len(offset_dataset)
+            initial_cent = {"xcent": np.repeat(xcent_guess, n),
+                            "ycent": np.repeat(ycent_guess, n)}
+        else:
+            initial_cent = None
+        spot_centroids = compute_psf_centroid(dataset = offset_dataset, template_dataset = template_dataset, initial_cent = initial_cent)
     
-    nb_filter = offset_dataset[0].ext_hdr["CFAMNAME"]
-    bb_filter = nb_filter[0]
-    cen_wave, _, _, _ = read_cent_wave(nb_filter)
-    xoff_nb, yoff_nb = spec_filter_offset.get_offsets(nb_filter)
-    xoff_bb, yoff_bb = spec_filter_offset.get_offsets(bb_filter)
-    # Correct the centroid for the filter-to-filter image offset, so that
-    # the coordinates (x0,y0) correspond to the wavelength location in the broadband filter. 
-    if bb_nb_dx is not None and bb_nb_dy is not None:
-        x0 = np.mean(spot_centroids.xfit) + bb_nb_dx
-        y0 = np.mean(spot_centroids.yfit) + bb_nb_dy
-    else:
-        x0 = np.mean(spot_centroids.xfit) + (xoff_bb - xoff_nb)
-        y0 = np.mean(spot_centroids.yfit) + (yoff_bb - yoff_nb)
-    x0err = np.sqrt(np.sum(spot_centroids.xfit_err**2)/len(spot_centroids.xfit_err))
-    y0err = np.sqrt(np.sum(spot_centroids.yfit_err**2)/len(spot_centroids.yfit_err))
-    if return_all or with_science == False:
-        sci_dataset = dataset
+        nb_filter = offset_dataset[0].ext_hdr["CFAMNAME"]
+        bb_filter = nb_filter[0]
+        cen_wave, _, _, _ = read_cent_wave(nb_filter)
+        xoff_nb, yoff_nb = spec_filter_offset.get_offsets(nb_filter)
+        xoff_bb, yoff_bb = spec_filter_offset.get_offsets(bb_filter)
+        # Correct the centroid for the filter-to-filter image offset, so that
+        # the coordinates (x0,y0) correspond to the wavelength location in the broadband filter. 
+        if bb_nb_dx is not None and bb_nb_dy is not None:
+            x0 = np.mean(spot_centroids.xfit) + bb_nb_dx
+            y0 = np.mean(spot_centroids.yfit) + bb_nb_dy
+        else:
+            x0 = np.mean(spot_centroids.xfit) + (xoff_bb - xoff_nb)
+            y0 = np.mean(spot_centroids.yfit) + (yoff_bb - yoff_nb)
+        x0err = np.sqrt(np.sum(spot_centroids.xfit_err**2)/len(spot_centroids.xfit_err))
+        y0err = np.sqrt(np.sum(spot_centroids.yfit_err**2)/len(spot_centroids.yfit_err))
 
-    for frame in sci_dataset:
-        frame.ext_hdr["WAVLEN0"] = cen_wave
-        frame.ext_hdr["WV0_X"] = x0
-        frame.ext_hdr["WV0_XERR"] = x0err
-        frame.ext_hdr["WV0_Y"] = y0
-        frame.ext_hdr["WV0_YERR"] = y0err
-        frame.ext_hdr["WV0_DIMX"] = offset_dataset[0].ext_hdr['NAXIS1']
-        frame.ext_hdr["WV0_DIMY"] = offset_dataset[0].ext_hdr['NAXIS2']
-                              
+        if return_all or with_science == False:
+            science_subset = offset_dataset
+        
+        if with_science:
+            science_subset = science_dataset[int(np.nonzero(visitid == visid)[0].item())]
+        
+
+        science_frames = []
+        for frame in science_subset:
+            frame.ext_hdr["WAVLEN0"] = cen_wave
+            frame.ext_hdr["WV0_X"] = x0
+            frame.ext_hdr["WV0_XERR"] = x0err
+            frame.ext_hdr["WV0_Y"] = y0
+            frame.ext_hdr["WV0_YERR"] = y0err
+            frame.ext_hdr["WV0_DIMX"] = offset_dataset[0].ext_hdr['NAXIS1']
+            frame.ext_hdr["WV0_DIMY"] = offset_dataset[0].ext_hdr['NAXIS2']
+            science_frames.append(frame)
+
+        all_science_frames = np.concatenate([np.array(all_science_frames),np.array(science_frames)])
+
+    sci_dataset = data.Dataset(all_science_frames)
+
     history_msg = "wavelength zeropoint values added to header"
     sci_dataset.update_after_processing_step(history_msg)
     return sci_dataset

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -908,7 +908,7 @@ def northup(input_dataset,use_wcs=True,rot_center='im_center',new_center=None):
     return processed_dataset
 
 
-def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset = None, xcent_guess = None, ycent_guess = None, bb_nb_dx = None, bb_nb_dy = None, return_all = False):
+def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset = None, subtract_no_offset_frames=True, xcent_guess = None, ycent_guess = None, bb_nb_dx = None, bb_nb_dy = None, return_all = False):
     """ 
     A procedure for estimating the centroid of the zero-point image
     (satellite spot or PSF) taken through the narrowband filter (2C or 3D) and slit.
@@ -918,6 +918,10 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
         spec_filter_offset (corgidrp.data.SpecFilterOffset): instance of SpecFilterOffset calibration class
         template_dataset (corgidrp.data.Dataset): dataset of the template PSF, if None, a simulated PSF from the data/spectroscopy/template 
                                                   path is taken
+        subtract_no_offset_frame (bool, optional): If True, the ''SATSPOTS=1'' frames are assumed to follow the three-group acquisition structure 
+        (no-offset / +offset / -offset). The no-offset median is subtracted from the offset median before star-center estimation to suppress static speckles and 
+        astrophysical sources. If False, all ''SATSPOTS=1'' frames are used directly as the offset (spot-bearing) median with no background subtraction and no 
+        three-group structure assumed. Defaults to True.
         xcent_guess (float): initial x guess for the centroid fit for all frames
         ycent_guess (float): initial y guess for the centroid fit for all frames
         bb_nb_dx (float): horizontal image offset between the narrowband and broadband filters, in EXCAM pixels. 
@@ -934,6 +938,8 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
     dpamname = dataset.frames[0].ext_hdr["DPAMNAME"]
     if not dpamname.startswith("PRISM"):
         raise AttributeError("This is not a spectroscopic observation. but {0}").format(dpamname)
+    if dataset.frames[0].ext_hdr["FPAMNAME"] == 'OPEN_34':
+        subtract_no_offset_frames = False
 
     # Assumed that only narrowband filter (includes sat spots) frames are taken to fit the zeropoint
     narrow_dataset, band = dataset.split_dataset(exthdr_keywords=["CFAMNAME"])
@@ -958,15 +964,75 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
     else:
         raise AttributeError("No narrowband frames found in input dataset")
     
+
+    if subtract_no_offset_frames:
+        # First we split satspot dataset into ref/target satspot as their exposure times might be different
+        satspot_dataset, exptime = sat_dataset.split_dataset(exthdr_keywords=["EXPTIME"])
+
+        ref_sat_dataset = satspot_dataset[int(np.nonzero(exptime == exptime[0])[0].item())]
+        refstar_satspot_frames = []
+        for frame in ref_sat_dataset:
+            refstar_satspot_frames.append(frame)
+        # Split sat spot frames into the three acquisition groups by SCTSRT order.
+        # Data collection order: N no-offset frames, N +offset frames, N -offset frames.
+        if len(refstar_satspot_frames) % 3 != 0:
+            raise ValueError(f"Expected the number of refstar SATSPOTS=1 frames to be divisible by 3 "
+                f"(no-offset / +offset / -offset groups), but got {len(refstar_satspot_frames)}.")
+        if all('SCTSRT' in f.ext_hdr for f in refstar_satspot_frames):
+            refstar_satspot_frames_sorted = sorted(refstar_satspot_frames, key=lambda f: f.ext_hdr['SCTSRT'])
+        else:
+            refstar_satspot_frames_sorted = sorted(refstar_satspot_frames, key=lambda f: f.filename)
+        n_per_group = len(refstar_satspot_frames_sorted) // 3
+        no_offset_frames = refstar_satspot_frames_sorted[:n_per_group]
+        refstar_offset_frames = refstar_satspot_frames_sorted[n_per_group:]
+        
+        img_no_offset = np.nanmedian(data.Dataset(no_offset_frames).all_data, axis=0)
+        for frame in data.Dataset(refstar_offset_frames):
+            frame.data = frame.data - img_no_offset
+
+        if len(exptime) == 1:
+            offset_dataset = data.Dataset(refstar_offset_frames)
+                
+        elif len(exptime) > 1:
+            target_sat_dataset = satspot_dataset[int(np.nonzero(exptime == exptime[1])[0].item())]
+            target_satspot_frames = []
+            for frame in target_sat_dataset:
+                target_satspot_frames.append(frame)
+            # Split sat spot frames into the three acquisition groups by SCTSRT order.
+            # Data collection order: N no-offset frames, N +offset frames, N -offset frames.
+            if len(target_satspot_frames) % 3 != 0:
+                raise ValueError(f"Expected the number of targetstar SATSPOTS=1 frames to be divisible by 3 "
+                    f"(no-offset / +offset / -offset groups), but got {len(target_satspot_frames)}.")
+            if all('SCTSRT' in f.ext_hdr for f in target_satspot_frames):
+                target_satspot_frames_sorted = sorted(target_satspot_frames, key=lambda f: f.ext_hdr['SCTSRT'])
+            else:
+                target_satspot_frames_sorted = sorted(target_satspot_frames, key=lambda f: f.filename)
+            n_per_group = len(target_satspot_frames_sorted) // 3
+            no_offset_frames = target_satspot_frames_sorted[:n_per_group]
+            target_offset_frames = target_satspot_frames_sorted[n_per_group:]
+                
+            img_no_offset = np.nanmedian(data.Dataset(no_offset_frames).all_data, axis=0)
+            for frame in data.Dataset(target_offset_frames):
+                frame.data = frame.data - img_no_offset
+
+            offset_dataset = data.Dataset(np.concatenate([np.array(refstar_offset_frames),np.array(target_offset_frames)]))
+
+    else:
+        sat_spot_frames = []
+        for frame in sat_dataset:
+            sat_spot_frames.append(frame)
+        offset_frames = sat_spot_frames
+        offset_dataset = data.Dataset(offset_frames)
+
     if xcent_guess is not None and ycent_guess is not None:
-        n = len(sat_dataset)
+        n = len(offset_dataset)
         initial_cent = {"xcent": np.repeat(xcent_guess, n),
                         "ycent": np.repeat(ycent_guess, n)}
     else:
         initial_cent = None
-    spot_centroids = compute_psf_centroid(dataset = sat_dataset, template_dataset = template_dataset, initial_cent = initial_cent)
+    spot_centroids = compute_psf_centroid(dataset = offset_dataset, template_dataset = template_dataset, initial_cent = initial_cent)
     
-    nb_filter = sat_dataset[0].ext_hdr["CFAMNAME"]
+    nb_filter = offset_dataset[0].ext_hdr["CFAMNAME"]
     bb_filter = nb_filter[0]
     cen_wave, _, _, _ = read_cent_wave(nb_filter)
     xoff_nb, yoff_nb = spec_filter_offset.get_offsets(nb_filter)
@@ -990,8 +1056,8 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
         frame.ext_hdr["WV0_XERR"] = x0err
         frame.ext_hdr["WV0_Y"] = y0
         frame.ext_hdr["WV0_YERR"] = y0err
-        frame.ext_hdr["WV0_DIMX"] = sat_dataset[0].ext_hdr['NAXIS1']
-        frame.ext_hdr["WV0_DIMY"] = sat_dataset[0].ext_hdr['NAXIS2']
+        frame.ext_hdr["WV0_DIMX"] = offset_dataset[0].ext_hdr['NAXIS1']
+        frame.ext_hdr["WV0_DIMY"] = offset_dataset[0].ext_hdr['NAXIS2']
                               
     history_msg = "wavelength zeropoint values added to header"
     sci_dataset.update_after_processing_step(history_msg)

--- a/corgidrp/recipe_templates/l2b_to_nd_filter_spec.json
+++ b/corgidrp/recipe_templates/l2b_to_nd_filter_spec.json
@@ -12,6 +12,9 @@
         "name": "determine_wave_zeropoint",
         "calibs": {
           "SpecFilterOffset": "AUTOMATIC"
+        },
+        "keywords" : {
+          "subtract_no_offset_frames": false
         }
       },
       {

--- a/corgidrp/recipe_templates/l2b_to_spec_flux.json
+++ b/corgidrp/recipe_templates/l2b_to_spec_flux.json
@@ -12,6 +12,9 @@
         "name": "determine_wave_zeropoint",
         "calibs": {
           "SpecFilterOffset": "AUTOMATIC"
+        },
+        "keywords" : {
+          "subtract_no_offset_frames": false
         }
       },
       {

--- a/corgidrp/recipe_templates/l2b_to_spec_linespread.json
+++ b/corgidrp/recipe_templates/l2b_to_spec_linespread.json
@@ -16,6 +16,7 @@
                     "SpecFilterOffset" : "AUTOMATIC"
             },
                 "keywords" : {
+                    "subtract_no_offset_frames": false,
                     "return_all" : true
             }
         },

--- a/corgidrp/recipe_templates/l3_to_l4_noncoron_spec.json
+++ b/corgidrp/recipe_templates/l3_to_l4_noncoron_spec.json
@@ -11,6 +11,9 @@
             "name" : "determine_wave_zeropoint",
                 "calibs" : {
                     "SpecFilterOffset" : "AUTOMATIC"
+            },
+                "keywords" : {
+                    "subtract_no_offset_frames": false
             }
         },
         {

--- a/tests/e2e_tests/l1_to_l3_spec_e2e.py
+++ b/tests/e2e_tests/l1_to_l3_spec_e2e.py
@@ -2,7 +2,6 @@ import argparse
 import os, sys
 import json
 import pytest
-import copy, datetime
 import numpy as np
 import astropy.time as time
 import astropy.io.fits as fits
@@ -262,51 +261,10 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     input_files = [f for f in all_files if f.endswith('l1_.fits')]
     if not input_files:
         raise FileNotFoundError(f"No files ending in 'l1_.fits' found in {l1_datadir}")
-    
+
+    # If we generate a fake background satspot file in l3->l4, sorts and selects input files so that we only take the previously generated fake file and two corgisim satspot files
     if fits.getheader(os.path.join(l1_datadir,input_files[0]), ext=1)['CFAMNAME'] == '3D':
-        # Existing satspot data only has +/- offset frames, but find_star expects
-        # three equal groups: no-offset, +offset, -offset.  We inject fake no-offset
-        # frames (science background data, no DM probe) at L1 so they flow through
-        # the full pipeline and sort first (year-2000 timestamps) into the no-offset
-        # group at L3.  Frames are grouped by (TARGET, DPAMNAME) — the same split
-        # find_star uses — and one real frame is dropped when the count is odd to
-        # keep each group size even so that n_fake = K/2 gives a divisible-by-3 total.
-        # We do this for all satspots
-
-        fake_l1 = []
-        accepted_real_files = []
-        if 'refstar_zeropoint' in l1_datadir:
-            fake_base_time = datetime.datetime(2000, 1, 1, 0, 0, 0)
-        else:
-            fake_base_time = datetime.datetime(2000, 1, 1, 0, 0, 1)
-
-        group_files = input_files
-        if len(group_files) % 2 != 0:
-            group_files = group_files[:-1]  # drop one frame to make count even
-        accepted_real_files.extend(list(group_files))
-
-        template_img = data.Image(os.path.join(l1_datadir,group_files[0]))
-        visitid = template_img.pri_hdr.get('VISITID', '')
-
-        for _ in range(len(group_files) // 2):
-            fake_frame = copy.deepcopy(template_img)
-            fake_frame.data[:] = np.zeros(np.shape(template_img.data))
-            if fake_frame.err is not None:
-                fake_frame.err[:] = np.zeros(np.shape(template_img.data))
-            fake_frame.ext_hdr['SCTSRT'] = fake_base_time.isoformat()
-            time_str = fake_base_time.strftime('%Y%m%dt%H%M%S%f')[:-5]
-            fake_satspot_filename = f"cgi_{visitid}_{time_str}_l1_.fits"
-            if os.path.exists(os.path.join(l1_datadir,fake_satspot_filename)): # If we already created a fake file earlier, prevents creation of new files
-                break
-            else:
-                fake_frame.save(filedir=l1_datadir, filename=fake_satspot_filename)
-                fake_l1.append(fake_frame.filename)
-                fake_base_time += datetime.timedelta(seconds=1)
-
-        # Rebuild input list: fake frames first (early timestamps sort them into the
-        # no-offset group), followed by the accepted real frames.
-        input_files = np.concatenate([np.array(fake_l1), np.array(accepted_real_files)])
-        if len(input_files) % 3 != 0:   # If we already created a fake file earlier, sorts and selects input files so that we only take the previously generated fake file and two corgisim satspot files
+        if len(input_files) % 3 != 0:
             input_files = sorted(input_files)
             input_files = input_files[:-1]
 

--- a/tests/e2e_tests/l1_to_l3_spec_e2e.py
+++ b/tests/e2e_tests/l1_to_l3_spec_e2e.py
@@ -279,7 +279,7 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
             if 'ISPC' in fits_file[1].header:
                 fits_file[1].header['ISPC'] = int(fits_file[1].header['ISPC'])
             fits_file[0].header['VISTYPE'] = 'CGIVST_TDD_OBS'
-            if fits_file[1].header['EMGAIN_C'] == 200:
+            if 'refstar' in l1_datadir:
                 logger.info(f"Filename: {fits_file[0].header['FILENAME']}")
                 logger.info(f"Original exposure time: {fits_file[1].header['EXPTIME']}")
                 if fits_file[1].header['EXPTIME'] >= 100:

--- a/tests/e2e_tests/l1_to_l3_spec_e2e.py
+++ b/tests/e2e_tests/l1_to_l3_spec_e2e.py
@@ -2,6 +2,7 @@ import argparse
 import os, sys
 import json
 import pytest
+import copy, datetime
 import numpy as np
 import astropy.time as time
 import astropy.io.fits as fits
@@ -60,7 +61,7 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     
     # ================================================================================
     # (1) Setup Calibrations
-    # ================================================================================
+    # ================================================================================    
     logger.info('='*80)
     logger.info('Pre-test: Set up calibration files')
     logger.info('='*80)
@@ -262,6 +263,53 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     if not input_files:
         raise FileNotFoundError(f"No files ending in 'l1_.fits' found in {l1_datadir}")
     
+    if fits.getheader(os.path.join(l1_datadir,input_files[0]), ext=1)['CFAMNAME'] == '3D':
+        # Existing satspot data only has +/- offset frames, but find_star expects
+        # three equal groups: no-offset, +offset, -offset.  We inject fake no-offset
+        # frames (science background data, no DM probe) at L1 so they flow through
+        # the full pipeline and sort first (year-2000 timestamps) into the no-offset
+        # group at L3.  Frames are grouped by (TARGET, DPAMNAME) — the same split
+        # find_star uses — and one real frame is dropped when the count is odd to
+        # keep each group size even so that n_fake = K/2 gives a divisible-by-3 total.
+        # We do this for all satspots
+
+        fake_l1 = []
+        accepted_real_files = []
+        if 'refstar_zeropoint' in l1_datadir:
+            fake_base_time = datetime.datetime(2000, 1, 1, 0, 0, 0)
+        else:
+            fake_base_time = datetime.datetime(2000, 1, 1, 0, 0, 1)
+
+        group_files = input_files
+        if len(group_files) % 2 != 0:
+            group_files = group_files[:-1]  # drop one frame to make count even
+        accepted_real_files.extend(list(group_files))
+
+        template_img = data.Image(os.path.join(l1_datadir,group_files[0]))
+        visitid = template_img.pri_hdr.get('VISITID', '')
+
+        for _ in range(len(group_files) // 2):
+            fake_frame = copy.deepcopy(template_img)
+            fake_frame.data[:] = np.zeros(np.shape(template_img.data))
+            if fake_frame.err is not None:
+                fake_frame.err[:] = np.zeros(np.shape(template_img.data))
+            fake_frame.ext_hdr['SCTSRT'] = fake_base_time.isoformat()
+            time_str = fake_base_time.strftime('%Y%m%dt%H%M%S%f')[:-5]
+            fake_satspot_filename = f"cgi_{visitid}_{time_str}_l1_.fits"
+            if os.path.exists(os.path.join(l1_datadir,fake_satspot_filename)): # If we already created a fake file earlier, prevents creation of new files
+                break
+            else:
+                fake_frame.save(filedir=l1_datadir, filename=fake_satspot_filename)
+                fake_l1.append(fake_frame.filename)
+                fake_base_time += datetime.timedelta(seconds=1)
+
+        # Rebuild input list: fake frames first (early timestamps sort them into the
+        # no-offset group), followed by the accepted real frames.
+        input_files = np.concatenate([np.array(fake_l1), np.array(accepted_real_files)])
+        if len(input_files) % 3 != 0:   # If we already created a fake file earlier, sorts and selects input files so that we only take the previously generated fake file and two corgisim satspot files
+            input_files = sorted(input_files)
+            input_files = input_files[:-1]
+
     input_data_filelist = [os.path.join(l1_datadir, f) for f in input_files]
     
     # Create input_data subfolder

--- a/tests/e2e_tests/l1_to_l3_spec_e2e.py
+++ b/tests/e2e_tests/l1_to_l3_spec_e2e.py
@@ -262,12 +262,6 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     if not input_files:
         raise FileNotFoundError(f"No files ending in 'l1_.fits' found in {l1_datadir}")
 
-    # If we generate a fake background satspot file in l3->l4, sorts and selects input files so that we only take the previously generated fake file and two corgisim satspot files
-    if fits.getheader(os.path.join(l1_datadir,input_files[0]), ext=1)['CFAMNAME'] == '3D':
-        if len(input_files) % 3 != 0:
-            input_files = sorted(input_files)
-            input_files = input_files[:-1]
-
     input_data_filelist = [os.path.join(l1_datadir, f) for f in input_files]
     
     # Create input_data subfolder

--- a/tests/e2e_tests/l1_to_l3_spec_e2e.py
+++ b/tests/e2e_tests/l1_to_l3_spec_e2e.py
@@ -269,8 +269,9 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     if not os.path.exists(input_data_dir):
         os.makedirs(input_data_dir)
 
-    # Update L1 headers for sims files
-    input_data_filelist = check.fix_hdrs_for_tvac(input_data_filelist, input_data_dir)
+    if 'SPEC-NOM' not in input_data_dir:
+        # Update L1 headers only for old sims files (TVAC data). New corgisim files have all relevant headers.
+        input_data_filelist = check.fix_hdrs_for_tvac(input_data_filelist, input_data_dir)
 
     ### Adhoc fix to extremely high exposure time (>100s) in satspot files, better fixes would involve using full-well capacity (fwc) instead
     for file in input_data_filelist:

--- a/tests/e2e_tests/l1_to_l3_spec_e2e.py
+++ b/tests/e2e_tests/l1_to_l3_spec_e2e.py
@@ -45,14 +45,15 @@ def patch_l2b_eacq_to_cropped_center(filelist):
             h['EACQ_COL'] = (n1 - 1) / 2.0
 
 
-def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
+def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger, fix_headers=True):
     """Run the complete L1 to L3 spectroscopy data end-to-end test.
     
     Args:
-        l1_datadir (str): Path to L1 input data directory
-        l3_outputdir (str): Path to output directory
-        processed_cal_path (str): Path to calibration files directory
-        logger (logging.Logger): Logger instance for output
+        l1_datadir (str): Path to L1 input data directory.
+        l3_outputdir (str): Path to output directory.
+        processed_cal_path (str): Path to calibration files directory.
+        logger (logging.Logger): Logger instance for output.
+        fix_headers (bool, optional): Fix headers for sims generated using TVAC data, not required for corgisim generated files. Default is True.
         
     Returns:
         list: List of L3 output filenames
@@ -269,7 +270,7 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger):
     if not os.path.exists(input_data_dir):
         os.makedirs(input_data_dir)
 
-    if 'SPEC-NOM' not in input_data_dir:
+    if fix_headers:
         # Update L1 headers only for old sims files (TVAC data). New corgisim files have all relevant headers.
         input_data_filelist = check.fix_hdrs_for_tvac(input_data_filelist, input_data_dir)
 

--- a/tests/e2e_tests/l1_to_l3_spec_e2e.py
+++ b/tests/e2e_tests/l1_to_l3_spec_e2e.py
@@ -273,6 +273,12 @@ def run_l1_to_l3_e2e_test(l1_datadir, l3_outputdir, processed_cal_path, logger, 
     if fix_headers:
         # Update L1 headers only for old sims files (TVAC data). New corgisim files have all relevant headers.
         input_data_filelist = check.fix_hdrs_for_tvac(input_data_filelist, input_data_dir)
+    #Delete COMMENT header keywords in L1 primary header, if present. Those are artifacts from corgisim.
+    for f in input_data_filelist:
+        try:
+            fits.delval(f, 'COMMENT', ext=0)
+        except:
+            pass
 
     ### Adhoc fix to extremely high exposure time (>100s) in satspot files, better fixes would involve using full-well capacity (fwc) instead
     for file in input_data_filelist:

--- a/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
+++ b/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
@@ -168,9 +168,7 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
         psfref_satspot_input_path = os.path.join(ref_spot_l3_output_dir,"input_l1")
         target_satspot_input_path = os.path.join(target_spot_l3_output_dir,"input_l1")
 
-        if os.path.exists(psfref_satspot_input_path): shutil.rmtree(psfref_satspot_input_path)
         os.makedirs(psfref_satspot_input_path)
-        if os.path.exists(target_satspot_input_path): shutil.rmtree(target_satspot_input_path)
         os.makedirs(target_satspot_input_path)
 
         logger.info(f"Copying psfref satspot files used as input to {psfref_satspot_input_path}.")

--- a/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
+++ b/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
@@ -79,19 +79,19 @@ def create_mock_L1_files(l1_datadir, l1_filelist, logger):
         template_img = Image(os.path.join(l1_datadir,group_files[0]))
         visitid = template_img.pri_hdr.get('VISITID', '')
         
-        for _ in range(len(group_files) // 2):
-            fake_frame = copy.deepcopy(template_img)
-            fake_frame.data[:] = np.zeros(np.shape(template_img.data))
-            if fake_frame.err is not None:
-                fake_frame.err[:] = np.zeros(np.shape(template_img.data))
-            fake_frame.ext_hdr['SCTSRT'] = fake_base_time.isoformat()
-            time_str = fake_base_time.strftime('%Y%m%dt%H%M%S%f')[:-5]
-            fake_satspot_filename = f"cgi_{visitid}_{time_str}_l1_.fits"
-            fake_frame.pri_hdr['FILENAME'] = fake_satspot_filename
+    for _ in range(len(group_files) // 2):
+        fake_frame = copy.deepcopy(template_img)
+        fake_frame.data[:] = np.zeros(np.shape(template_img.data))
+        if fake_frame.err is not None:
+            fake_frame.err[:] = np.zeros(np.shape(template_img.data))
+        fake_frame.ext_hdr['SCTSRT'] = fake_base_time.isoformat()
+        time_str = fake_base_time.strftime('%Y%m%dt%H%M%S%f')[:-5]
+        fake_satspot_filename = f"cgi_{visitid}_{time_str}_l1_.fits"
+        fake_frame.pri_hdr['FILENAME'] = fake_satspot_filename
 
-            fake_frame.save(filedir=l1_datadir, filename=fake_satspot_filename)
-            fake_base_time += datetime.timedelta(seconds=1)
-            l1_filelist.append(os.path.join(l1_datadir, fake_satspot_filename))
+        fake_frame.save(filedir=l1_datadir, filename=fake_satspot_filename)
+        fake_base_time += datetime.timedelta(seconds=1)
+        l1_filelist.append(os.path.join(l1_datadir, fake_satspot_filename))
     
     l1_filelist = sorted(l1_filelist)
     return l1_filelist
@@ -149,7 +149,21 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
     # Patch EACQ_ROW/EACQ_COL on L1s. TODO: fix this in the sims
     for flist in (psfref_satspot_files, psfref_files, target_satspot_files, target_files):
         patch_eacq_to_center_if_missing(flist)
-    
+
+    # Copy and save all L1 satspot files in output_dir
+    psfref_satspot_path = os.path.join(ref_spot_l3_output_dir,"all_L1")
+    target_satspot_path = os.path.join(target_spot_l3_output_dir,"all_L1")
+    os.makedirs(psfref_satspot_path)
+    os.makedirs(target_satspot_path)
+
+    for file in psfref_satspot_files:
+        filename = fits.getheader(file)['FILENAME']
+        shutil.copy(file,os.path.join(psfref_satspot_path,filename))
+    for file in target_satspot_files:
+        filename = fits.getheader(file)['FILENAME']
+        shutil.copy(file,os.path.join(target_satspot_path,filename))
+
+    # Create fake background satspot files (if required), and save them to L1 folder in output_dir
     psfref_satspot_files = create_mock_L1_files(psfref_satspot_path, psfref_satspot_files, logger)
     target_satspot_files = create_mock_L1_files(target_satspot_path, target_satspot_files, logger)
 

--- a/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
+++ b/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
@@ -87,6 +87,7 @@ def create_mock_L1_files(l1_datadir, l1_filelist, logger):
             fake_frame.ext_hdr['SCTSRT'] = fake_base_time.isoformat()
             time_str = fake_base_time.strftime('%Y%m%dt%H%M%S%f')[:-5]
             fake_satspot_filename = f"cgi_{visitid}_{time_str}_l1_.fits"
+            fake_frame.pri_hdr['FILENAME'] = fake_satspot_filename
 
             fake_frame.save(filedir=l1_datadir, filename=fake_satspot_filename)
             fake_base_time += datetime.timedelta(seconds=1)
@@ -161,9 +162,29 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
             fits.setval(f, 'VISITID', value = '0200001001001002001', ext=0) 
         changed_visitid=True
 
-    run_l1_to_l3_e2e_test(psfref_satspot_path, ref_spot_l3_output_dir, processed_cal_path, logger)
+    # If we have generated a fake background satspot file, sorts and selects input L1 files so that we only take the previously generated fake file and two corgisim satspot files.
+    # Those files are copied and saved to a different folder
+    if len(target_satspot_files) % 3 != 0:
+        psfref_satspot_input_path = os.path.join(ref_spot_l3_output_dir,"input_l1")
+        target_satspot_input_path = os.path.join(target_spot_l3_output_dir,"input_l1")
+
+        if os.path.exists(psfref_satspot_input_path): shutil.rmtree(psfref_satspot_input_path)
+        os.makedirs(psfref_satspot_input_path)
+        if os.path.exists(target_satspot_input_path): shutil.rmtree(target_satspot_input_path)
+        os.makedirs(target_satspot_input_path)
+
+        logger.info(f"Copying psfref satspot files used as input to {psfref_satspot_input_path}.")
+        for file in psfref_satspot_files[:-1]:
+            filename = fits.getheader(file)['FILENAME']
+            shutil.copy(file,os.path.join(psfref_satspot_input_path,filename))
+        logger.info(f"Copying target satspot files used as input to {target_satspot_input_path}.")
+        for file in target_satspot_files[:-1]:
+            filename = fits.getheader(file)['FILENAME']
+            shutil.copy(file,os.path.join(target_satspot_input_path,filename))
+
+    run_l1_to_l3_e2e_test(psfref_satspot_input_path, ref_spot_l3_output_dir, processed_cal_path, logger)
     run_l1_to_l3_e2e_test(psfref_files_path, ref_l3_output_dir, processed_cal_path, logger)
-    run_l1_to_l3_e2e_test(target_satspot_path, target_spot_l3_output_dir, processed_cal_path, logger)
+    run_l1_to_l3_e2e_test(target_satspot_input_path, target_spot_l3_output_dir, processed_cal_path, logger)
     run_l1_to_l3_e2e_test(target_files_path, target_l3_output_dir, processed_cal_path, logger)
 
     l3_files = []

--- a/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
+++ b/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
@@ -61,6 +61,9 @@ def create_mock_L1_files(l1_datadir, l1_filelist, logger):
         l1_datadir (str): Filepath to directory with L1 files.
         l1_filelist (list): List of L1 files in l1_datadir.
         logger (logging.Logger): Logger instance for output.
+
+    Returns:
+        list: List of L1 filenames for input.
     """
 
     if 'refstar_zeropoint' in l1_datadir:  # Different SCTSRT keyword for refstar and targetstar background satspot files

--- a/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
+++ b/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
@@ -157,6 +157,7 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
     # Artificial change to visitid for target files since both refstar/target corgisim files have same visitid. We need them different for determine_wave_zeropoint
     if fits.getheader(target_satspot_files[0])['VISITID'] == fits.getheader(psfref_satspot_files[0])['VISITID']:
         for f in target_satspot_files:
+            target_visitid = fits.getheader(psfref_satspot_files[0])['VISITID']
             fits.setval(f, 'VISITID', value = '0200001001001002001', ext=0)
         for f in target_files:
             fits.setval(f, 'VISITID', value = '0200001001001002001', ext=0) 
@@ -172,11 +173,11 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
         os.makedirs(target_satspot_input_path)
 
         logger.info(f"Copying psfref satspot files used as input to {psfref_satspot_input_path}.")
-        for file in psfref_satspot_files[:-1]:
+        for file in psfref_satspot_files[:-(len(psfref_satspot_files) % 3)]:
             filename = fits.getheader(file)['FILENAME']
             shutil.copy(file,os.path.join(psfref_satspot_input_path,filename))
         logger.info(f"Copying target satspot files used as input to {target_satspot_input_path}.")
-        for file in target_satspot_files[:-1]:
+        for file in target_satspot_files[:-(len(target_satspot_files) % 3)]:
             filename = fits.getheader(file)['FILENAME']
             shutil.copy(file,os.path.join(target_satspot_input_path,filename))
 
@@ -196,7 +197,14 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
     l3_files.extend(l3_target_spot)
     l3_dataset = Dataset(l3_files)
     logger.info('')
-    
+
+    # Reverting changed visitids to old values.
+    if changed_visitid:
+        for f in target_satspot_files:
+            fits.setval(f, 'VISITID', value = target_visitid, ext=0)
+        for f in target_files:
+            fits.setval(f, 'VISITID', value = target_visitid, ext=0) 
+            
     # ================================================================================
     # (2) Validate Input Images
     # ================================================================================
@@ -282,13 +290,6 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
     # Scan for default calibrations
     this_caldb.scan_dir_for_new_entries(corgidrp.default_cal_dir)
     
-    # Reverting changed visitids to old values.
-    if changed_visitid:
-        for f in target_satspot_files:
-            fits.setval(f, 'VISITID', value = '0200001001001001001', ext=0)
-        for f in target_files:
-            fits.setval(f, 'VISITID', value = '0200001001001001001', ext=0) 
-
     # ================================================================================
     # (3) Run Processing Pipeline
     # ================================================================================

--- a/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
+++ b/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
@@ -1,5 +1,7 @@
 import os
 import glob
+import copy
+import datetime
 import shutil
 import numpy as np
 import astropy.io.fits as fits
@@ -42,6 +44,53 @@ def patch_eacq_to_center_if_missing(filelist):
                 h['EACQ_ROW'] = (n2 - 1) / 2.0
                 h['EACQ_COL'] = (n1 - 1) / 2.0
 
+# Existing satspot data only has +/- offset frames, but find_star expects
+# three equal groups: no-offset, +offset, -offset.  We inject fake no-offset
+# frames (science background data, no DM probe) at L1 so they flow through
+# the full pipeline and sort first (year-2000 timestamps) into the no-offset
+# group at L3.  Frames are grouped by (TARGET, DPAMNAME) — the same split
+# find_star uses — and one real frame is dropped when the count is odd to
+# keep each group size even so that n_fake = K/2 gives a divisible-by-3 total.
+# We do this for all satspots
+
+def create_mock_L1_files(l1_datadir, l1_filelist, logger):
+    """
+    Create mock L1 background satspot (no offset) files using np.zeros.
+
+    Args:
+        l1_datadir (str): Filepath to directory with L1 files.
+        l1_filelist (list): List of L1 files in l1_datadir.
+        logger (logging.Logger): Logger instance for output.
+    """
+
+    if 'refstar_zeropoint' in l1_datadir:  # Different SCTSRT keyword for refstar and targetstar background satspot files
+        fake_base_time = datetime.datetime(2000, 1, 1, 0, 0, 0)
+    else:
+        fake_base_time = datetime.datetime(2000, 1, 1, 0, 0, 1)
+
+    group_files = sorted(glob.glob(os.path.join(l1_datadir, "cgi_*l1_.fits")))
+    if len(group_files) % 2 != 0:
+        logger.info(f'Creating mock L1 background satspot file in {l1_datadir}')
+        group_files = group_files[:-1]  # drop one frame to make count even
+
+        template_img = Image(os.path.join(l1_datadir,group_files[0]))
+        visitid = template_img.pri_hdr.get('VISITID', '')
+        
+        for _ in range(len(group_files) // 2):
+            fake_frame = copy.deepcopy(template_img)
+            fake_frame.data[:] = np.zeros(np.shape(template_img.data))
+            if fake_frame.err is not None:
+                fake_frame.err[:] = np.zeros(np.shape(template_img.data))
+            fake_frame.ext_hdr['SCTSRT'] = fake_base_time.isoformat()
+            time_str = fake_base_time.strftime('%Y%m%dt%H%M%S%f')[:-5]
+            fake_satspot_filename = f"cgi_{visitid}_{time_str}_l1_.fits"
+
+            fake_frame.save(filedir=l1_datadir, filename=fake_satspot_filename)
+            fake_base_time += datetime.timedelta(seconds=1)
+            l1_filelist.append(os.path.join(l1_datadir, fake_satspot_filename))
+    
+    l1_filelist = sorted(l1_filelist)
+    return l1_filelist
 
 # ================================================================================
 # Main Spec L3 to L4 E2E Test Function PSF subtracted
@@ -96,6 +145,18 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
     # Patch EACQ_ROW/EACQ_COL on L1s. TODO: fix this in the sims
     for flist in (psfref_satspot_files, psfref_files, target_satspot_files, target_files):
         patch_eacq_to_center_if_missing(flist)
+    
+    psfref_satspot_files = create_mock_L1_files(psfref_satspot_path, psfref_satspot_files, logger)
+    target_satspot_files = create_mock_L1_files(target_satspot_path, target_satspot_files, logger)
+
+    changed_visitid=False
+    # Artificial change to visitid for target files since both refstar/target corgisim files have same visitid. We need them different for determine_wave_zeropoint
+    if fits.getheader(target_satspot_files[0])['VISITID'] == fits.getheader(psfref_satspot_files[0])['VISITID']:
+        for f in target_satspot_files:
+            fits.setval(f, 'VISITID', value = '0200001001001002001', ext=0)
+        for f in target_files:
+            fits.setval(f, 'VISITID', value = '0200001001001002001', ext=0) 
+        changed_visitid=True
 
     run_l1_to_l3_e2e_test(psfref_satspot_path, ref_spot_l3_output_dir, processed_cal_path, logger)
     run_l1_to_l3_e2e_test(psfref_files_path, ref_l3_output_dir, processed_cal_path, logger)
@@ -199,6 +260,13 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
     # Scan for default calibrations
     this_caldb.scan_dir_for_new_entries(corgidrp.default_cal_dir)
     
+    # Reverting changed visitids to old values.
+    if changed_visitid:
+        for f in target_satspot_files:
+            fits.setval(f, 'VISITID', value = '0200001001001001001', ext=0)
+        for f in target_files:
+            fits.setval(f, 'VISITID', value = '0200001001001001001', ext=0) 
+
     # ================================================================================
     # (3) Run Processing Pipeline
     # ================================================================================

--- a/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
+++ b/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
@@ -83,9 +83,13 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
     
     processed_cal_path = os.path.join(e2edata_path, "TV-36_Coronagraphic_Data", "Cals")
     ref_l3_output_dir = os.path.join(e2edata_path, "SPEC_NOM_sims","SPEC-NOM_refstar_science_analog", "L3")
+    if os.path.exists(ref_l3_output_dir):shutil.rmtree(ref_l3_output_dir)
     target_l3_output_dir = os.path.join(e2edata_path, "SPEC_NOM_sims","SPEC-NOM_targetstar_science_analog", "L3")
+    if os.path.exists(target_l3_output_dir):shutil.rmtree(target_l3_output_dir)
     ref_spot_l3_output_dir = os.path.join(e2edata_path, "SPEC_NOM_sims","SPEC-NOM_refstar_zeropoint", "L3")
+    if os.path.exists(ref_spot_l3_output_dir):shutil.rmtree(ref_spot_l3_output_dir)
     target_spot_l3_output_dir = os.path.join(e2edata_path, "SPEC_NOM_sims","SPEC-NOM_targetstar_zeropoint", "L3")
+    if os.path.exists(target_spot_l3_output_dir):shutil.rmtree(target_spot_l3_output_dir)
 
     cpgs_xml_filepath = os.path.join(os.path.dirname(__file__), "..", "test_data", "CPGS_betatest_041426.xml")
 
@@ -97,7 +101,7 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
     run_l1_to_l3_e2e_test(psfref_files_path, ref_l3_output_dir, processed_cal_path, logger)
     run_l1_to_l3_e2e_test(target_satspot_path, target_spot_l3_output_dir, processed_cal_path, logger)
     run_l1_to_l3_e2e_test(target_files_path, target_l3_output_dir, processed_cal_path, logger)
-    
+
     l3_files = []
     l3_psfref = sorted(glob.glob(os.path.join(ref_l3_output_dir, "cgi_*l3_.fits")))
     l3_files.extend(l3_psfref)

--- a/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
+++ b/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
@@ -75,7 +75,7 @@ def create_mock_L1_files(l1_datadir, logger):
         logger.info(f'Creating mock L1 background satspot file in {l1_datadir}')
         group_files = group_files[:-1]  # drop one frame to make count even
 
-        template_img = Image(os.path.join(l1_datadir,group_files[0]))
+        template_img = Image(group_files[0])
         visitid = template_img.pri_hdr.get('VISITID', '')
         
     for _ in range(len(group_files) // 2):
@@ -193,10 +193,10 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
             filename = fits.getheader(file)['FILENAME']
             shutil.copy(file,os.path.join(target_satspot_input_path,filename))
     
-    run_l1_to_l3_e2e_test(psfref_satspot_input_path, ref_spot_l3_output_dir, processed_cal_path, logger)
-    run_l1_to_l3_e2e_test(psfref_files_path, ref_l3_output_dir, processed_cal_path, logger)
-    run_l1_to_l3_e2e_test(target_satspot_input_path, target_spot_l3_output_dir, processed_cal_path, logger)
-    run_l1_to_l3_e2e_test(target_files_path, target_l3_output_dir, processed_cal_path, logger)
+    run_l1_to_l3_e2e_test(psfref_satspot_input_path, ref_spot_l3_output_dir, processed_cal_path, logger, fix_headers=False)
+    run_l1_to_l3_e2e_test(psfref_files_path, ref_l3_output_dir, processed_cal_path, logger, fix_headers=False)
+    run_l1_to_l3_e2e_test(target_satspot_input_path, target_spot_l3_output_dir, processed_cal_path, logger, fix_headers=False)
+    run_l1_to_l3_e2e_test(target_files_path, target_l3_output_dir, processed_cal_path, logger, fix_headers=False)
 
     l3_files = []
     l3_psfref = sorted(glob.glob(os.path.join(ref_l3_output_dir, "cgi_*l3_.fits")))

--- a/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
+++ b/tests/e2e_tests/spec_l3_to_l4_psfsub_e2e.py
@@ -53,13 +53,12 @@ def patch_eacq_to_center_if_missing(filelist):
 # keep each group size even so that n_fake = K/2 gives a divisible-by-3 total.
 # We do this for all satspots
 
-def create_mock_L1_files(l1_datadir, l1_filelist, logger):
+def create_mock_L1_files(l1_datadir, logger):
     """
     Create mock L1 background satspot (no offset) files using np.zeros.
 
     Args:
         l1_datadir (str): Filepath to directory with L1 files.
-        l1_filelist (list): List of L1 files in l1_datadir.
         logger (logging.Logger): Logger instance for output.
 
     Returns:
@@ -91,9 +90,8 @@ def create_mock_L1_files(l1_datadir, l1_filelist, logger):
 
         fake_frame.save(filedir=l1_datadir, filename=fake_satspot_filename)
         fake_base_time += datetime.timedelta(seconds=1)
-        l1_filelist.append(os.path.join(l1_datadir, fake_satspot_filename))
     
-    l1_filelist = sorted(l1_filelist)
+    l1_filelist = sorted(glob.glob(os.path.join(l1_datadir,"cgi_*l1_.fits")))
     return l1_filelist
 
 # ================================================================================
@@ -135,13 +133,13 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
     logger.info(f"Found {len(psfref_satspot_files)} existing L1 reference satspot files in {e2edata_path}")
     
     processed_cal_path = os.path.join(e2edata_path, "TV-36_Coronagraphic_Data", "Cals")
-    ref_l3_output_dir = os.path.join(e2edata_path, "SPEC_NOM_sims","SPEC-NOM_refstar_science_analog", "L3")
+    ref_l3_output_dir = os.path.join(e2eoutput_path,"SPEC-NOM_refstar_science_analog", "L1_to_L3")
     if os.path.exists(ref_l3_output_dir):shutil.rmtree(ref_l3_output_dir)
-    target_l3_output_dir = os.path.join(e2edata_path, "SPEC_NOM_sims","SPEC-NOM_targetstar_science_analog", "L3")
+    target_l3_output_dir = os.path.join(e2eoutput_path, "SPEC-NOM_targetstar_science_analog", "L1_to_L3")
     if os.path.exists(target_l3_output_dir):shutil.rmtree(target_l3_output_dir)
-    ref_spot_l3_output_dir = os.path.join(e2edata_path, "SPEC_NOM_sims","SPEC-NOM_refstar_zeropoint", "L3")
+    ref_spot_l3_output_dir = os.path.join(e2eoutput_path, "SPEC-NOM_refstar_zeropoint", "L1_to_L3")
     if os.path.exists(ref_spot_l3_output_dir):shutil.rmtree(ref_spot_l3_output_dir)
-    target_spot_l3_output_dir = os.path.join(e2edata_path, "SPEC_NOM_sims","SPEC-NOM_targetstar_zeropoint", "L3")
+    target_spot_l3_output_dir = os.path.join(e2eoutput_path, "SPEC-NOM_targetstar_zeropoint", "L1_to_L3")
     if os.path.exists(target_spot_l3_output_dir):shutil.rmtree(target_spot_l3_output_dir)
 
     cpgs_xml_filepath = os.path.join(os.path.dirname(__file__), "..", "test_data", "CPGS_betatest_041426.xml")
@@ -164,14 +162,14 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
         shutil.copy(file,os.path.join(target_satspot_path,filename))
 
     # Create fake background satspot files (if required), and save them to L1 folder in output_dir
-    psfref_satspot_files = create_mock_L1_files(psfref_satspot_path, psfref_satspot_files, logger)
-    target_satspot_files = create_mock_L1_files(target_satspot_path, target_satspot_files, logger)
+    psfref_satspot_files = create_mock_L1_files(psfref_satspot_path, logger)
+    target_satspot_files = create_mock_L1_files(target_satspot_path, logger)
 
     changed_visitid=False
     # Artificial change to visitid for target files since both refstar/target corgisim files have same visitid. We need them different for determine_wave_zeropoint
     if fits.getheader(target_satspot_files[0])['VISITID'] == fits.getheader(psfref_satspot_files[0])['VISITID']:
         for f in target_satspot_files:
-            target_visitid = fits.getheader(psfref_satspot_files[0])['VISITID']
+            target_visitid = fits.getheader(psfref_satspot_files[0])['VISITID'] # We only change if refstar and target star visitids are same. Saving refstar visitid here as it is never altered.
             fits.setval(f, 'VISITID', value = '0200001001001002001', ext=0)
         for f in target_files:
             fits.setval(f, 'VISITID', value = '0200001001001002001', ext=0) 
@@ -194,7 +192,7 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
         for file in target_satspot_files[:-(len(target_satspot_files) % 3)]:
             filename = fits.getheader(file)['FILENAME']
             shutil.copy(file,os.path.join(target_satspot_input_path,filename))
-
+    
     run_l1_to_l3_e2e_test(psfref_satspot_input_path, ref_spot_l3_output_dir, processed_cal_path, logger)
     run_l1_to_l3_e2e_test(psfref_files_path, ref_l3_output_dir, processed_cal_path, logger)
     run_l1_to_l3_e2e_test(target_satspot_input_path, target_spot_l3_output_dir, processed_cal_path, logger)
@@ -241,7 +239,7 @@ def run_spec_l3_to_l4_psfsub_e2e_test(e2edata_path, e2eoutput_path):
         verify_header_keywords(frame.ext_hdr, {'SATSPOTS'}, frame_info, logger)
         logger.info("")
     
-    l3_files_dir = os.path.join(e2eoutput_path, "L3")
+    l3_files_dir = os.path.join(e2eoutput_path, "input_L3")
     if os.path.exists(l3_files_dir):
         shutil.rmtree(l3_files_dir)
     os.makedirs(l3_files_dir)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,4 +1,4 @@
-import os
+import os, copy
 import numpy as np
 import pytest
 import logging
@@ -459,14 +459,17 @@ def test_determine_zeropoint():
     slit_x = initial_cent.get("xcent")[12]
     slit_y = initial_cent.get("ycent")[12]
 
+    frame_time = datetime(2024, 1, 1, 0, 0, 0)
     ext_hdr['DPAMNAME'] = 'PRISM3'
     ext_hdr['FSAMNAME'] = 'R1C2'
     psf_images = []
     for i in range(psf_array.shape[0]):
         data_2d = np.copy(psf_array[i])
+        frame_time += timedelta(seconds=3)
         ext_hdr["NAXIS1"] =np.shape(data_2d)[0]
         ext_hdr["NAXIS2"] =np.shape(data_2d)[1]
         ext_hdr['CFAMNAME'] = '3'
+        ext_hdr['SCTSRT'] = frame_time.isoformat()
         if i == 12:
             ext_hdr["SATSPOTS"] = True
             ext_hdr['CFAMNAME'] = '3D'
@@ -482,16 +485,32 @@ def test_determine_zeropoint():
             dq=dq
         )
         psf_images.append(image)
+        if i == 11:       #With rule of threes, we need three satspot frames. We get it by creating a zeros frame as no_offset satspot frame and duplicating the original satspot frame in the test dataset
+            image_copy=copy.deepcopy(image)
+            frame_time += timedelta(seconds=3)
+            image_copy.ext_hdr['SCTSRT'] = frame_time.isoformat()
+            image_copy.ext_hdr["SATSPOTS"] = True
+            image_copy.ext_hdr['CFAMNAME'] = '3D'
+            image_copy.data = np.zeros(np.shape(image.data))
+            image_copy.err = np.zeros(np.shape(image.err))
+            psf_images.append(image_copy)
+        elif i == 12:      
+            image_copy=copy.deepcopy(image)
+            frame_time += timedelta(seconds=3)
+            image_copy.ext_hdr['SCTSRT'] = frame_time.isoformat()
+            image_copy.ext_hdr["SATSPOTS"] = True
+            image_copy.ext_hdr['CFAMNAME'] = '3D'
+            psf_images.append(image_copy)
 
     # Load the filter-to-filter image offsets to correct for the location of the narrowband centroid
     # with respect to the broadband filter.
     (xoff_nb, yoff_nb) = (steps.read_cent_wave('3D')[2], steps.read_cent_wave('3D')[3])
     (xoff_bb, yoff_bb) = (steps.read_cent_wave('3')[2], steps.read_cent_wave('3')[3])
 
-    #test it with optional initial guess and with one satspot frame
+    #test it with optional initial guess and with three satspot frames
     spec_filter_offset = SpecFilterOffset({})
     input_dataset = Dataset(psf_images)
-    dataset_guess = l3_to_l4.determine_wave_zeropoint(input_dataset, spec_filter_offset, xcent_guess = 40., ycent_guess = 32.)
+    dataset_guess = l3_to_l4.determine_wave_zeropoint(input_dataset, spec_filter_offset, subtract_no_offset_frames=True, xcent_guess = 40., ycent_guess = 32.)
 
     assert len(dataset_guess) < len(input_dataset)
     for frame in dataset_guess:
@@ -513,12 +532,16 @@ def test_determine_zeropoint():
         assert y0err < errortol_pix
     
     psf_images = []
+    frame_time = datetime(2024, 1, 1, 0, 0, 0)
     for i in range(psf_array.shape[0]):
         data_2d = np.copy(psf_array[i])
+        frame_time += timedelta(seconds=3)
         ext_hdr["NAXIS1"] =np.shape(data_2d)[0]
         ext_hdr["NAXIS2"] =np.shape(data_2d)[1]
         ext_hdr['CFAMNAME'] = '3D'
+        ext_hdr["FPAMNAME"] = 'OPEN_34'
         ext_hdr["SATSPOTS"] = False
+        ext_hdr['SCTSRT'] = frame_time.isoformat()
         err = np.zeros_like(data_2d)
         dq = np.zeros_like(data_2d, dtype=int)
         image = Image(
@@ -532,12 +555,12 @@ def test_determine_zeropoint():
 
     #test it as non-coronagraphic observation of only psf narrowband, so no science frames, a print statement should be raised
     input_dataset2 = Dataset(psf_images)
-    dataset = l3_to_l4.determine_wave_zeropoint(input_dataset2, spec_filter_offset)
+    dataset = l3_to_l4.determine_wave_zeropoint(input_dataset2, spec_filter_offset, subtract_no_offset_frames=False)
     assert len(dataset) > 0
     
     #only 1 fake science dataset frame
     input_dataset2.frames[0].ext_hdr['CFAMNAME'] = '3'
-    dataset = l3_to_l4.determine_wave_zeropoint(input_dataset2, spec_filter_offset)
+    dataset = l3_to_l4.determine_wave_zeropoint(input_dataset2, spec_filter_offset, subtract_no_offset_frames=False)
     assert len(dataset) == 1
     for frame in dataset:
         assert frame.ext_hdr["SATSPOTS"] == False
@@ -559,13 +582,13 @@ def test_determine_zeropoint():
     
     #to test the accuracy add noise to the dataset frames
     read_noise = 200
-    np.random.seed(0)
+    np.random.seed(2)
 
     noise_dataset = input_dataset.copy()
     for frame in noise_dataset:
         frame.data = np.random.poisson(np.abs(frame.data)/3) + \
         np.random.normal(loc=0, scale=read_noise, size = frame.data.shape)
-    noisci_dataset = l3_to_l4.determine_wave_zeropoint(noise_dataset, spec_filter_offset)
+    noisci_dataset = l3_to_l4.determine_wave_zeropoint(noise_dataset, spec_filter_offset, subtract_no_offset_frames = True)
     for i in range(len(noisci_dataset)):
         x0_noi = noisci_dataset[i].ext_hdr["WV0_X"]
         y0_noi = noisci_dataset[i].ext_hdr["WV0_Y"]

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -513,7 +513,7 @@ def test_determine_zeropoint():
     #test it with optional initial guess and with three satspot frames
     spec_filter_offset = SpecFilterOffset({})
     input_dataset = Dataset(psf_images)
-    dataset_guess = l3_to_l4.determine_wave_zeropoint(input_dataset, spec_filter_offset, subtract_no_offset_frames=True, xcent_guess = 40., ycent_guess = 32.)
+    dataset_guess = l3_to_l4.determine_wave_zeropoint(input_dataset, spec_filter_offset, xcent_guess = 40., ycent_guess = 32.)
 
     assert len(dataset_guess) < len(input_dataset)
     for frame in dataset_guess:
@@ -591,7 +591,7 @@ def test_determine_zeropoint():
     for frame in noise_dataset:
         frame.data = np.random.poisson(np.abs(frame.data)/3) + \
         np.random.normal(loc=0, scale=read_noise, size = frame.data.shape)
-    noisci_dataset = l3_to_l4.determine_wave_zeropoint(noise_dataset, spec_filter_offset, subtract_no_offset_frames = True)
+    noisci_dataset = l3_to_l4.determine_wave_zeropoint(noise_dataset, spec_filter_offset)
     for i in range(len(noisci_dataset)):
         x0_noi = noisci_dataset[i].ext_hdr["WV0_X"]
         y0_noi = noisci_dataset[i].ext_hdr["WV0_Y"]

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -470,9 +470,15 @@ def test_determine_zeropoint():
         ext_hdr["NAXIS2"] =np.shape(data_2d)[1]
         ext_hdr['CFAMNAME'] = '3'
         ext_hdr['SCTSRT'] = frame_time.isoformat()
-        if i == 12:
+        # We need three satspot frames, with no offset/+offset/-offset. Test dataset has just one satspot frame, which has +offset (possibly).
+        # We create a fake no_offset (background) satspot frame using np.zeros and a second offset satspot frame by duplicating the pre-existing satspot frame in the test dataset
+        # In next few lines, we only create the data_2d_copy needed for frame faking/duplication
+        if i == 11: 
+            data_2d_copy = np.zeros_like(data_2d)
+        elif i == 12:
             ext_hdr["SATSPOTS"] = True
             ext_hdr['CFAMNAME'] = '3D'
+            data_2d_copy = np.copy(data_2d)
         else:
             ext_hdr["SATSPOTS"] = False
         err = np.zeros_like(data_2d)
@@ -485,21 +491,18 @@ def test_determine_zeropoint():
             dq=dq
         )
         psf_images.append(image)
-        if i == 11:       #With rule of threes, we need three satspot frames. We get it by creating a zeros frame as no_offset satspot frame and duplicating the original satspot frame in the test dataset
-            image_copy=copy.deepcopy(image)
+        if i in [11,12]: # Actually generating the additional satspot frames using data_2d_copy
             frame_time += timedelta(seconds=3)
-            image_copy.ext_hdr['SCTSRT'] = frame_time.isoformat()
-            image_copy.ext_hdr["SATSPOTS"] = True
-            image_copy.ext_hdr['CFAMNAME'] = '3D'
-            image_copy.data = np.zeros(np.shape(image.data))
-            image_copy.err = np.zeros(np.shape(image.err))
-            psf_images.append(image_copy)
-        elif i == 12:      
-            image_copy=copy.deepcopy(image)
-            frame_time += timedelta(seconds=3)
-            image_copy.ext_hdr['SCTSRT'] = frame_time.isoformat()
-            image_copy.ext_hdr["SATSPOTS"] = True
-            image_copy.ext_hdr['CFAMNAME'] = '3D'
+            ext_hdr['SCTSRT'] = frame_time.isoformat()
+            ext_hdr["SATSPOTS"] = True
+            ext_hdr['CFAMNAME'] = '3D'
+            image_copy = Image(
+                data_or_filepath=data_2d_copy,
+                pri_hdr=pri_hdr.copy(),
+                ext_hdr=ext_hdr.copy(),
+                err=err,
+                dq=dq
+            )
             psf_images.append(image_copy)
 
     # Load the filter-to-filter image offsets to correct for the location of the narrowband centroid


### PR DESCRIPTION

## Describe your changes
Satspot frames will always be in groups of 3, ordered as no offset/+offset/-offset frames. Determine_wavelength_zeropoint now considers first satspot frame (ordered by SCTSRT) as no_offset frame and uses it to subtract background from +/- offset frame. Implementing this in unit tests and e2e tests requires creation of a fake no_offset satspot frame with np.zeros

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
#889 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
