### PR TITLE
642 update crpix when shifting image

### DIFF
--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -940,7 +940,7 @@ def northup(input_dataset,use_wcs=True,rot_center='im_center',new_center=None):
         #update CPIX/STARLOC
         crpix1_rot, crpix2_rot = corgidrp.spec.rotate_points((sci_hd['CRPIX1'], sci_hd['CRPIX2']), np.deg2rad(rotation_angle), (xcen, ycen))
         sci_hd['CRPIX1'] = crpix1_rot
-        sci_hd['CRPIX12'] = crpix2_rot
+        sci_hd['CRPIX2'] = crpix2_rot
         try:
             starlocx_rot, starlocy_rot = corgidrp.spec.rotate_points((sci_hd['STARLOCX'], sci_hd['STARLOCY']), np.deg2rad(rotation_angle), (xcen, ycen))
             sci_hd['STARLOCX'] = starlocx_rot

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -939,12 +939,14 @@ def northup(input_dataset,use_wcs=True,rot_center='im_center',new_center=None):
 
         #update CPIX/STARLOC
         crpix1_rot, crpix2_rot = corgidrp.spec.rotate_points((sci_hd['CRPIX1'], sci_hd['CRPIX2']), np.deg2rad(rotation_angle), (xcen, ycen))
-        starlocx_rot, starlocy_rot = corgidrp.spec.rotate_points((sci_hd['STARLOCX'], sci_hd['STARLOCY']), np.deg2rad(rotation_angle), (xcen, ycen))
         sci_hd['CRPIX1'] = crpix1_rot
         sci_hd['CRPIX12'] = crpix2_rot
-        sci_hd['STARLOCX'] = starlocx_rot
-        sci_hd['STARLOCY'] = starlocy_rot
-
+        try:
+            starlocx_rot, starlocy_rot = corgidrp.spec.rotate_points((sci_hd['STARLOCX'], sci_hd['STARLOCY']), np.deg2rad(rotation_angle), (xcen, ycen))
+            sci_hd['STARLOCX'] = starlocx_rot
+            sci_hd['STARLOCY'] = starlocy_rot
+        except KeyError:
+            warnings.warn('"STARLOCX/Y" missing from ext_hdr. Not possible to update header.')
         #############
         ## HDU ERR ##
         err_data = processed_data.err

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -938,15 +938,15 @@ def northup(input_dataset,use_wcs=True,rot_center='im_center',new_center=None):
         processed_data.ext_hdr = sci_hd
 
         #update CPIX/STARLOC
-        crpix1_rot, crpix2_rot = corgidrp.spec.rotate_points((sci_hd['CRPIX1'], sci_hd['CRPIX2']), np.deg2rad(rotation_angle), (xcen, ycen))
-        sci_hd['CRPIX1'] = crpix1_rot
-        sci_hd['CRPIX2'] = crpix2_rot
-        try:
+        if sci_hd['CRPIX1'] != xcen or sci_hd['CRPIX2'] != ycen:
+            crpix1_rot, crpix2_rot = corgidrp.spec.rotate_points((sci_hd['CRPIX1'], sci_hd['CRPIX2']), np.deg2rad(rotation_angle), (xcen, ycen))
+            sci_hd['CRPIX1'] = crpix1_rot
+            sci_hd['CRPIX2'] = crpix2_rot
+        if 'STARLOCX' in sci_hd and 'STARLOCY' in sci_hd:
             starlocx_rot, starlocy_rot = corgidrp.spec.rotate_points((sci_hd['STARLOCX'], sci_hd['STARLOCY']), np.deg2rad(rotation_angle), (xcen, ycen))
             sci_hd['STARLOCX'] = starlocx_rot
             sci_hd['STARLOCY'] = starlocy_rot
-        except KeyError:
-            warnings.warn('"STARLOCX/Y" missing from ext_hdr. Not possible to update header.')
+
         #############
         ## HDU ERR ##
         err_data = processed_data.err

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -937,6 +937,14 @@ def northup(input_dataset,use_wcs=True,rot_center='im_center',new_center=None):
         sci_hd['CD2_2'] = astr_hdr.wcs.cd[1, 1]
         processed_data.ext_hdr = sci_hd
 
