### PR TITLE
Keep CR frames through L2a and flag them  IS_BAD

### DIFF
--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -159,7 +159,8 @@ def prescan_biassub(input_dataset, noise_maps=None, return_full_frame=False,
 
 def detect_cosmic_rays(input_dataset, detector_params, k_gain = None, sat_thresh=0.95,
                        plat_thresh=0.85, cosm_filter=1, cosm_box=3, cosm_tail=10,
-                       mode='image', detector_regions=None, pct_oversat_lim=20, dataset_copy=True):
+                       mode='image', detector_regions=None, pct_oversat_lim=20,
+                       dataset_copy=True, discard_oversat=False):
     """
     Detects cosmic rays in a given dataset. Updates the DQ to reflect the pixels that are affected.
     TODO: (Eventually) Decide if we want to invest time in improving CR rejection (modeling and subtracting the hit
@@ -205,9 +206,11 @@ def detect_cosmic_rays(input_dataset, detector_params, k_gain = None, sat_thresh
             found in detector_areas in detector.py. Defaults to detector_areas in detector.py.
         pct_oversat_lim: (float):
             Percent of total frame over sat_fwc over which we determine the frame is oversaturated
-            and will be discarded. Frame saturations equal to this argument are not discarded.
+            and will be marked bad or discarded. Frame saturations equal to this argument are not flagged.
         dataset_copy (bool): flag indicating whether the input dataset will be preserved after this function is executed or not.  If False, the output dataset will be the input dataset modified, and 
             the input and output datasets will be identical.  This is useful when handling a large dataset and when the input dataset is not needed afterwards. Defaults to True.
+        discard_oversat (bool): if True, discard frames that exceed pct_oversat_lim, preserving the previous behavior.
+            If False, keep them, mark IS_BAD, and skip cosmic ray identification for those frames. Defaults to False.
 
     Returns:
         corgidrp.data.Dataset:
@@ -255,26 +258,34 @@ def detect_cosmic_rays(input_dataset, detector_params, k_gain = None, sat_thresh
         frame.ext_hdr['FWC_EM_E'] = fwcem_e_arr[i]
         frame.ext_hdr['SAT_DN'] = initial_sat_fwcs[i]
 
-
-    crmasked_dataset = initial_dataset
-    crmasked_cube = crmasked_dataset.all_data
-    sat_fwcs = initial_sat_fwcs
-
-    # keep oversaturated frames, but mark them bad and skip the expensive CR search.
     oversat_frames = set()
-    for i, frame in enumerate(crmasked_dataset.frames):
-        pct_frame_sat = ((frame.data > sat_fwcs[i]).sum() / frame.data.size) * 100
-        if pct_frame_sat > pct_oversat_lim:
-            frame.ext_hdr['IS_BAD'] = True
-            oversat_frames.add(i)
+    if discard_oversat:
+        # Preserve previous behavior as an option.
+        crmasked_dataset, sat_fwcs = remove_sat_images(initial_dataset, initial_sat_fwcs, pct_oversat_lim, dataset_copy=False)
+    else:
+        crmasked_dataset = initial_dataset
+        sat_fwcs = initial_sat_fwcs
+
+        # Keep oversaturated frames, but mark them bad and skip the expensive CR search.
+        for i, frame in enumerate(crmasked_dataset.frames):
+            pct_frame_sat = ((frame.data > sat_fwcs[i]).sum() / frame.data.size) * 100
+            if pct_frame_sat > pct_oversat_lim:
+                frame.ext_hdr['IS_BAD'] = True
+                frame.ext_hdr.add_history(
+                    "Marked IS_BAD because frame exceeded pct_oversat_lim in detect_cosmic_rays."
+                )
+                frame.ext_hdr.add_history(
+                    "Cosmic ray identification skipped for this oversaturated frame."
+                )
+                oversat_frames.add(i)
+
+    crmasked_cube = crmasked_dataset.all_data
 
     sat_fwcs_array = np.array([np.full_like(crmasked_cube[0],sat_fwcs[i]) for i in range(len(sat_fwcs))])
 
     # threshold the frame to catch any values above sat_fwc --> this is
     # mask 1
     m1 = (crmasked_cube >= sat_fwcs_array) * sat_dqval
-    for i in oversat_frames:
-        m1[i, :, :] = sat_dqval
     # Mask 2:  captures cosmic rays.  If EM gain is 1, no cosmic tails made since 
     # those are only made in gain register.  
     # Do a for loop since it's calling a for loop in the sub-routine anyway

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -255,15 +255,26 @@ def detect_cosmic_rays(input_dataset, detector_params, k_gain = None, sat_thresh
         frame.ext_hdr['FWC_EM_E'] = fwcem_e_arr[i]
         frame.ext_hdr['SAT_DN'] = initial_sat_fwcs[i]
 
-    # Remove images that are too saturated to remove cosmics in a timely manner
-    crmasked_dataset, sat_fwcs = remove_sat_images(initial_dataset, initial_sat_fwcs, pct_oversat_lim, dataset_copy=dataset_copy)
+
+    crmasked_dataset = initial_dataset
     crmasked_cube = crmasked_dataset.all_data
+    sat_fwcs = initial_sat_fwcs
+
+    # keep oversaturated frames, but mark them bad and skip the expensive CR search.
+    oversat_frames = set()
+    for i, frame in enumerate(crmasked_dataset.frames):
+        pct_frame_sat = ((frame.data > sat_fwcs[i]).sum() / frame.data.size) * 100
+        if pct_frame_sat > pct_oversat_lim:
+            frame.ext_hdr['IS_BAD'] = True
+            oversat_frames.add(i)
 
     sat_fwcs_array = np.array([np.full_like(crmasked_cube[0],sat_fwcs[i]) for i in range(len(sat_fwcs))])
 
     # threshold the frame to catch any values above sat_fwc --> this is
     # mask 1
     m1 = (crmasked_cube >= sat_fwcs_array) * sat_dqval
+    for i in oversat_frames:
+        m1[i, :, :] = sat_dqval
     # Mask 2:  captures cosmic rays.  If EM gain is 1, no cosmic tails made since 
     # those are only made in gain register.  
     # Do a for loop since it's calling a for loop in the sub-routine anyway
@@ -277,6 +288,9 @@ def detect_cosmic_rays(input_dataset, detector_params, k_gain = None, sat_thresh
             break
 
     for i in range(len(crmasked_cube)):
+        if i in oversat_frames:
+            continue
+
         arrtype = crmasked_dataset.frames[i].ext_hdr['ARRTYPE']
         if emgain_list[i] == 1:
             cosm_tail_i = 0

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -306,6 +306,11 @@ def frame_select(input_dataset, bpix_frac=1., allowed_bpix=0, overexp=False, tt_
 
     for i, frame in enumerate(pruned_dataset.frames):
         reject_reasons[i] = [] # list of rejection reasons
+        # Reject frames already marked bad by an upstream step.
+        if frame.ext_hdr.get('IS_BAD', False):
+            reject_flags[i] += 64
+            reject_reasons[i].append("IS_BAD = T")
+
         if bpix_frac < 1:
             masked_dq = np.bitwise_and(frame.dq, disallowed_bits) # handle allowed_bpix values
             numbadpix = np.size(np.where(masked_dq > 0)[0])

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -279,7 +279,8 @@ def flat_division_pol(input_dataset, flat_fieldPOL0, flat_fieldPOL45):
 
     return output_dataset
 
-def frame_select(input_dataset, bpix_frac=1., allowed_bpix=0, overexp=False, tt_rms_thres=None, tt_bias_thres=None, discard_bad=True):
+def frame_select(input_dataset, bpix_frac=1., allowed_bpix=0, overexp=False, tt_rms_thres=None,
+                 tt_bias_thres=None, discard_bad=True, record_selection=True):
     """
 
     Selects the frames that we want to use for further processing.
