### PR TITLE
CFAMNAME 3F is the same as broadband name 3

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -1400,7 +1400,10 @@ class SpecFilterOffset(Image):
         self.dq = None
 
     def get_offsets(self, filter):
-        return self.offsets.get(filter.upper())
+        filt = filter.upper()
+        if filt.endswith("F"):
+            filt = filt[0]
+        return self.offsets.get(filt)
 
     def save(self, filedir=None, filename=None):
         """

--- a/corgidrp/spec.py
+++ b/corgidrp/spec.py
@@ -389,6 +389,8 @@ def compute_psf_centroid(dataset, template_dataset = None, initial_cent = None, 
     filters = []
     for idx, frame in enumerate(dataset):
         cfam = frame.ext_hdr['CFAMNAME']
+        if cfam.endswith("F"):
+            cfam = cfam[0]
         filters.append(cfam)
         psf_data = frame.data
         if xcent is None:
@@ -401,6 +403,8 @@ def compute_psf_centroid(dataset, template_dataset = None, initial_cent = None, 
             found_cfam = False
             for k, temp_frame in enumerate(template_dataset):
                 cfam_temp = temp_frame.ext_hdr['CFAMNAME']
+                if cfam_temp.endswith("F"):
+                    cfam_temp = cfam_temp[0]
                 if cfam == cfam_temp:
                     temp_psf_data = temp_frame.data
                     temp_x = xcent_temp[k]
@@ -474,6 +478,8 @@ def read_cent_wave(band, filter_file = None):
     data = ascii.read(filter_file, format = 'csv', data_start = 1)
     filter_names = data.columns[0]
     band = band.upper()
+    if band.endswith("F"):
+        band = band[0]
     if band not in filter_names:
         raise ValueError("{0} is not in table band names {1}".format(band, filter_names))
     ret_list = []
@@ -594,7 +600,7 @@ def calibrate_dispersion_model(centroid_psf, spec_filter_offset, band_center_fil
 
     #PRISM2 not yet available
     if prism == 'PRISM2':
-        subband_list = ['2A', '2B', '2C', '2F']
+        subband_list = ['2A', '2B', '2C']
         ref_cfam = '2'
         ref_wavlen = 660.
     else:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -280,12 +280,14 @@ def test_read_cent_wave():
     with pytest.raises(ValueError):
         cen_wave = steps.read_cent_wave('X')[0]
     
+    #3F should be the same as band 3, the broadband
+    f_list = steps.read_cent_wave('3F')
     cen_wave_list = steps.read_cent_wave('3')
     assert len(cen_wave_list) == 4
-    assert cen_wave_list[0] == 729.3
-    assert cen_wave_list[1] == 122.3
-    assert cen_wave_list[2] == 0.725909
-    assert cen_wave_list[3] == -0.09398
+    assert f_list[0] == cen_wave_list[0] == 729.3
+    assert f_list[1] == cen_wave_list[1] == 122.3
+    assert f_list[2] == cen_wave_list[2] == 0.725909
+    assert f_list[3] == cen_wave_list[3] == -0.09398
     
     
 def test_calibrate_dispersion_model():    
@@ -1438,6 +1440,8 @@ def test_filter_offset():
     assert offset.offsets["2A"][1] == 0.2
     assert offset.offsets["3"] == offset.default_offsets["3"]
     assert offset.get_offsets("2a") == offset.offsets["2A"]
+    #CFAMNAME 3F is the same as broadband 3
+    assert offset.get_offsets("3f") ==  offset.get_offsets("3")
     xoff, yoff = offset.get_offsets("2A")
     assert xoff == 0.5
     assert yoff == 0.2


### PR DESCRIPTION
## Describe your changes
The CFAMNAMEs 2F/3F mean the same as the broadband 2 or 3 we use in spec_filter_offset and the bandpass center files. 
Catch the F bands when calling the file content.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
#914

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
