### PR TITLE
Allow default recipes to be overriden by user recipes

### DIFF
--- a/corgidrp/__init__.py
+++ b/corgidrp/__init__.py
@@ -31,6 +31,11 @@ def create_config_dir():
     if not os.path.exists(default_cal_dir):
         os.mkdir(default_cal_dir)
 
+    # make user templates folder if it doesn't exist
+    user_templates_dir = os.path.join(config_folder, "user_templates")
+    if not os.path.exists(user_templates_dir):
+        os.mkdir(user_templates_dir)
+
     # write config if it doesn't exist
     config_filepath = os.path.join(config_folder, "corgidrp.cfg")
     if not os.path.exists(config_filepath):
@@ -38,6 +43,7 @@ def create_config_dir():
         config["PATH"] = {}
         config["PATH"]["caldb"] = os.path.join(config_folder, "corgidrp_caldb.csv") # location to store caldb
         config["PATH"]["default_calibs"] = default_cal_dir
+        config["PATH"]["user_templates"] = user_templates_dir
         config["DATA"] = {}
         config["DATA"]["track_individual_errors"] = "False"
         config["DATA"]["chunk_size"] = "200"
@@ -46,6 +52,7 @@ def create_config_dir():
         config["WALKER"] = {}
         config["WALKER"]["skip_missing_cal_steps"] = "False"
         config["WALKER"]["jit_calib_id"] = "False"
+        config["WALKER"]["enforce_template_structure"] = "False"
         # overwrite with old settings if needed
         if oldconfig is not None:
             config["PATH"]["caldb"] = oldconfig["PATH"]["caldb"]
@@ -61,7 +68,7 @@ def update_pipeline_settings():
     Loads configuration file to update pipeline settings
     """
     global config_filepath
-    global caldb_filepath, default_cal_dir, track_individual_errors, chunk_size, image_dtype, dq_dtype, skip_missing_cal_steps, jit_calib_id
+    global caldb_filepath, default_cal_dir, user_templates_dir, track_individual_errors, chunk_size, image_dtype, dq_dtype, skip_missing_cal_steps, jit_calib_id, enforce_template_structure
     # borrowed from the kpicdrp caldb
     # load in default caldbs based on configuration file
     config_filepath = os.path.join(pathlib.Path.home(), ".corgidrp", "corgidrp.cfg")
@@ -75,12 +82,14 @@ def update_pipeline_settings():
     ## pipeline settings
     caldb_filepath = config.get("PATH", "caldb", fallback=None) # path to calibration db
     default_cal_dir = config.get("PATH", "default_calibs", fallback=None) # path to default calibrations directory
+    user_templates_dir = config.get("PATH", "user_templates", fallback=os.path.join(pathlib.Path.home(), ".corgidrp", "user_templates")) # path to user templates directory
     track_individual_errors = _bool_map[config.get("DATA", "track_individual_errors", fallback='false').lower()] # save each individual error component separately?
     chunk_size = int(float(config.get("DATA", "chunk_size", fallback="200"))) # number of frames to process at a time if pocessing in chunks for RAM conservation
     image_dtype = image_datatype_map[config.get("DATA", "image_dtype", fallback="32")] # bit size for image and error data
     dq_dtype = dq_datatype_map[config.get("DATA", "dq_dtype", fallback="16")] # bit size for DQ data
     skip_missing_cal_steps = _bool_map[config.get("WALKER", "skip_missing_cal_steps", fallback='false').lower()] # skip steps, instead of crashing, when suitable calibration file cannot be found 
     jit_calib_id = _bool_map[config.get("WALKER", "jit_calib_id", fallback='false').lower()] # AUTOMATIC calibration files identified right before the execution of a step, rather than when recipe is first generated
+    enforce_template_structure = _bool_map[config.get("WALKER", "enforce_template_structure", fallback='false').lower()] # require user templates to have same step structure as default templates
 
 
 create_config_dir()

--- a/corgidrp/ops.py
+++ b/corgidrp/ops.py
@@ -1,18 +1,22 @@
 import corgidrp
 import corgidrp.caldb as caldb
 import corgidrp.walker as walker
-import argparse
 
 
-def step_1_initialize():
+def step_1_initialize(user_templates_dir=None):
     """
     Initialize corgidrp and it's caldb again
+
+    Args:
+        user_templates_dir (str): the path to the user recipe template directory (optional)
 
     Returns: 
         caldb.CalDB: an instance of an initialized caldb object
     """
     corgidrp.create_config_dir()
     corgidrp.update_pipeline_settings()
+    if user_templates_dir is not None:
+        corgidrp.user_templates_dir = user_templates_dir
     corgidrp.enforce_template_structure = True
     caldb.initialize()
     this_caldb = caldb.CalDB()

--- a/corgidrp/ops.py
+++ b/corgidrp/ops.py
@@ -13,6 +13,7 @@ def step_1_initialize():
     """
     corgidrp.create_config_dir()
     corgidrp.update_pipeline_settings()
+    corgidrp.enforce_template_structure = True
     caldb.initialize()
     this_caldb = caldb.CalDB()
     return this_caldb

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -128,14 +128,14 @@ def _load_recipe_template(recipe_filename, user_templates_dir=None):
         f"({user_templates_dir}) or default templates ({recipe_dir})"
     )
 