+        #update CPIX/STARLOC
+        crpix1_rot, crpix2_rot = corgidrp.spec.rotate_points((sci_hd['CRPIX1'], sci_hd['CRPIX2']), np.deg2rad(rotation_angle), (xcen, ycen))
+        starlocx_rot, starlocy_rot = corgidrp.spec.rotate_points((sci_hd['STARLOCX'], sci_hd['STARLOCY']), np.deg2rad(rotation_angle), (xcen, ycen))
+        sci_hd['CRPIX1'] = crpix1_rot
+        sci_hd['CRPIX12'] = crpix2_rot
+        sci_hd['STARLOCX'] = starlocx_rot
+        sci_hd['STARLOCY'] = starlocy_rot
+
         #############
         ## HDU ERR ##
         err_data = processed_data.err

--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -1291,6 +1291,8 @@ def align_polarimetry_frames(input_dataset):
             frame.data[1] = shift( frame.data[1], shift_value)
             frame.ext_hdr['STARLOCX'] = starloc0[0]
             frame.ext_hdr['STARLOCY'] = starloc0[1]
+        frame.ext_hdr['CRPIX1'] = starloc0[0]
+        frame.ext_hdr['CRPIX2'] = starloc0[1]
 
     history_msgs = "Images centered on star location."
 

--- a/tests/test_northup_and_align.py
+++ b/tests/test_northup_and_align.py
@@ -179,7 +179,6 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
                 x_test = round(xcen + r * np.cos(np.deg2rad(angle_offset + theta)))
                 y_test = round(ycen + r * np.sin(np.deg2rad(angle_offset + theta)))
                 # check if rotation works properly
-                # check if rotation works properly
                 if rot_center == 'im_center':
                     assert (sci_input[y_value1, x_value1] != sci_derot[y_value1, x_value1])
                     assert (dq_input[y_value1, x_value1] != dq_derot[y_value1, x_value1])

