### PR TITLE
Fix northangle convention in l2b_to_l3

### DIFF
--- a/corgidrp/l2b_to_l3.py
+++ b/corgidrp/l2b_to_l3.py
@@ -39,7 +39,8 @@ def create_wcs(input_dataset, astrom_calibration, offset=None):
         target_ra, target_dec = image.pri_hdr['RA'], image.pri_hdr['DEC']
         corrected_ra, corrected_dec = target_ra - ra_offset, target_dec - dec_offset
         pa_aper_deg = image.pri_hdr['PA_APER']
-        roll_offset_deg = pa_aper_deg - pa_aper_deg_astrom  #Define a roll offset using the pa_aper for the image frame and astrom cal frame
+        #roll_offset_deg = pa_aper_deg - pa_aper_deg_astrom  #Define a roll offset using the pa_aper for the image frame and astrom cal frame
+        roll_offset_deg = - (pa_aper_deg - pa_aper_deg_astrom)  #Define a roll offset using the pa_aper for the image frame and astrom cal frame
 
         #TO DO: double check this. northangle may be defined as the full rotation angle, 
         # not north offset, in which case, adding the two below would be adding two absolute rotation angles from north
@@ -68,6 +69,7 @@ def create_wcs(input_dataset, astrom_calibration, offset=None):
 
         wcs_info['PLTSCALE'] = platescale  ## [mas] / pixel
         wcs_info['NORTHANG'] = northangle - roll_offset_deg  ## deg
+        #wcs_info['NORTHANG'] = northangle + roll_offset_deg  ## deg
 
         # update the image header with wcs information
         for key, value in wcs_info.items():

--- a/corgidrp/l2b_to_l3.py
+++ b/corgidrp/l2b_to_l3.py
@@ -40,11 +40,12 @@ def create_wcs(input_dataset, astrom_calibration, offset=None):
         corrected_ra, corrected_dec = target_ra - ra_offset, target_dec - dec_offset
         pa_aper_deg = image.pri_hdr['PA_APER']
         #roll_offset_deg = pa_aper_deg - pa_aper_deg_astrom  #Define a roll offset using the pa_aper for the image frame and astrom cal frame
-        roll_offset_deg = - (pa_aper_deg - pa_aper_deg_astrom)  #Define a roll offset using the pa_aper for the image frame and astrom cal frame
+        roll_offset_deg = pa_aper_deg - pa_aper_deg_astrom  #Define a roll offset using the pa_aper for the image frame and astrom cal frame
 
         #TO DO: double check this. northangle may be defined as the full rotation angle, 
         # not north offset, in which case, adding the two below would be adding two absolute rotation angles from north
-        vert_ang = np.radians(northangle - roll_offset_deg)
+        #vert_ang = np.radians(northangle - roll_offset_deg)
+        vert_ang = np.radians(northangle + roll_offset_deg)
         pc = np.array([[-np.cos(vert_ang), np.sin(vert_ang)], [np.sin(vert_ang), np.cos(vert_ang)]])
         cdmatrix = pc * (platescale * 0.001) / 3600.
 
@@ -68,8 +69,8 @@ def create_wcs(input_dataset, astrom_calibration, offset=None):
         wcs_info['CRVAL2'] = float(corrected_dec)
 
         wcs_info['PLTSCALE'] = platescale  ## [mas] / pixel
-        wcs_info['NORTHANG'] = northangle - roll_offset_deg  ## deg
-        #wcs_info['NORTHANG'] = northangle + roll_offset_deg  ## deg
+        #wcs_info['NORTHANG'] = northangle - roll_offset_deg  ## deg
+        wcs_info['NORTHANG'] = northangle + roll_offset_deg  ## deg
 
         # update the image header with wcs information
         for key, value in wcs_info.items():

--- a/corgidrp/l4_to_tda.py
+++ b/corgidrp/l4_to_tda.py
@@ -678,7 +678,7 @@ def compute_flux_ratio_noise(input_dataset, NDcalibration, unocculted_star_datas
         # by amplitude and FWHM used for KLIP throughput calculation.  Amplitude found by doing Gaussian fit.
         star_fr = unocculted_star_dataset.frames[i]
         if unocculted_star_loc is None:
-            peak_row, peak_col = np.where(star_fr.data == star_fr.data.max())
+            peak_row, peak_col = np.where(star_fr.data == np.nanmax(star_fr.data))
             pos = (peak_row[0], peak_col[0])
         else:
             pos = (unocculted_star_loc[0][i], unocculted_star_loc[1][i])

--- a/tests/e2e_tests/l2b_to_l4_e2e.py
+++ b/tests/e2e_tests/l2b_to_l4_e2e.py
@@ -159,7 +159,7 @@ def test_l2b_to_l3(e2edata_path, e2eoutput_path):
         # new_image.ext_hdr.set('PSF_CEN_Y', new_psf_center_y)
         new_image.pri_hdr.set('FRAMET', str(frame_exptime_sec[ibatch]))
         new_image.ext_hdr.set('EXPTIME', frame_exptime_sec[ibatch])
-        new_image.pri_hdr.set('PA_APER',rotation[ibatch])
+        new_image.pri_hdr.set('PA_APER',-rotation[ibatch])
         new_image.ext_hdr.set('FSMPRFL','NFOV')
         new_image.ext_hdr.set('LSAMNAME','NFOV')
         new_image.ext_hdr.set('CFAMNAME','1F')


### PR DESCRIPTION
## Describe your changes
After conversations with Neil and Alex, we determined that the L3 keyword NORTHANG should be defined as northangle + roll_offset_deg where roll_offset_deg = pa_aper_deg - pa_aper_astrom. The vertang is also fixed for consistency which determines the CD matrix.

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)


## Reference any relevant issues (don't forget the #)
#865 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