-def _validate_template_structure(user_template, default_template, recipe_filename):
+def _validate_template_structure(user_template, default_template_path, recipe_filename):
     """
     Validate that user template has same step names/order as default.
     Raises ValueError if mismatch found when enforce_template_structure=True.
 
     Args:
         user_template (dict): User-provided template
-        default_template (dict): Default template from repo
+        default_template_path (str): Path of the default template from repo
         recipe_filename (str): Template name for error messages
 
     Raises:
@@ -144,23 +144,33 @@ def _validate_template_structure(user_template, default_template, recipe_filenam
     if not corgidrp.enforce_template_structure:
         return  # Validation disabled
 
-    # Extract step names from both templates
-    user_steps = [step['name'] for step in user_template.get('steps', [])]
-    default_steps = [step['name'] for step in default_template.get('steps', [])]
-
-    # Check if step names and order match
-    if user_steps != default_steps:
-        error_msg = (
-            f"User template '{recipe_filename}' has different step structure than default.\n"
-            f"User template steps: {user_steps}\n"
-            f"Default template steps: {default_steps}\n"
-            f"When enforce_template_structure=True, user templates must have the same "
-            f"step names in the same order as default templates. You can modify step "
-            f"keywords and calibs, but not add/remove/reorder steps.\n"
-            f"To allow different step structures, set enforce_template_structure=False "
-            f"in your config file or via environment variable."
+    if not os.path.exists(default_template_path):
+        raise FileNotFoundError(
+            f"Cannot validate user template '{recipe_filename}': "
+            f"no corresponding default template found at {default_template_path}. "
+            f"User templates must have same filename as a default template when "
+            f"enforce_template_structure=True."
         )
-        raise ValueError(error_msg)
+    with open(default_template_path, 'r') as f:
+        default_template = json.load(f)
+
+        # Extract step names from both templates
+        user_steps = [step['name'] for step in user_template.get('steps', [])]
+        default_steps = [step['name'] for step in default_template.get('steps', [])]
+    
+        # Check if step names and order match
+        if user_steps != default_steps:
+            error_msg = (
+                f"User template '{recipe_filename}' has different step structure than default.\n"
+                f"User template steps: {user_steps}\n"
+                f"Default template steps: {default_steps}\n"
+                f"When enforce_template_structure=True, user templates must have the same "
+                f"step names in the same order as default templates. You can modify step "
+                f"keywords and calibs, but not add/remove/reorder steps.\n"
+                f"To allow different step structures, set enforce_template_structure=False "
+                f"in your config file or via environment variable."
+            )
+            raise ValueError(error_msg)
 
 def walk_corgidrp(filelist, CPGS_XML_filepath, outputdir, template=None):
     """
@@ -185,20 +195,10 @@ def walk_corgidrp(filelist, CPGS_XML_filepath, outputdir, template=None):
         if os.path.sep not in template:
             # this is just a template name. check user_templates first, then defaults
             template, recipe_filepath, is_user_template = _load_recipe_template(template)
-
             # Validate user template structure if enabled
             if is_user_template and corgidrp.enforce_template_structure:
                 default_template_path = os.path.join(recipe_dir, os.path.basename(recipe_filepath))
-                if not os.path.exists(default_template_path):
-                    raise FileNotFoundError(
-                        f"Cannot validate user template '{os.path.basename(recipe_filepath)}': "
-                        f"no corresponding default template found at {default_template_path}. "
-                        f"User templates must have same filename as a default template when "
-                        f"enforce_template_structure=True."
-                    )
-                with open(default_template_path, 'r') as f:
-                    default_template = json.load(f)
-                _validate_template_structure(template, default_template, os.path.basename(recipe_filepath))
+                _validate_template_structure(template, default_template_path, os.path.basename(recipe_filepath))
         else:
             recipe_filepath = template
             template = json.load(open(recipe_filepath, 'r'))
@@ -318,17 +318,7 @@ def autogen_recipe(filelist, outputdir, template=None):
                 if is_user_template and corgidrp.enforce_template_structure:
                     # Load default template for comparison
                     default_template_path = os.path.join(recipe_dir, recipe_filename)
-                    if not os.path.exists(default_template_path):
-                        raise FileNotFoundError(
-                            f"Cannot validate user template '{recipe_filename}': "
-                            f"no corresponding default template found at {default_template_path}. "
-                            f"User templates must have same filename as a default template when "
-                            f"enforce_template_structure=True."
-                        )
-                    with open(default_template_path, 'r') as f:
-                        default_template = json.load(f)
-                    _validate_template_structure(template, default_template, recipe_filename)
-
+                    _validate_template_structure(template, default_template_path, recipe_filename)
                 recipe_template_list.append(template)
                 template_sources.append((recipe_filename, template_path, is_user_template))
             recipe_template_list_list.append(recipe_template_list)
@@ -343,16 +333,7 @@ def autogen_recipe(filelist, outputdir, template=None):
             if is_user_template and corgidrp.enforce_template_structure:
                 # Load default template for comparison
                 default_template_path = os.path.join(recipe_dir, template)