--- a/tests/test_northup_and_align.py
+++ b/tests/test_northup_and_align.py
@@ -23,6 +23,25 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
 
     """
 
+    def rotate_point(point, center, ang):
+        """
+        Basic rotation algorithm to test behavior of the northup function when updating CRPIX/STARLOC
+        Args:
+            point: (x,y) coordinates of the point to be rotated
+            center: (x,y) coordinates of the center of the point to be rotated
+            ang: angle of rotation in radians, positive for counterclockwise rotation
+
+        Returns:
+            (x,y) coordinates of the rotated point
+        """
+        # ang in radians
+        x,y = point
+        xc,yc = center
+        x_shifted, y_shifted = x - xc, y - yc
+        xr = x_shifted * np.cos(ang) - y_shifted * np.sin(ang)
+        yr = x_shifted * np.sin(ang) + y_shifted * np.cos(ang)
+        return xr + xc, yr + yc
+
     # read mock file
     dirname = 'test_data/'
     filename = 'JWST_CALFIELD2020.csv'
@@ -223,6 +242,7 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
             dq_input = input_data.dq
             dq_derot = derot_data.dq
             sci_hd = input_data.ext_hdr
+            sci_hd_derot = derot_data.ext_hdr
             # rotate around the center of the image
             ylen, xlen = sci_input.shape
             xcen, ycen = xlen / 2, ylen / 2
@@ -261,6 +281,19 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
                 astr_hdr_new = WCS(derot_data.ext_hdr)
             north_pa = -np.rad2deg(np.arctan2(-astr_hdr_new.wcs.cd[0, 1], astr_hdr_new.wcs.cd[1, 1]))
             assert (math.isclose(north_pa, 0, abs_tol=1e-3))
+
+            #check if CRPIX and STARLOC are updated correctly
+            input_starlocx,input_starlocy = sci_hd['STARLOCX'], sci_hd['STARLOCY']
+            derot_starlocx,derot_starlocy = sci_hd_derot['STARLOCX'], sci_hd_derot['STARLOCY']
+            input_crpix1,input_crpix2 = sci_hd['CRPIX1'], sci_hd['CRPIX2']
+            derot_crpix1,derot_crpix2 = sci_hd_derot['CRPIX1'], sci_hd_derot['CRPIX2']
+            test_derot_starlocx,test_derot_starlocy = rotate_point([input_starlocx,input_starlocy], [input_crpix1,input_crpix2], np.deg2rad(angle_offset))
+            test_derot_crpix1,test_derot_crpix2 = rotate_point([input_crpix1,input_crpix2], [input_crpix1,input_crpix2],  np.deg2rad(angle_offset))
+            assert (math.isclose(derot_starlocx, test_derot_starlocx, rel_tol=0.01))
+            assert (math.isclose(derot_starlocy, test_derot_starlocy, rel_tol=0.01))
+            assert (math.isclose(test_derot_crpix1, derot_crpix1, rel_tol=0.01))
+            assert (math.isclose(test_derot_crpix2, derot_crpix2, rel_tol=0.01))
+
             # (optional) save comparison figure
             ang = ang_list[i]
             if save_comp_figure:

--- a/tests/test_northup_and_align.py
+++ b/tests/test_northup_and_align.py
@@ -183,6 +183,9 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
                     assert (sci_input[y_value1, x_value1] != sci_derot[y_value1, x_value1])
                     assert (dq_input[y_value1, x_value1] != dq_derot[y_value1, x_value1])
                 elif rot_center == 'starloc':
+                    #When rotating around STALOC, with STARLOC as reference and not im_center,
+                    #the value at STARLOC location should be the same before and after
+                    #(compared to the case 'im_center' when instead it need to be different).
                     assert (math.isclose(sci_input[y_value1, x_value1], sci_derot[y_value1, x_value1], rel_tol=0.01))
                     assert (dq_input[y_value1, x_value1] == dq_derot[y_value1, x_value1])
 

--- a/tests/test_northup_and_align.py
+++ b/tests/test_northup_and_align.py
@@ -21,11 +21,15 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
         save_comp_figure (optional): if you want to save a comparison figure of the original mock data and the derotated data
         pol_data (optional): if you want to test the northup function on pol data (Image shape (2,1024,1024), turn True
         rot_center: 'im_center', 'starloc', or manual coordinate (x,y) for nothup. 'im_center' uses the center of the image. 'starloc' refers to 'STARLOCX' and 'STARLOCY' in the header.
+        point: (x,y) coordinates of the point to be rotated in rotate_point function
+        center: (x,y) coordinates of the center of the point to be rotated in rotate_point function
+        ang: angle of rotation in radians, positive for counterclockwise rotation in rotate_point function
     """
 
     def rotate_point(point, center, ang):
         """
         Basic rotation algorithm to test behavior of the northup function when updating CRPIX/STARLOC
+
         Args:
             point: (x,y) coordinates of the point to be rotated
             center: (x,y) coordinates of the center of the point to be rotated

--- a/tests/test_northup_and_align.py
+++ b/tests/test_northup_and_align.py
@@ -152,9 +152,13 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
                 dq_input = input_data.dq[pol_idx]
                 dq_derot = derot_data.dq[pol_idx]
                 sci_hd = input_data.ext_hdr
+                sci_hd_derot = derot_data.ext_hdr
                 # rotate around the center of the image
                 ylen, xlen = sci_input.shape
-                xcen, ycen = xlen / 2, ylen / 2
+                if rot_center == 'im_center':
+                    xcen, ycen = xlen / 2, ylen / 2
+                elif rot_center == 'starloc':
+                    xcen, ycen = input_dataset[0].ext_hdr['STARLOCX'], input_dataset[0].ext_hdr['STARLOCY']
                 # check the angle offset
                 with warnings.catch_warnings():  # catch a warning related to a long fits header card - doesn't matter here
                     warnings.filterwarnings("ignore", category=fits.verify.VerifyWarning) 
@@ -171,8 +175,14 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
                 x_test = round(xcen + r * np.cos(np.deg2rad(angle_offset + theta)))
                 y_test = round(ycen + r * np.sin(np.deg2rad(angle_offset + theta)))
                 # check if rotation works properly
-                assert (sci_input[y_value1, x_value1] != sci_derot[y_value1, x_value1])
-                assert (dq_input[y_value1, x_value1] != dq_derot[y_value1, x_value1])
+                # check if rotation works properly
+                if rot_center == 'im_center':
+                    assert (sci_input[y_value1, x_value1] != sci_derot[y_value1, x_value1])
+                    assert (dq_input[y_value1, x_value1] != dq_derot[y_value1, x_value1])
+                elif rot_center == 'starloc':
+                    assert (math.isclose(sci_input[y_value1, x_value1], sci_derot[y_value1, x_value1], rel_tol=0.01))
+                    assert (dq_input[y_value1, x_value1] == dq_derot[y_value1, x_value1])
+
                 assert (math.isclose(sci_derot[y_test, x_test], sci_input[y_value1, x_value1], rel_tol=0.01))
                 assert (dq_input[y_value1, x_value1] == dq_derot[y_test, x_test])
                 # check if the derotated DQ frame has no non-integer values (except NaN)
@@ -185,6 +195,20 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
                     astr_hdr_new = WCS(derot_data.ext_hdr)
                 north_pa = -np.rad2deg(np.arctan2(-astr_hdr_new.wcs.cd[0, 1], astr_hdr_new.wcs.cd[1, 1]))
                 assert (math.isclose(north_pa, 0, abs_tol=1e-3))
+
+                # check if CRPIX and STARLOC are updated correctly
+                input_starlocx, input_starlocy = sci_hd['STARLOCX'], sci_hd['STARLOCY']
+                derot_starlocx, derot_starlocy = sci_hd_derot['STARLOCX'], sci_hd_derot['STARLOCY']
+                input_crpix1, input_crpix2 = sci_hd['CRPIX1'], sci_hd['CRPIX2']
+                derot_crpix1, derot_crpix2 = sci_hd_derot['CRPIX1'], sci_hd_derot['CRPIX2']
+                test_derot_starlocx, test_derot_starlocy = rotate_point([input_starlocx, input_starlocy], [xcen, ycen],
+                                                                        np.deg2rad(angle_offset))
+                test_derot_crpix1, test_derot_crpix2 = rotate_point([input_crpix1, input_crpix2], [xcen, ycen],
+                                                                    np.deg2rad(angle_offset))
+                assert (math.isclose(derot_starlocx, test_derot_starlocx, rel_tol=0.01))
+                assert (math.isclose(derot_starlocy, test_derot_starlocy, rel_tol=0.01))
+                assert (math.isclose(test_derot_crpix1, derot_crpix1, rel_tol=0.01))
+                assert (math.isclose(test_derot_crpix2, derot_crpix2, rel_tol=0.01))
 
                 # save comparison figure only for first pol mode
                 if pol_idx == 0:

--- a/tests/test_northup_and_align.py
+++ b/tests/test_northup_and_align.py
@@ -80,8 +80,8 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
             mock_dataset_3d[0].ext_hdr = updated_dataset_temp[0].ext_hdr.copy()
             # inject fake sources for test - for both pol modes
             mock_dataset_3d[0].data[:, 340:360, 340:360] = 5
-            mock_dataset_3d[0].ext_hdr['X_1VAL'] = 350
-            mock_dataset_3d[0].ext_hdr['Y_1VAL'] = 350
+            mock_dataset_3d[0].ext_hdr['STARLOCX'] = 350
+            mock_dataset_3d[0].ext_hdr['STARLOCY'] = 350
             mock_dataset_3d[0].dq[:, 340:360, 340:360] = 1
         else:
             mock_dataset = mock_dataset_ori.copy()
@@ -91,8 +91,8 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
             updated_dataset = create_wcs(mock_dataset, astrom_cal)
             # inject fake sources for test
             updated_dataset[0].data[340:360, 340:360] = 5
-            updated_dataset[0].ext_hdr['X_1VAL'] = 350
-            updated_dataset[0].ext_hdr['Y_1VAL'] = 350
+            updated_dataset[0].ext_hdr['STARLOCX'] = 350
+            updated_dataset[0].ext_hdr['STARLOCY'] = 350
             updated_dataset[0].dq[340:360, 340:360] = 1
         if pol_data == True:
             # update datalist for pol data - expected to be 4d array (shape 6, 2, 1024, 1024 for test)
@@ -142,8 +142,8 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
                     astr_hdr = WCS(sci_hd)
                 angle_offset = np.rad2deg(-np.arctan2(-astr_hdr.wcs.cd[0, 1], astr_hdr.wcs.cd[1, 1]))
                 # the location for test
-                x_value1 = input_dataset[0].ext_hdr['X_1VAL']
-                y_value1 = input_dataset[0].ext_hdr['Y_1VAL']
+                x_value1 = input_dataset[0].ext_hdr['STARLOCX']
+                y_value1 = input_dataset[0].ext_hdr['STARLOCY']
                 r = np.sqrt((x_value1 - xcen) ** 2 + (y_value1 - ycen) ** 2)
                 theta = np.rad2deg(np.arctan2(y_value1 - ycen, x_value1 - xcen))
                 if theta < 0:
@@ -232,8 +232,8 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
                 astr_hdr = WCS(sci_hd)
             angle_offset = np.rad2deg(-np.arctan2(-astr_hdr.wcs.cd[0, 1], astr_hdr.wcs.cd[1, 1]))
             # the location for test
-            x_value1 = input_dataset[0].ext_hdr['X_1VAL']
-            y_value1 = input_dataset[0].ext_hdr['Y_1VAL']
+            x_value1 = input_dataset[0].ext_hdr['STARLOCX']
+            y_value1 = input_dataset[0].ext_hdr['STARLOCY']
             r = np.sqrt((x_value1 - xcen) ** 2 + (y_value1 - ycen) ** 2)
             theta = np.rad2deg(np.arctan2(y_value1 - ycen, x_value1 - xcen))
             if theta < 0:

--- a/tests/test_northup_and_align.py
+++ b/tests/test_northup_and_align.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 
-def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figure=False,pol_data = False,test_offset=False):
+def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figure=False,pol_data = False,rot_center='im_center'):
     """
     unit test of the northup function
 