@@ -294,6 +295,7 @@ def frame_select(input_dataset, bpix_frac=1., allowed_bpix=0, overexp=False, tt_
         tt_rms_thres (float): maximum allowed RMS tip or tilt in image to be considered good. Default: None (not used)
         tt_bias_thres (float): maximum allowed bias in tip/tilt over the course of an image to be consdiered good. Default: None (not used)
         discard_bad (bool): if True, drops the bad frames rather than keeping them through processing
+        record_selection (bool): if True, records frame selection criteria in FRMSEL header keywords.
         
     Returns:
         corgidrp.data.Dataset: a version of the input dataset with only the frames we want to use
@@ -320,13 +322,15 @@ def frame_select(input_dataset, bpix_frac=1., allowed_bpix=0, overexp=False, tt_
                 reject_flags[i] += 1
                 reject_reasons[i].append("bad pix frac {0:.5f} > {1:.5f}"
                                          .format(frame_badpix_frac, bpix_frac))
-        frame.ext_hdr['FRMSEL01'] = (bpix_frac, "Bad Pixel Fraction < This Value. Doesn't include DQflags summed to {0}".format(allowed_bpix)) # record selection criteria
+        if record_selection:
+            frame.ext_hdr['FRMSEL01'] = (bpix_frac, "Bad Pixel Fraction < This Value. Doesn't include DQflags summed to {0}".format(allowed_bpix)) # record selection criteria
 
         if overexp:
             if frame.ext_hdr['OVEREXP']:
                 reject_flags[i] += 2 # use distinct bits in case it's useful
                 reject_reasons[i].append("OVEREXP = T")
-        frame.ext_hdr['FRMSEL02'] = (overexp, "Are we selecting on the OVEREXP flag?") # record selection criteria
+        if record_selection:
+            frame.ext_hdr['FRMSEL02'] = (overexp, "Are we selecting on the OVEREXP flag?") # record selection criteria
 
         if tt_rms_thres is not None:
             if frame.ext_hdr['Z2VAR'] > tt_rms_thres:
@@ -341,8 +345,9 @@ def frame_select(input_dataset, bpix_frac=1., allowed_bpix=0, overexp=False, tt_
             tt_rms_thres_hdr = -999. # to keep type consistency
         else:
             tt_rms_thres_hdr = tt_rms_thres
-        frame.ext_hdr['FRMSEL03'] = (tt_rms_thres_hdr, "tip rms (Z2VAR) threshold") # record selection criteria
-        frame.ext_hdr['FRMSEL04'] = (tt_rms_thres_hdr, "tilt rms (Z3VAR) threshold") # record selection criteria
+        if record_selection:
+            frame.ext_hdr['FRMSEL03'] = (tt_rms_thres_hdr, "tip rms (Z2VAR) threshold") # record selection criteria
+            frame.ext_hdr['FRMSEL04'] = (tt_rms_thres_hdr, "tilt rms (Z3VAR) threshold") # record selection criteria
         
         if tt_bias_thres is not None:
             if frame.ext_hdr['Z2RES'] > tt_bias_thres:
@@ -357,8 +362,9 @@ def frame_select(input_dataset, bpix_frac=1., allowed_bpix=0, overexp=False, tt_
             tt_bias_thres_hdr = -999. # to keep type consistency
         else:
             tt_bias_thres_hdr = tt_bias_thres
-        frame.ext_hdr['FRMSEL05'] = (tt_bias_thres_hdr, "tip bias (Z2RES) threshold") # record selection criteria
-        frame.ext_hdr['FRMSEL06'] = (tt_bias_thres_hdr, "tilt bias (Z3RES) threshold") # record selection criteria
+        if record_selection:
+            frame.ext_hdr['FRMSEL05'] = (tt_bias_thres_hdr, "tip bias (Z2RES) threshold") # record selection criteria
+            frame.ext_hdr['FRMSEL06'] = (tt_bias_thres_hdr, "tilt bias (Z3RES) threshold") # record selection criteria
                 
         # if rejected, mark as bad in the header
         if reject_flags[i] > 0:

--- a/corgidrp/recipe_templates/build_trad_dark_full_frame.json
+++ b/corgidrp/recipe_templates/build_trad_dark_full_frame.json
@@ -44,6 +44,9 @@
             "name" : "update_to_l2a"
         },
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "convert_to_electrons",
             "calibs" : {
                 "KGain" : "AUTOMATIC"

--- a/corgidrp/recipe_templates/build_trad_dark_full_frame.json
+++ b/corgidrp/recipe_templates/build_trad_dark_full_frame.json
@@ -44,7 +44,10 @@
             "name" : "update_to_l2a"
         },
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "convert_to_electrons",

--- a/corgidrp/recipe_templates/build_trad_dark_image.json
+++ b/corgidrp/recipe_templates/build_trad_dark_image.json
@@ -44,6 +44,9 @@
             "name" : "update_to_l2a"
         },
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "convert_to_electrons",
             "calibs" : {
                 "KGain" : "AUTOMATIC"

--- a/corgidrp/recipe_templates/build_trad_dark_image.json
+++ b/corgidrp/recipe_templates/build_trad_dark_image.json
@@ -44,7 +44,10 @@
             "name" : "update_to_l2a"
         },
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "convert_to_electrons",

--- a/corgidrp/recipe_templates/build_trad_dark_image_2.json
+++ b/corgidrp/recipe_templates/build_trad_dark_image_2.json
@@ -9,7 +9,10 @@
     "outputdir" : "",
     "steps" : [
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "build_trad_dark",

--- a/corgidrp/recipe_templates/build_trad_dark_image_2.json
+++ b/corgidrp/recipe_templates/build_trad_dark_image_2.json
@@ -9,6 +9,9 @@
     "outputdir" : "",
     "steps" : [
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "build_trad_dark",
             "calibs" : {
                 "DetectorParams" : "AUTOMATIC"

--- a/corgidrp/recipe_templates/l1_to_kgain.json
+++ b/corgidrp/recipe_templates/l1_to_kgain.json
@@ -55,11 +55,14 @@
 				"mode" : "full",
                 "dataset_copy" : false
             }
-	},
-	{
-	    "name" : "calibrate_kgain",
-	    "keywords" : {
-	        "detector_regions" : {
+		},
+		{
+		    "name" : "frame_select"
+		},
+		{
+		    "name" : "calibrate_kgain",
+		    "keywords" : {
+		        "detector_regions" : {
 		    "SCI" : {
 		        "frame_rows" : 1200,
 			"frame_cols" : 2200,

--- a/corgidrp/recipe_templates/l1_to_kgain.json
+++ b/corgidrp/recipe_templates/l1_to_kgain.json
@@ -57,7 +57,10 @@
             }
 		},
 		{
-		    "name" : "frame_select"
+		    "name" : "frame_select",
+		    "keywords" : {
+		        "record_selection" : false
+		    }
 		},
 		{
 		    "name" : "calibrate_kgain",

--- a/corgidrp/recipe_templates/l1_to_kgain_2.json
+++ b/corgidrp/recipe_templates/l1_to_kgain_2.json
@@ -49,11 +49,14 @@
 				"mode" : "full",
                 "dataset_copy" : false
             }
-	},
-	{
-	    "name" : "calibrate_kgain",
-	    "keywords" : {
-	        "detector_regions" : {
+		},
+		{
+		    "name" : "frame_select"
+		},
+		{
+		    "name" : "calibrate_kgain",
+		    "keywords" : {
+		        "detector_regions" : {
 		    "SCI" : {
 		        "frame_rows" : 1200,
 			"frame_cols" : 2200,

--- a/corgidrp/recipe_templates/l1_to_kgain_2.json
+++ b/corgidrp/recipe_templates/l1_to_kgain_2.json
@@ -51,7 +51,10 @@
             }
 		},
 		{
-		    "name" : "frame_select"
+		    "name" : "frame_select",
+		    "keywords" : {
+		        "record_selection" : false
+		    }
 		},
 		{
 		    "name" : "calibrate_kgain",

--- a/corgidrp/recipe_templates/l1_to_l2a_noisemap.json
+++ b/corgidrp/recipe_templates/l1_to_l2a_noisemap.json
@@ -44,7 +44,10 @@
             "name" : "save"
         },
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "convert_to_electrons",

--- a/corgidrp/recipe_templates/l1_to_l2a_noisemap.json
+++ b/corgidrp/recipe_templates/l1_to_l2a_noisemap.json
@@ -44,6 +44,9 @@
             "name" : "save"
         },
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "convert_to_electrons",
             "calibs" : {
                 "KGain" : "AUTOMATIC"

--- a/corgidrp/recipe_templates/l1_to_l2a_noisemap_2.json
+++ b/corgidrp/recipe_templates/l1_to_l2a_noisemap_2.json
@@ -9,7 +9,10 @@
     "outputdir" : "",
     "steps" : [
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "calibrate_darks",

--- a/corgidrp/recipe_templates/l1_to_l2a_noisemap_2.json
+++ b/corgidrp/recipe_templates/l1_to_l2a_noisemap_2.json
@@ -9,6 +9,9 @@
     "outputdir" : "",
     "steps" : [
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "calibrate_darks",
             "calibs" : {
                 "DetectorParams" : "AUTOMATIC"

--- a/corgidrp/recipe_templates/l1_to_l2a_nonlin.json
+++ b/corgidrp/recipe_templates/l1_to_l2a_nonlin.json
@@ -56,6 +56,9 @@
             }
         },
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "calibrate_nonlin",
               "keywords": {"n_cal":20}
         },

--- a/corgidrp/recipe_templates/l1_to_l2a_nonlin.json
+++ b/corgidrp/recipe_templates/l1_to_l2a_nonlin.json
@@ -56,7 +56,10 @@
             }
         },
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "calibrate_nonlin",

--- a/corgidrp/recipe_templates/l1_to_l2a_nonlin_3.json
+++ b/corgidrp/recipe_templates/l1_to_l2a_nonlin_3.json
@@ -9,8 +9,11 @@
     "outputdir" : "",
     "steps" : [
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "calibrate_nonlin",
-              "keywords": {"n_cal":20}
+            "keywords": {"n_cal":20}
         },
         {
             "name" : "save"

--- a/corgidrp/recipe_templates/l1_to_l2a_nonlin_3.json
+++ b/corgidrp/recipe_templates/l1_to_l2a_nonlin_3.json
@@ -9,7 +9,10 @@
     "outputdir" : "",
     "steps" : [
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "calibrate_nonlin",

--- a/corgidrp/recipe_templates/l2a_build_trad_dark_image.json
+++ b/corgidrp/recipe_templates/l2a_build_trad_dark_image.json
@@ -8,7 +8,10 @@
     "outputdir" : "",
     "steps" : [
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "convert_to_electrons",

--- a/corgidrp/recipe_templates/l2a_build_trad_dark_image.json
+++ b/corgidrp/recipe_templates/l2a_build_trad_dark_image.json
@@ -8,6 +8,9 @@
     "outputdir" : "",
     "steps" : [
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "convert_to_electrons",
             "calibs" : {
                 "KGain" : "AUTOMATIC"

--- a/corgidrp/recipe_templates/l2a_build_trad_dark_image_2.json
+++ b/corgidrp/recipe_templates/l2a_build_trad_dark_image_2.json
@@ -9,7 +9,10 @@
     "outputdir" : "",
     "steps" : [
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "build_trad_dark",

--- a/corgidrp/recipe_templates/l2a_build_trad_dark_image_2.json
+++ b/corgidrp/recipe_templates/l2a_build_trad_dark_image_2.json
@@ -9,6 +9,9 @@
     "outputdir" : "",
     "steps" : [
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "build_trad_dark",
             "calibs" : {
                 "DetectorParams" : "AUTOMATIC"

--- a/corgidrp/recipe_templates/l2a_to_l2a_noisemap.json
+++ b/corgidrp/recipe_templates/l2a_to_l2a_noisemap.json
@@ -8,7 +8,10 @@
     "outputdir" : "",
     "steps" : [
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "convert_to_electrons",

--- a/corgidrp/recipe_templates/l2a_to_l2a_noisemap.json
+++ b/corgidrp/recipe_templates/l2a_to_l2a_noisemap.json
@@ -8,6 +8,9 @@
     "outputdir" : "",
     "steps" : [
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "convert_to_electrons",
             "calibs" : {
                 "KGain" : "AUTOMATIC"

--- a/corgidrp/recipe_templates/l2a_to_l2a_noisemap_2.json
+++ b/corgidrp/recipe_templates/l2a_to_l2a_noisemap_2.json
@@ -9,7 +9,10 @@
     "outputdir" : "",
     "steps" : [
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "calibrate_darks",

--- a/corgidrp/recipe_templates/l2a_to_l2a_noisemap_2.json
+++ b/corgidrp/recipe_templates/l2a_to_l2a_noisemap_2.json
@@ -9,6 +9,9 @@
     "outputdir" : "",
     "steps" : [
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "calibrate_darks",
             "calibs" : {
                 "DetectorParams" : "AUTOMATIC"

--- a/corgidrp/recipe_templates/l2a_to_polflat.json
+++ b/corgidrp/recipe_templates/l2a_to_polflat.json
@@ -8,6 +8,9 @@
     "outputdir" : "",
     "steps" : [
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "convert_to_electrons",
             "calibs" : {
                 "KGain" : "AUTOMATIC"

--- a/corgidrp/recipe_templates/trap_pump_cal_2.json
+++ b/corgidrp/recipe_templates/trap_pump_cal_2.json
@@ -9,7 +9,10 @@
     "outputdir" : "",
     "steps" : [
         {
-            "name" : "frame_select"
+            "name" : "frame_select",
+            "keywords" : {
+                "record_selection" : false
+            }
         },
         {
             "name" : "calibrate_trap_pump"

--- a/corgidrp/recipe_templates/trap_pump_cal_2.json
+++ b/corgidrp/recipe_templates/trap_pump_cal_2.json
@@ -9,6 +9,9 @@
     "outputdir" : "",
     "steps" : [
         {
+            "name" : "frame_select"
+        },
+        {
             "name" : "calibrate_trap_pump"
         },
         {

--- a/tests/e2e_tests/l1_to_l2b_e2e.py
+++ b/tests/e2e_tests/l1_to_l2b_e2e.py
@@ -164,8 +164,9 @@ def test_l1_to_l2b(e2edata_path, e2eoutput_path):
 
     # define the raw science data to process
 
-    l1_data_filelist = [os.path.join(l1_datadir, os.listdir(l1_datadir)[i]) for i in [0,1]] #[os.path.join(l1_datadir, "{0}.fits".format(i)) for i in [90499, 90500]] # just grab the first two files
 
+    l1_filenames=sorted(os.listdir(l1_datadir))
+    l1_data_filelist=[os.path.join(l1_datadir,l1_filenames[i]) for i in [0,3]]
     # Update headers for TVAC files
     l1_data_filelist = check.fix_hdrs_for_tvac(l1_data_filelist, input_data_dir)
 

--- a/tests/test_cr_detection.py
+++ b/tests/test_cr_detection.py
@@ -884,6 +884,25 @@ def test_EM_gain_1():
 
     assert (np.array_equal(dataset_masked[0].dq, check_mask))
 
+def test_oversaturated_frames_are_marked_not_removed():
+    """
+    Tests that oversaturated frames are kept, marked bad, and skipped by CR detection.
+    """
+    #mock dataset, saturate a frame
+    dataset = mocks.create_cr_dataset(nonlin_fits_filepath, filedir=datadir, numfiles=2, numCRs=0)
+    dataset[0].data[:] = 1e9
+
+
+    output_dataset = detect_cosmic_rays(dataset, detector_params, k_gain, pct_oversat_lim=20)
+    # saturated frame should stay in the dataset, but be marked bad for later rejection.
+    assert len(output_dataset) == len(dataset)
+    assert output_dataset[0].ext_hdr['IS_BAD'] is True
+    assert output_dataset[1].ext_hdr.get('IS_BAD', False) is False
+
+    # since CR detection was skipped for this frame it should only have saturation DQ
+    assert np.all(output_dataset[0].dq > 0)
+    assert np.all(np.bitwise_and(output_dataset[0].dq, 128) == 0)
+
 if __name__ == "__main__":
     test_EM_gain_1()
     test_iit_vs_corgidrp()
@@ -906,3 +925,4 @@ if __name__ == "__main__":
     test_cosm_tail_2()
     test_cosm_tail_bleed_over()
     test_remove_sat_images()
+    test_oversaturated_frames_are_marked_not_removed()

--- a/tests/test_cr_detection.py
+++ b/tests/test_cr_detection.py
@@ -888,10 +888,10 @@ def test_oversaturated_frames_are_marked_not_removed():
     """
     Tests that oversaturated frames are kept, marked bad, and skipped by CR detection.
     """
-    #mock dataset, saturate a frame
+    # mock dataset, saturate enough of one frame to exceed pct_oversat_lim
     dataset = mocks.create_cr_dataset(nonlin_fits_filepath, filedir=datadir, numfiles=2, numCRs=0)
-    dataset[0].data[:] = 1e9
-
+    num_oversat_rows = int(np.ceil(dataset[0].data.shape[0] * 0.25))
+    dataset[0].data[:num_oversat_rows, :] = 1e9
 
     output_dataset = detect_cosmic_rays(dataset, detector_params, k_gain, pct_oversat_lim=20)
     # saturated frame should stay in the dataset, but be marked bad for later rejection.
@@ -899,8 +899,9 @@ def test_oversaturated_frames_are_marked_not_removed():
     assert output_dataset[0].ext_hdr['IS_BAD'] is True
     assert output_dataset[1].ext_hdr.get('IS_BAD', False) is False
 
-    # since CR detection was skipped for this frame it should only have saturation DQ
-    assert np.all(output_dataset[0].dq > 0)
+    # since CR detection was skipped for this frame it should only flag saturated pixels
+    assert np.any(output_dataset[0].dq > 0)
+    assert not np.all(output_dataset[0].dq > 0)
     assert np.all(np.bitwise_and(output_dataset[0].dq, 128) == 0)
 
 if __name__ == "__main__":

--- a/tests/test_frame_selection.py
+++ b/tests/test_frame_selection.py
@@ -184,10 +184,30 @@ def test_marking():
     # and last 2 are bad
     for frame in pruned_dataset[3:]:
         assert frame.ext_hdr['IS_BAD'] == True
+def test_preexisting_is_bad_rejected():
+    """
+    Tests that frames marked bad by an upstream step are rejected.
+    """
 
+    # simulate an upstream step marking the whole frame bad.
+    default_dataset = mocks.create_dark_calib_files(numfiles=5)
+    default_dataset[0].ext_hdr['IS_BAD'] = True
+
+    # by default, frame_select should drop frames already marked IS_BAD
+    pruned_dataset = frame_select(default_dataset)
+
+    assert len(pruned_dataset) == 4
+    assert all(frame.ext_hdr.get('IS_BAD', False) is False for frame in pruned_dataset)
+
+    # With discard_bad=False, the bad frame should be kept but still marked.
+    marked_dataset = frame_select(default_dataset, discard_bad=False)
+
+    assert len(marked_dataset) == 5
+    assert marked_dataset[0].ext_hdr['IS_BAD'] is True
 if __name__ == "__main__":
     test_no_selection()
     test_bpfrac_cutoff()
     test_overexp()
     test_tt_rms()
     test_remove_all()
+    test_preexisting_is_bad_rejected()


### PR DESCRIPTION
## Describe your changes

Updates cosmic ray detection so oversaturated frames are no longer silently removed during L1 -> L2a processing. Instead the oversaturated frames are kept, marked with IS_BAD=True and assigned saturation DQ across the frame. Frames are still skipped by the expensive cosmic ray detection step.

Updates frame_select() so frames already marked IS_BAD=True by an upstream step are rejected during L2a -> L2b processing.

Adds unit tests for both behaviors under test_cr_detection and test_frame_selection. 

Also makes the l1_to_l2b_e2e input selection deterministic by sorting the L1 files and avoiding known problematic inputs to address #895 

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)

Fixes #843 , #895

## Checklist before requesting a review
- [X ] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [ X] I have checked that I am merging into the right branch
- [ ] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [ X] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