-                if not os.path.exists(default_template_path):
-                    raise FileNotFoundError(
-                        f"Cannot validate user template '{template}': "
-                        f"no corresponding default template found at {default_template_path}. "
-                        f"User templates must have same filename as a default template when "
-                        f"enforce_template_structure=True."
-                    )
-                with open(default_template_path, 'r') as f:
-                    default_template = json.load(f)
-                _validate_template_structure(template_dict, default_template, template)
+                _validate_template_structure(template_dict, default_template_path, template)
 
             recipe_template_list = [template_dict]
             template_sources = [(template, template_path, is_user_template)]

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -180,10 +180,25 @@ def walk_corgidrp(filelist, CPGS_XML_filepath, outputdir, template=None):
     Returns:
         json or list: the JSON recipe (or list of JSON recipes) that was used for processing
     """
+    recipe_filepath = None
     if isinstance(template, str):
         if os.path.sep not in template:
             # this is just a template name. check user_templates first, then defaults
             template, recipe_filepath, is_user_template = _load_recipe_template(template)
+
+            # Validate user template structure if enabled
+            if is_user_template and corgidrp.enforce_template_structure:
+                default_template_path = os.path.join(recipe_dir, os.path.basename(recipe_filepath))
+                if not os.path.exists(default_template_path):
+                    raise FileNotFoundError(
+                        f"Cannot validate user template '{os.path.basename(recipe_filepath)}': "
+                        f"no corresponding default template found at {default_template_path}. "
+                        f"User templates must have same filename as a default template when "
+                        f"enforce_template_structure=True."
+                    )
+                with open(default_template_path, 'r') as f:
+                    default_template = json.load(f)
+                _validate_template_structure(template, default_template, os.path.basename(recipe_filepath))
         else:
             recipe_filepath = template
             template = json.load(open(recipe_filepath, 'r'))
@@ -191,6 +206,17 @@ def walk_corgidrp(filelist, CPGS_XML_filepath, outputdir, template=None):
 
     # generate recipe
     recipes = autogen_recipe(filelist, outputdir, template=template)
+
+    if recipe_filepath is not None:
+        if isinstance(recipes, list):
+            for r in recipes:
+                if isinstance(r, list):
+                    for sub_r in r:
+                        sub_r["RECIPE_SRC"] = recipe_filepath
+                else:
+                    r["RECIPE_SRC"] = recipe_filepath
+        else:
+            recipes["RECIPE_SRC"] = recipe_filepath
 
 
     if not isinstance(recipes, list):

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -94,6 +94,74 @@ all_steps = {
 
 recipe_dir = os.path.join(os.path.dirname(__file__), "recipe_templates")
 
+def _load_recipe_template(recipe_filename, user_templates_dir=None):
+    """
+    Load recipe template, checking user_templates first, then defaults.
+
+    Args:
+        recipe_filename (str): Template filename (e.g., "l1_to_l2a_basic.json")
+        user_templates_dir (str): Path to user templates directory. If None, uses corgidrp.user_templates_dir
+
+    Returns:
+        tuple: (template dict, source path, is_user_template bool)
+    """
+    if user_templates_dir is None:
+        user_templates_dir = corgidrp.user_templates_dir
+
+    # First check user templates directory
+    user_template_path = os.path.join(user_templates_dir, recipe_filename)
+    if os.path.exists(user_template_path):
+        with open(user_template_path, 'r') as f:
+            template = json.load(f)
+        return template, user_template_path, True
+
+    # Fall back to default template
+    default_template_path = os.path.join(recipe_dir, recipe_filename)
+    if os.path.exists(default_template_path):
+        with open(default_template_path, 'r') as f:
+            template = json.load(f)
+        return template, default_template_path, False
+
+    # Template not found in either location
+    raise FileNotFoundError(
+        f"Recipe template '{recipe_filename}' not found in user templates "
+        f"({user_templates_dir}) or default templates ({recipe_dir})"
+    )
+
+def _validate_template_structure(user_template, default_template, recipe_filename):
+    """
+    Validate that user template has same step names/order as default.
+    Raises ValueError if mismatch found when enforce_template_structure=True.
+
+    Args:
+        user_template (dict): User-provided template
+        default_template (dict): Default template from repo
+        recipe_filename (str): Template name for error messages
+
+    Raises:
+        ValueError: If template structures don't match and enforcement is enabled
+    """
+    if not corgidrp.enforce_template_structure:
+        return  # Validation disabled
+
+    # Extract step names from both templates
+    user_steps = [step['name'] for step in user_template.get('steps', [])]
+    default_steps = [step['name'] for step in default_template.get('steps', [])]
+
+    # Check if step names and order match
+    if user_steps != default_steps:
+        error_msg = (
+            f"User template '{recipe_filename}' has different step structure than default.\n"
+            f"User template steps: {user_steps}\n"
+            f"Default template steps: {default_steps}\n"
+            f"When enforce_template_structure=True, user templates must have the same "
+            f"step names in the same order as default templates. You can modify step "
+            f"keywords and calibs, but not add/remove/reorder steps.\n"
+            f"To allow different step structures, set enforce_template_structure=False "
+            f"in your config file or via environment variable."
+        )
+        raise ValueError(error_msg)
+
 def walk_corgidrp(filelist, CPGS_XML_filepath, outputdir, template=None):
     """
     Automatically create a recipe and process the input filelist.