@@ -20,7 +20,7 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
         save_derot_dataset (optional): if you want to save the derotated files at the input directory, turn True
         save_comp_figure (optional): if you want to save a comparison figure of the original mock data and the derotated data
         pol_data (optional): if you want to test the northup function on pol data (Image shape (2,1024,1024), turn True
-
+        rot_center: 'im_center', 'starloc', or manual coordinate (x,y) for nothup. 'im_center' uses the center of the image. 'starloc' refers to 'STARLOCX' and 'STARLOCY' in the header.
     """
 
     def rotate_point(point, center, ang):
@@ -122,7 +122,7 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
 
     # run northup function
     input_dataset = data.Dataset(updated_datalist)
-    derot_dataset = northup(input_dataset)
+    derot_dataset = northup(input_dataset,rot_center=rot_center)
 
     if save_mock_dataset == True:
         outdir = os.path.join('./', dirname)
@@ -245,7 +245,10 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
             sci_hd_derot = derot_data.ext_hdr
             # rotate around the center of the image
             ylen, xlen = sci_input.shape
-            xcen, ycen = xlen / 2, ylen / 2
+            if rot_center == 'im_center':
+                xcen, ycen = xlen / 2, ylen / 2
+            elif rot_center == 'starloc':
+                xcen, ycen = input_dataset[0].ext_hdr['STARLOCX'], input_dataset[0].ext_hdr['STARLOCY']
             # check the angle offset
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=fits.verify.VerifyWarning) 
@@ -264,8 +267,12 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
             y_test = round(ycen + r * np.sin(np.deg2rad(angle_offset + theta)))
 
             # check if rotation works properly
-            assert (sci_input[y_value1, x_value1] != sci_derot[y_value1, x_value1])
-            assert (dq_input[y_value1, x_value1] != dq_derot[y_value1, x_value1])
+            if rot_center == 'im_center':
+                assert (sci_input[y_value1, x_value1] != sci_derot[y_value1, x_value1])
+                assert (dq_input[y_value1, x_value1] != dq_derot[y_value1, x_value1])
+            elif rot_center == 'starloc':
+                assert (math.isclose(sci_input[y_value1, x_value1], sci_derot[y_value1, x_value1], rel_tol=0.01))
+                assert (dq_input[y_value1, x_value1] == dq_derot[y_value1, x_value1])
 
             assert (math.isclose(sci_derot[y_test, x_test], sci_input[y_value1, x_value1], rel_tol=0.01))
             assert (dq_input[y_value1, x_value1] == dq_derot[y_test, x_test])
@@ -287,8 +294,8 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
             derot_starlocx,derot_starlocy = sci_hd_derot['STARLOCX'], sci_hd_derot['STARLOCY']
             input_crpix1,input_crpix2 = sci_hd['CRPIX1'], sci_hd['CRPIX2']
             derot_crpix1,derot_crpix2 = sci_hd_derot['CRPIX1'], sci_hd_derot['CRPIX2']
-            test_derot_starlocx,test_derot_starlocy = rotate_point([input_starlocx,input_starlocy], [input_crpix1,input_crpix2], np.deg2rad(angle_offset))
-            test_derot_crpix1,test_derot_crpix2 = rotate_point([input_crpix1,input_crpix2], [input_crpix1,input_crpix2],  np.deg2rad(angle_offset))
+            test_derot_starlocx,test_derot_starlocy = rotate_point([input_starlocx,input_starlocy], [xcen, ycen], np.deg2rad(angle_offset))
+            test_derot_crpix1,test_derot_crpix2 = rotate_point([input_crpix1,input_crpix2], [xcen, ycen],  np.deg2rad(angle_offset))
             assert (math.isclose(derot_starlocx, test_derot_starlocx, rel_tol=0.01))
             assert (math.isclose(derot_starlocy, test_derot_starlocy, rel_tol=0.01))
             assert (math.isclose(test_derot_crpix1, derot_crpix1, rel_tol=0.01))
@@ -348,8 +355,17 @@ def test_northup(save_mock_dataset=False,save_derot_dataset=False,save_comp_figu
 
     return
 
+def test_northup_starloc():
+    test_northup(rot_center='starloc')
+    return
+
 def test_northup_pol():
     test_northup(pol_data=True)
+    return
+
+def test_northup_pol_starloc():
+    test_northup(pol_data=True, rot_center='starloc')
+    return
 
 def test_wcs_and_offset(save_mock_dataset=False):
    """

--- a/tests/test_polarimetry.py
+++ b/tests/test_polarimetry.py
@@ -21,6 +21,7 @@ import corgidrp.l4_to_tda as l4_to_tda
 from corgidrp.pol import calc_stokes_unocculted
 import corgidrp.corethroughput as corethroughput
 import corgidrp.check as check
+from pyklip.instruments.utils.wcsgen import generate_wcs
 
 from corgidrp import star_center
 
@@ -445,18 +446,26 @@ def test_align_frames():
         left_image_value=1, right_image_value=2,
         star_center=injected_position_pol0, amplitude_multiplier=0)
     image_WP1_nfov_sp_nooffset.ext_hdr['SCTSRT'] = sctsrt_no_offset
