### PR TITLE
NaN pixel fix for boresight calibration 

### DIFF
--- a/corgidrp/astrom.py
+++ b/corgidrp/astrom.py
@@ -170,11 +170,19 @@ def measure_offset(frame, xstar_guess, ystar_guess, xoffset_guess, yoffset_guess
     ydata += ystar + yoffset_guess
     
     data = ndi.map_coordinates(frame, [ydata, xdata])
-    
+
     ### Fit the PSF to the data ###
+    # Replace NaN/Inf values with zeros before fitting
+    # This allows curve_fit to work, treating bad pixels as background
+    stamp_clean = np.copy(stamp)
+    data_clean = np.copy(data)
+
+    stamp_clean[~np.isfinite(stamp)] = 0.0
+    data_clean[~np.isfinite(data)] = 0.0
+
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=OptimizeWarning) 
-        popt, pcov = optimize.curve_fit(shift_psf, stamp, data.ravel(), p0=(0,0,guessflux), maxfev=2000)
+        warnings.filterwarnings("ignore", category=OptimizeWarning)
+        popt, pcov = optimize.curve_fit(shift_psf, stamp_clean, data_clean.ravel(), p0=(0,0,guessflux), maxfev=2000)
     tinyoffsets = popt[0:2]
     fit_errs = np.sqrt([pcov[0,0], pcov[1,1], pcov[2,2]])
 


### PR DESCRIPTION
## Describe your changes
Modifies measure_offset() function to handle NaN/Inf pixels by replacing non-finite values with 0.0 before PSF fitting.

This is needed because L2b images contain NaN pixels from bad pixel masks and scipy.optimize.curve_fit() raises ValueError when encountering NaN/Inf values.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