@@ -114,12 +182,12 @@ def walk_corgidrp(filelist, CPGS_XML_filepath, outputdir, template=None):
     """
     if isinstance(template, str):
         if os.path.sep not in template:
-            # this is just a template name in the recipe_templates folder
-            recipe_filepath = os.path.join(recipe_dir, template)
+            # this is just a template name. check user_templates first, then defaults
+            template, recipe_filepath, is_user_template = _load_recipe_template(template)
         else:
             recipe_filepath = template
-
-        template = json.load(open(recipe_filepath, 'r'))
+            template = json.load(open(recipe_filepath, 'r'))
+            is_user_template = False  # explicit paths are not user templates
 
     # generate recipe
     recipes = autogen_recipe(filelist, outputdir, template=template)
@@ -214,27 +282,76 @@ def autogen_recipe(filelist, outputdir, template=None):
                 raise TypeError("Each element of recipe_filename_list should be a list, but got {0}".format(type(l)))
         
         recipe_template_list_list = []
+        template_sources = []  # Track sources for logging
         for recipe_filename_list in recipe_filename_list_list:
             recipe_template_list = []
             for recipe_filename in recipe_filename_list:
-                # load the template recipe
-                recipe_filepath = os.path.join(recipe_dir, recipe_filename)
-                template = json.load(open(recipe_filepath, 'r'))
+                # load the template recipe (check user_templates first, then defaults)
+                template, template_path, is_user_template = _load_recipe_template(recipe_filename)
+                # If user template loaded and validation enabled, validate structure
+                if is_user_template and corgidrp.enforce_template_structure:
+                    # Load default template for comparison
+                    default_template_path = os.path.join(recipe_dir, recipe_filename)
+                    if not os.path.exists(default_template_path):
+                        raise FileNotFoundError(
+                            f"Cannot validate user template '{recipe_filename}': "
+                            f"no corresponding default template found at {default_template_path}. "
+                            f"User templates must have same filename as a default template when "
+                            f"enforce_template_structure=True."
+                        )
+                    with open(default_template_path, 'r') as f:
+                        default_template = json.load(f)
+                    _validate_template_structure(template, default_template, recipe_filename)
+
                 recipe_template_list.append(template)
+                template_sources.append((recipe_filename, template_path, is_user_template))
             recipe_template_list_list.append(recipe_template_list)
     else:
         # user passed in a single template
-        recipe_template_list = [template]
+        # Check if it's a string (filename) or already loaded dict
+        if isinstance(template, str):
+            # It's a filename, load it (check user_templates first)
+            template_dict, template_path, is_user_template = _load_recipe_template(template)
+
+            # If user template loaded and validation enabled, validate structure
+            if is_user_template and corgidrp.enforce_template_structure:
+                # Load default template for comparison
+                default_template_path = os.path.join(recipe_dir, template)
+                if not os.path.exists(default_template_path):
+                    raise FileNotFoundError(
+                        f"Cannot validate user template '{template}': "
+                        f"no corresponding default template found at {default_template_path}. "
+                        f"User templates must have same filename as a default template when "
+                        f"enforce_template_structure=True."
+                    )
+                with open(default_template_path, 'r') as f:
+                    default_template = json.load(f)
+                _validate_template_structure(template_dict, default_template, template)
+
+            recipe_template_list = [template_dict]
+            template_sources = [(template, template_path, is_user_template)]
+        else:
+            # It's already a loaded dict
+            recipe_template_list = [template]
+            template_sources = []
+
         recipe_template_list_list = [recipe_template_list]
         chained = False
 
     recipe_list_list = []
+    source_idx = 0  # Index into template_sources list
     for recipe_template_list in recipe_template_list_list:
         recipe_list = []
         for i, template in enumerate(recipe_template_list):
             # create the personalized recipe
             recipe = template.copy()
             recipe["template"] = False
+
+            # Add template source for traceability
+            if source_idx < len(template_sources):
+                _, template_path, is_user_template = template_sources[source_idx]
+                recipe["RECIPE_SRC"] = template_path
+                source_idx += 1
 
             # for chained recipes, don't put the input in yet since we don't know it
             if i > 0 and chained:
@@ -287,19 +404,30 @@ def autogen_recipe(filelist, outputdir, template=None):
 
     # Print the recipes
     print("\n" + "="*60)
+    user_templates_dir = corgidrp.user_templates_dir
     if len(recipe_list_list) > 1:
         print("Generated Recipe Chains:")
         for chain_idx, recipe_list in enumerate(recipe_list_list):
             print(f"\nChain {chain_idx + 1}:")
             for recipe_idx, recipe in enumerate(recipe_list):
-                print(f"\n  Recipe {recipe_idx + 1}: {recipe['name']}" )
+                print(f"\n  Recipe {recipe_idx + 1}: {recipe['name']}")
+                if 'RECIPE_SRC' in recipe:
+                    src_label = " (user template)" if user_templates_dir in recipe['RECIPE_SRC'] else " (default template)"
+                    print(f"    Source: {recipe['RECIPE_SRC']}{src_label}")
     else:
         if len(recipe_list_list[0]) > 1:
             print("Generated Recipe Chain:")
             for recipe_idx, recipe in enumerate(recipe_list_list[0]):
                 print(f"\nRecipe {recipe_idx + 1}: {recipe['name']}")
+                if 'RECIPE_SRC' in recipe:
+                    src_label = " (user template)" if user_templates_dir in recipe['RECIPE_SRC'] else " (default template)"
+                    print(f"  Source: {recipe['RECIPE_SRC']}{src_label}")
         else:
             print(f"Generated Recipe: {recipe_list_list[0][0]['name']}")
+            if 'RECIPE_SRC' in recipe_list_list[0][0]:
+                recipe = recipe_list_list[0][0]
+                src_label = " (user template)" if user_templates_dir in recipe['RECIPE_SRC'] else " (default template)"
+                print(f"  Source: {recipe['RECIPE_SRC']}{src_label}")
     print("="*60 + "\n")
 
     # if list of chains, return that.  If single list, return that.  If single

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,4 +1,6 @@
 import os
+import json
+import tempfile
 import numpy as np
 import corgidrp
 import astropy.time as time
@@ -8,8 +10,7 @@ import corgidrp.caldb as caldb
 import corgidrp.mocks as mocks
 
 
-
-def test_ops_produces_expected_file(): 
+def _setup_ops_test_data():
     """
     Tests that the ops module produces the expected files. Based on test_autoreducingin test_walker.py
     """
@@ -62,6 +63,15 @@ def test_ops_produces_expected_file():
     mycaldb = caldb.CalDB()
     mycaldb.create_entry(new_nonlinearity)
 
+    return filelist, main_cal_dir, outputdir, new_nonlinearity
+
+
+def test_ops_produces_expected_file():
+    """
+    Tests that the ops module produces the expected files. Based on test_autoreducing in test_walker.py
+    """
+    filelist, main_cal_dir, outputdir, new_nonlinearity = _setup_ops_test_data()
+
     CPGS_XML_filepath = "" # not yet implemented
 
     #######################
@@ -82,7 +92,64 @@ def test_ops_produces_expected_file():
         assert os.path.exists(output_file), f"Expected output file {output_file} does not exist."
 
     ### Clean up
+    mycaldb = caldb.CalDB()
     mycaldb.remove_entry(new_nonlinearity)
+
+
+def test_ops_with_user_templates_dir():
+    """
+    Tests that the ops module works with a custom user_templates_dir argument.
+    Same as test_ops_produces_expected_file but with user template override.
+    """
+    import copy
+    import corgidrp.walker as walker
+
+    filelist, main_cal_dir, outputdir, new_nonlinearity = _setup_ops_test_data()
+
+    CPGS_XML_filepath = ""
+
+    with tempfile.TemporaryDirectory() as user_templates_dir:
+        # Load default template and modify one keyword
+        default_template_path = os.path.join(
+            os.path.dirname(walker.__file__), "recipe_templates", "l1_to_l2a_basic.json"
+        )
+        with open(default_template_path, 'r') as f:
+            user_template = json.load(f)
+
+        # Override sat_thresh in detect_cosmic_rays step
+        detect_cr_step = next(s for s in user_template['steps'] if s['name'] == 'detect_cosmic_rays')
+        detect_cr_step['keywords']['sat_thresh'] = 0.7
+
+        # Write modified template to user templates dir
+        template_path = os.path.join(user_templates_dir, "l1_to_l2a_basic.json")
+        with open(template_path, 'w') as f:
+            json.dump(user_template, f)
+
+        # Run the full ops chain with custom user_templates_dir
+        this_caldb = ops.step_1_initialize(user_templates_dir=user_templates_dir)
+        ops.step_2_load_cal(this_caldb, main_cal_dir)
+        ops.step_3_process_data(filelist, CPGS_XML_filepath, outputdir, template="l1_to_l2a_basic.json")
+
+        # Check output files exist
+        output_filelist = [os.path.join(outputdir, os.path.basename(filename).replace("_l1_", "_l2a")) for filename in filelist]
+        for output_file in output_filelist:
+            assert os.path.exists(output_file), f"Expected output file {output_file} does not exist."
+
+        # Verify RECIPE_SRC traces to user template directory
+        output_dataset = data.Dataset(output_filelist)
+        for frame in output_dataset:
+            recipe = json.loads(frame.ext_hdr["RECIPE"])
+            assert "RECIPE_SRC" in recipe
+            assert user_templates_dir in recipe["RECIPE_SRC"]
+            # Verify user-modified keyword propagated
+            recipe_cr_step = next(s for s in recipe['steps'] if s['name'] == 'detect_cosmic_rays')
+            assert recipe_cr_step['keywords']['sat_thresh'] == 0.7
+
+    ### Clean up
+    mycaldb = caldb.CalDB()
+    mycaldb.remove_entry(new_nonlinearity)
+
 
 if __name__ == "__main__":#
     test_ops_produces_expected_file()
+    test_ops_with_user_templates_dir()

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -926,16 +926,20 @@ def test_validation_mode_matching_structure():
             {'name': 'step3'}
         ]
     }
-
-    # Save original setting
-    original_enforce = corgidrp.enforce_template_structure
-
-    try:
-        corgidrp.enforce_template_structure = True
-        # Should not raise
-        walker._validate_template_structure(user_template, default_template, "test.json")
-    finally:
-        corgidrp.enforce_template_structure = original_enforce
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Write template to temp directory
+        default_template_path = os.path.join(tmpdir, "test_template.json")
+        with open(default_template_path, 'w') as f:
+            json.dump(default_template, f)
+        # Save original setting
+        original_enforce = corgidrp.enforce_template_structure
+    
+        try:
+            corgidrp.enforce_template_structure = True
+            # Should not raise
+            walker._validate_template_structure(user_template, default_template_path, "test.json")
+        finally:
+            corgidrp.enforce_template_structure = original_enforce
 
 def test_validation_mode_mismatched_structure_raises():
     """