+    wcs_header = generate_wcs(0, [image_WP1_nfov_sp_nooffset.ext_hdr['NAXIS1']//2, image_WP1_nfov_sp_nooffset.ext_hdr['NAXIS1']//2], platescale=0.0218).to_header()
+    image_WP1_nfov_sp_nooffset.ext_hdr.extend(wcs_header, update=True)
 
     image_WP1_nfov_sp = mocks.create_mock_l2b_polarimetric_image_with_satellite_spots(
         dpamname='POL0', observing_mode='NFOV',
         left_image_value=1, right_image_value=2,
         star_center=injected_position_pol0, amplitude_multiplier=1000)
     image_WP1_nfov_sp.ext_hdr['SCTSRT'] = sctsrt_pos_offset
+    wcs_header = generate_wcs(0, [image_WP1_nfov_sp.ext_hdr['NAXIS1']//2, image_WP1_nfov_sp.ext_hdr['NAXIS1']//2], platescale=0.0218).to_header()
+    image_WP1_nfov_sp.ext_hdr.extend(wcs_header, update=True)
 
     image_WP1_nfov_sp_neg = copy.deepcopy(image_WP1_nfov_sp)
     image_WP1_nfov_sp_neg.ext_hdr['SCTSRT'] = sctsrt_neg_offset
+    wcs_header = generate_wcs(0, [image_WP1_nfov_sp_neg.ext_hdr['NAXIS1'] // 2, image_WP1_nfov_sp_neg.ext_hdr['NAXIS1'] // 2], platescale=0.0218).to_header()
+    image_WP1_nfov_sp.ext_hdr.extend(wcs_header, update=True)
 
     image_WP1_nfov = mocks.create_mock_l2b_polarimetric_image(dpamname='POL0',
      observing_mode='NFOV', left_image_value=1, right_image_value=2)
+    wcs_header = generate_wcs(0, [image_WP1_nfov.ext_hdr['NAXIS1'] // 2, image_WP1_nfov.ext_hdr['NAXIS1'] // 2], platescale=0.0218).to_header()
+    image_WP1_nfov.ext_hdr.extend(wcs_header, update=True)
 
     # POL45 satspot frames
     image_WP2_nfov_sp_nooffset = mocks.create_mock_l2b_polarimetric_image_with_satellite_spots(
@@ -464,18 +473,26 @@ def test_align_frames():
         left_image_value=1, right_image_value=2,
         star_center=injected_position_pol45, amplitude_multiplier=0)
     image_WP2_nfov_sp_nooffset.ext_hdr['SCTSRT'] = sctsrt_no_offset
+    wcs_header = generate_wcs(0, [image_WP2_nfov_sp_nooffset.ext_hdr['NAXIS1']//2, image_WP2_nfov_sp_nooffset.ext_hdr['NAXIS1']//2], platescale=0.0218).to_header()
+    image_WP2_nfov_sp_nooffset.ext_hdr.extend(wcs_header, update=True)
 
     image_WP2_nfov_sp = mocks.create_mock_l2b_polarimetric_image_with_satellite_spots(
         dpamname='POL45', observing_mode='NFOV',
         left_image_value=1, right_image_value=2,
         star_center=injected_position_pol45, amplitude_multiplier=1000)
     image_WP2_nfov_sp.ext_hdr['SCTSRT'] = sctsrt_pos_offset
+    wcs_header = generate_wcs(0, [image_WP2_nfov_sp.ext_hdr['NAXIS1']//2, image_WP2_nfov_sp.ext_hdr['NAXIS1']//2], platescale=0.0218).to_header()
+    image_WP2_nfov_sp.ext_hdr.extend(wcs_header, update=True)
 
     image_WP2_nfov_sp_neg = copy.deepcopy(image_WP2_nfov_sp)
     image_WP2_nfov_sp_neg.ext_hdr['SCTSRT'] = sctsrt_neg_offset
+    wcs_header = generate_wcs(0, [image_WP2_nfov_sp_neg.ext_hdr['NAXIS1'] // 2, image_WP2_nfov_sp_neg.ext_hdr['NAXIS1'] // 2], platescale=0.0218).to_header()
+    image_WP2_nfov_sp_neg.ext_hdr.extend(wcs_header, update=True)
 
     image_WP2_nfov = mocks.create_mock_l2b_polarimetric_image(dpamname='POL45',
      observing_mode='NFOV', left_image_value=1, right_image_value=2)
+    wcs_header = generate_wcs(0, [image_WP2_nfov.ext_hdr['NAXIS1'] // 2, image_WP2_nfov.ext_hdr['NAXIS1'] // 2], platescale=0.0218).to_header()
+    image_WP2_nfov.ext_hdr.extend(wcs_header, update=True)
 
     # Input order: no-offset, +offset, -offset satspot frames then science frame per POL.
     # After split and find_star (drop_satspots_frames=False), frame layout:
@@ -513,6 +530,24 @@ def test_align_frames():
     assert np.isclose(starloc_pol0[1] - starloc_pol45[1], injected_y_slice_0 - injected_y_slice_45, atol=0.1)
     # Align the pol 45 data with the pol 0 data
     output_dataset_aligned = l3_to_l4.align_polarimetry_frames(dataset_with_center)
+
+    # check that CRPIX==STARLOC after alignment
+    assert output_dataset_aligned.frames[0].ext_hdr['STARLOCX'] == output_dataset_aligned.frames[0].ext_hdr['CRPIX1']
+    assert output_dataset_aligned.frames[0].ext_hdr['STARLOCY'] == output_dataset_aligned.frames[0].ext_hdr['CRPIX2']
+    assert output_dataset_aligned.frames[1].ext_hdr['STARLOCX'] == output_dataset_aligned.frames[1].ext_hdr['CRPIX1']
+    assert output_dataset_aligned.frames[1].ext_hdr['STARLOCY'] == output_dataset_aligned.frames[1].ext_hdr['CRPIX2']
+    assert output_dataset_aligned.frames[2].ext_hdr['STARLOCX'] == output_dataset_aligned.frames[2].ext_hdr['CRPIX1']
+    assert output_dataset_aligned.frames[2].ext_hdr['STARLOCY'] == output_dataset_aligned.frames[2].ext_hdr['CRPIX2']
+    assert output_dataset_aligned.frames[3].ext_hdr['STARLOCX'] == output_dataset_aligned.frames[3].ext_hdr['CRPIX1']
+    assert output_dataset_aligned.frames[3].ext_hdr['STARLOCY'] == output_dataset_aligned.frames[3].ext_hdr['CRPIX2']
+    assert output_dataset_aligned.frames[4].ext_hdr['STARLOCX'] == output_dataset_aligned.frames[4].ext_hdr['CRPIX1']
+    assert output_dataset_aligned.frames[4].ext_hdr['STARLOCY'] == output_dataset_aligned.frames[4].ext_hdr['CRPIX2']
+    assert output_dataset_aligned.frames[5].ext_hdr['STARLOCX'] == output_dataset_aligned.frames[5].ext_hdr['CRPIX1']
+    assert output_dataset_aligned.frames[5].ext_hdr['STARLOCY'] == output_dataset_aligned.frames[5].ext_hdr['CRPIX2']
+    assert output_dataset_aligned.frames[6].ext_hdr['STARLOCX'] == output_dataset_aligned.frames[6].ext_hdr['CRPIX1']
+    assert output_dataset_aligned.frames[6].ext_hdr['STARLOCY'] == output_dataset_aligned.frames[6].ext_hdr['CRPIX2']
+    assert output_dataset_aligned.frames[7].ext_hdr['STARLOCX'] == output_dataset_aligned.frames[7].ext_hdr['CRPIX1']
+    assert output_dataset_aligned.frames[7].ext_hdr['STARLOCY'] == output_dataset_aligned.frames[7].ext_hdr['CRPIX2']
 
     # Check that the pol 45 frames are now aligned on the pol 0 frames.
     # Use the +offset satspot frame (frames[5]) which has satellite spots for centroiding.


### PR DESCRIPTION
## Describe your changes
Testing CRPIX and STARLOC get updated correctly when `derotate_arr` is invoked:
- Already done by default in align_2d_frames. No changes needed
- updated northup to correctly rotate CRPIX/STARLOC as needed
- updated align_polarimetry_frames to overwrite CRPIX with STARLOC values  

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