@@ -958,20 +962,24 @@ def test_validation_mode_mismatched_structure_raises():
             {'name': 'step3'}
         ]
     }
-
-    # Save original setting
-    original_enforce = corgidrp.enforce_template_structure
-
-    try:
-        corgidrp.enforce_template_structure = True
-        with pytest.raises(ValueError) as exc_info:
-            walker._validate_template_structure(user_template, default_template, "test.json")
-
-        error_msg = str(exc_info.value)
-        assert "different step structure" in error_msg.lower()
-        assert "test.json" in error_msg
-    finally:
-        corgidrp.enforce_template_structure = original_enforce
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Write template to temp directory
+        default_template_path = os.path.join(tmpdir, "test_template.json")
+        with open(default_template_path, 'w') as f:
+            json.dump(default_template, f)
+        # Save original setting
+        original_enforce = corgidrp.enforce_template_structure
+    
+        try:
+            corgidrp.enforce_template_structure = True
+            with pytest.raises(ValueError) as exc_info:
+                walker._validate_template_structure(user_template, default_template_path, "test.json")
+    
+            error_msg = str(exc_info.value)
+            assert "different step structure" in error_msg.lower()
+            assert "test.json" in error_msg
+        finally:
+            corgidrp.enforce_template_structure = original_enforce
 
 def test_validation_mode_disabled_allows_mismatch():
     """
@@ -993,16 +1001,21 @@ def test_validation_mode_disabled_allows_mismatch():
             {'name': 'step3'}
         ]
     }
-
-    # Save original setting
-    original_enforce = corgidrp.enforce_template_structure
-
-    try:
-        corgidrp.enforce_template_structure = False
-        # Should not raise even with mismatched structure
-        walker._validate_template_structure(user_template, default_template, "test.json")
-    finally:
-        corgidrp.enforce_template_structure = original_enforce
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Write template to temp directory
+        default_template_path = os.path.join(tmpdir, "test_template.json")
+        with open(default_template_path, 'w') as f:
+            json.dump(default_template, f)
+            
+        # Save original setting
+        original_enforce = corgidrp.enforce_template_structure
+    
+        try:
+            corgidrp.enforce_template_structure = False
+            # Should not raise even with mismatched structure
+            walker._validate_template_structure(user_template, default_template_path, "test.json")
+        finally:
+            corgidrp.enforce_template_structure = original_enforce
 
 def test_user_template_in_autogen_recipe():
     """

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -5,6 +5,8 @@ import os
 import glob
 import json
 import warnings
+import shutil
+import pytest
 import numpy as np
 import astropy.time as time
 import astropy.io.fits as fits
@@ -827,6 +829,265 @@ def test_guess_template_l1_pol_setup():
         assert recipe_filename == expected_chain
         assert chained == True
 
+def test_load_user_template_when_exists():
+    """
+    Test that user template is loaded when it exists in user_templates directory
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a user template programmatically
+        user_template = {
+            "name": "l1_to_l2a_basic",
+            "template": True,
+            "steps": [
+                {"name": "prescan_biassub"},
+                {"name": "discard_setup_frames"},
+                {
+                    "name": "detect_cosmic_rays",
+                    "keywords": {"test_user_param": 42}
+                },
+                {"name": "correct_nonlinearity"},
+                {"name": "update_to_l2a"},
+                {"name": "save"}
+            ]
+        }
+
+        # Write template to temp directory
+        template_path = os.path.join(tmpdir, "l1_to_l2a_basic.json")
+        with open(template_path, 'w') as f:
+            json.dump(user_template, f)
+
+        # Load template
+        template, loaded_path, is_user_template = walker._load_recipe_template(
+            "l1_to_l2a_basic.json", user_templates_dir=tmpdir
+        )
+
+        # Verify user template was loaded
+        assert is_user_template == True
+        assert tmpdir in loaded_path
+        assert template['name'] == "l1_to_l2a_basic"
+
+        # Verify user-specific parameter is present
+        detect_cr_step = next(s for s in template['steps'] if s['name'] == 'detect_cosmic_rays')
+        assert 'test_user_param' in detect_cr_step['keywords']
+        assert detect_cr_step['keywords']['test_user_param'] == 42
+
+def test_fallback_to_default_when_user_missing():
+    """
+    Test that default template is loaded when user template doesn't exist
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Empty temp directory - template doesn't exist here
+        # Load template that doesn't exist in tmpdir (should fall back to default)
+        template, template_path, is_user_template = walker._load_recipe_template(
+            "l2a_to_l2b.json", user_templates_dir=tmpdir
+        )
+
+        # Verify default template was loaded
+        assert is_user_template == False
+        assert "recipe_templates" in template_path
+        assert template['name'] == "l2a_to_l2b"
+
+def test_template_not_found_raises_error():
+    """
+    Test that FileNotFoundError is raised when template not in user or default
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(FileNotFoundError) as exc_info:
+            walker._load_recipe_template("nonexistent_template.json", user_templates_dir=tmpdir)
+
+        assert "not found" in str(exc_info.value).lower()
+        assert "nonexistent_template.json" in str(exc_info.value)
+
+def test_validation_mode_matching_structure():
+    """
+    Test that validation passes when user template has matching structure
+    """
+    # Create mock templates with matching structure
+    user_template = {
+        'name': 'test',
+        'steps': [
+            {'name': 'step1'},
+            {'name': 'step2'},
+            {'name': 'step3'}
+        ]
+    }
+    default_template = {
+        'name': 'test',
+        'steps': [
+            {'name': 'step1'},
+            {'name': 'step2'},
+            {'name': 'step3'}
+        ]
+    }
+
+    # Save original setting
+    original_enforce = corgidrp.enforce_template_structure
+
+    try:
+        corgidrp.enforce_template_structure = True
+        # Should not raise
+        walker._validate_template_structure(user_template, default_template, "test.json")
+    finally:
+        corgidrp.enforce_template_structure = original_enforce
+
+def test_validation_mode_mismatched_structure_raises():
+    """
+    Test that validation raises ValueError when structures don't match
+    """
+    # Create mock templates with different structures
+    user_template = {
+        'name': 'test',
+        'steps': [
+            {'name': 'step1'},
+            {'name': 'step3'},  # Missing step2
+            {'name': 'step2'}   # Wrong order
+        ]
+    }
+    default_template = {
+        'name': 'test',
+        'steps': [
+            {'name': 'step1'},
+            {'name': 'step2'},
+            {'name': 'step3'}
+        ]
+    }
+
+    # Save original setting
+    original_enforce = corgidrp.enforce_template_structure
+
+    try:
+        corgidrp.enforce_template_structure = True
+        with pytest.raises(ValueError) as exc_info:
+            walker._validate_template_structure(user_template, default_template, "test.json")
+
+        error_msg = str(exc_info.value)
+        assert "different step structure" in error_msg.lower()
+        assert "test.json" in error_msg
+    finally:
+        corgidrp.enforce_template_structure = original_enforce
+
+def test_validation_mode_disabled_allows_mismatch():
+    """
+    Test that validation is skipped when enforce_template_structure=False
+    """
+    # Create mock templates with different structures
+    user_template = {
+        'name': 'test',
+        'steps': [
+            {'name': 'step1'},
+            {'name': 'step3'}
+        ]
+    }
+    default_template = {
+        'name': 'test',
+        'steps': [
+            {'name': 'step1'},
+            {'name': 'step2'},
+            {'name': 'step3'}
+        ]
+    }
+
+    # Save original setting
+    original_enforce = corgidrp.enforce_template_structure
+
+    try:
+        corgidrp.enforce_template_structure = False
+        # Should not raise even with mismatched structure
+        walker._validate_template_structure(user_template, default_template, "test.json")
+    finally:
+        corgidrp.enforce_template_structure = original_enforce
+
+def test_user_template_in_autogen_recipe():
+    """
+    Test that autogen_recipe correctly uses user templates and adds RECIPE_SRC
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a user template programmatically
+        user_template = {
+            "name": "l1_to_l2a_basic",
+            "template": True,
+            "process_in_chunks": True,
+            "drpconfig": {"track_individual_errors": False},
+            "inputs": [],
+            "outputdir": "",
+            "steps": [
+                {
+                    "name": "prescan_biassub",
+                    "calibs": {"DetectorNoiseMaps": "AUTOMATIC,OPTIONAL"},
+                    "keywords": {"return_full_frame": False, "dataset_copy": False}
+                },
+                {
+                    "name": "discard_setup_frames",
+                    "keywords": {"keywords_to_check": ["ISACQ"]}
+                },
+                {
+                    "name": "detect_cosmic_rays",
+                    "calibs": {"DetectorParams": "AUTOMATIC", "KGain": "AUTOMATIC, OPTIONAL"},
+                    "keywords": {"dataset_copy": False, "test_user_param": 42}
+                },
+                {
+                    "name": "correct_nonlinearity",
+                    "calibs": {"NonLinearityCalibration": "AUTOMATIC"}
+                },
+                {"name": "update_to_l2a"},
+                {"name": "save"}
+            ]
+        }
+
+        # Write template to temp directory
+        template_path = os.path.join(tmpdir, "l1_to_l2a_basic.json")
+        with open(template_path, 'w') as f:
+            json.dump(user_template, f)
+
+        # Create simulated data
+        datadir = os.path.join(os.path.dirname(__file__), "simdata")
+        if not os.path.exists(datadir):
+            os.mkdir(datadir)
+
+        l1_dataset = mocks.create_prescan_files(filedir=datadir, arrtype="SCI", numfiles=2)
+        for frame in l1_dataset:
+            frame.pri_hdr['VISTYPE'] = 'CGIVST_OBS_CORIMG'
+            frame.ext_hdr['DATALVL'] = 'L1'
+        l1_dataset.save(filedir=datadir)
+        filelist = [frame.filepath for frame in l1_dataset]
+
+        # Save original setting
+        original_user_templates = corgidrp.user_templates_dir
+
+        try:
+            # Temporarily set user_templates_dir
+            corgidrp.user_templates_dir = tmpdir
+
+            # Create output directory
+            outputdir = os.path.join(os.path.dirname(__file__), "test_user_template_output")
+            if not os.path.exists(outputdir):
+                os.mkdir(outputdir)
+
+            # Generate recipe
+            recipe = walker.autogen_recipe(filelist, outputdir, template="l1_to_l2a_basic.json")
+
+            # Verify RECIPE_SRC is present and points to user template
+            assert 'RECIPE_SRC' in recipe
+            assert tmpdir in recipe['RECIPE_SRC']
+
+            # Verify user-specific parameter is in the recipe
+            detect_cr_step = next(s for s in recipe['steps'] if s['name'] == 'detect_cosmic_rays')
+            assert 'test_user_param' in detect_cr_step['keywords']
+
+            # Clean up
+            shutil.rmtree(outputdir, ignore_errors=True)
+
+        finally:
+            corgidrp.user_templates_dir = original_user_templates
+
 if __name__ == "__main__":#
     test_autoreducing()
     test_auto_template_identification()
@@ -842,4 +1103,11 @@ if __name__ == "__main__":#
     test_guess_template_l1_absflux_pol()
     test_guess_template_l1_absflux_non_pol()
     test_guess_template_l1_pol_setup()
+    test_load_user_template_when_exists()
+    test_fallback_to_default_when_user_missing()
+    test_template_not_found_raises_error()
+    test_validation_mode_matching_structure()
+    test_validation_mode_mismatched_structure_raises()
+    test_validation_mode_disabled_allows_mismatch()
+    test_user_template_in_autogen_recipe()
 

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -4,6 +4,7 @@ Test the walker infrastructure to read and execute recipes
 import os
 import glob
 import json
+import tempfile
 import warnings
 import shutil
 import pytest
@@ -1088,6 +1089,77 @@ def test_user_template_in_autogen_recipe():
         finally:
             corgidrp.user_templates_dir = original_user_templates
 
+def test_user_template_wrong_name_loads_without_validation():
+    """
+    User template with non-existent default name loads fine when validation disabled.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        wrong_template = {
+            "name": "nonexistent_recipe",
+            "template": True,
+            "inputs": [],
+            "outputdir": "",
+            "drpconfig": {},
+            "steps": [{"name": "save"}]
+        }
+        template_path = os.path.join(tmpdir, "nonexistent_recipe.json")
+        with open(template_path, 'w') as f:
+            json.dump(wrong_template, f)
+
+        template, loaded_path, is_user = walker._load_recipe_template(
+            "nonexistent_recipe.json", user_templates_dir=tmpdir
+        )
+        assert is_user == True
+        assert template['name'] == "nonexistent_recipe"
+
+
+def test_user_template_wrong_name_rejected_with_validation():
+    """
+    User template with non-existent default name raises FileNotFoundError
+    when enforce_template_structure=True.
+    """
+    original_enforce = corgidrp.enforce_template_structure
+    original_user_templates = corgidrp.user_templates_dir
+
+    try:
+        corgidrp.enforce_template_structure = True
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wrong_template = {
+                "name": "nonexistent_recipe",
+                "template": True,
+                "inputs": [],
+                "outputdir": "",
+                "drpconfig": {},
+                "steps": [{"name": "save"}]
+            }
+            template_path = os.path.join(tmpdir, "nonexistent_recipe.json")
+            with open(template_path, 'w') as f:
+                json.dump(wrong_template, f)
+
+            datadir = os.path.join(os.path.dirname(__file__), "simdata")
+            os.makedirs(datadir, exist_ok=True)
+            l1_dataset = mocks.create_prescan_files(filedir=datadir, arrtype="SCI", numfiles=1)
+            l1_dataset[0].filename = "test_l1_.fits"
+            l1_dataset.save(filedir=datadir)
+            filelist = [l1_dataset[0].filepath]
+
+            outputdir = os.path.join(os.path.dirname(__file__), "test_output")
+            os.makedirs(outputdir, exist_ok=True)
+
+            corgidrp.user_templates_dir = tmpdir
+
+            with pytest.raises(FileNotFoundError) as exc_info:
+                walker.autogen_recipe(filelist, outputdir, template="nonexistent_recipe.json")
+
+            assert "nonexistent_recipe.json" in str(exc_info.value)
+            assert "default" in str(exc_info.value).lower()
+
+    finally:
+        corgidrp.enforce_template_structure = original_enforce
+        corgidrp.user_templates_dir = original_user_templates
+
+
 if __name__ == "__main__":#
     test_autoreducing()
     test_auto_template_identification()
@@ -1110,4 +1182,6 @@ if __name__ == "__main__":#
     test_validation_mode_mismatched_structure_raises()
     test_validation_mode_disabled_allows_mismatch()
     test_user_template_in_autogen_recipe()
+    test_user_template_wrong_name_loads_without_validation()
+    test_user_template_wrong_name_rejected_with_validation()
 


### PR DESCRIPTION
## Describe your changes

If it does not exist already, corgidrp will now create `~/.corgidrp/user_templates` where users can put recipe overrides. A recipe overrides must have the same name as an existing recipe. When a recipe is used, corgidrp will look for a recipe override and otherwise will fallback to the default one provided with corgidrp. 

There is a boolean in the configuration stating whether the override recipes must have the same steps or not. If they must have the same steps, it will be checked, and arguments can still differ (that's the original intent of this feature I understand). In ops, this boolean will be set to True (in ops.py). Otherwise, it's set to False. 

## Type of change

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
Solves #923 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [ ] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
