### PR TITLE
Change filenames+data level of intermediate products in chained recipes 

### DIFF
--- a/corgidrp/darks.py
+++ b/corgidrp/darks.py
@@ -905,7 +905,7 @@ def calibrate_darks_lsq(dataset, detector_params, weighting=True, detector_regio
     noise_maps.ext_hdr['DRPNFILE'] = int(np.round(np.sum(mean_num_good_fr)))
     l2a_data_filename = dataset[-1].filename.split('.fits')[0]
     noise_maps.filename =  l2a_data_filename + '_dnm_cal.fits'
-    noise_maps.filename = re.sub('_l[0-9].', '', noise_maps.filename)
+    noise_maps.filename = re.sub(r'_(?:l[0-9][ab_]|im\d+)', '', noise_maps.filename)
     noise_maps.ext_hdr.set('FPN_IMM', FPN_image_mean, 'mean of the image-area fixed-pattern noise (e-). -999. if no value supplied.')
     noise_maps.ext_hdr.set('CIC_IMM', CIC_image_mean, 'mean of the image-area clock-induced charge (e-). -999. if no value supplied.')
     noise_maps.ext_hdr.set('DC_IMM', DC_image_mean, 'mean of the image-area dark current (e-/s). -999. if no value supplied.')

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -147,8 +147,11 @@ class Dataset():
                 filenames.append(frame.filename)
 
         for filename, frame in zip(filenames, self.frames):
-            if ram_heavy_save: 
-                temp_frame = Image(frame.filepath)
+            if ram_heavy_save:
+                source_path = frame.filepath
+                if not os.path.exists(source_path):
+                    source_path = getattr(frame, '_source_filepath', source_path)
+                temp_frame = Image(source_path)
                 if frame.data is None:
                     frame.data = temp_frame.data
                 if frame.err is None:
@@ -435,6 +438,8 @@ class Image():
             else:
                 self.filename = filepath_args[-1]
                 self.filedir = os.path.sep.join(filepath_args[:-1])
+            # remember load path so ram_heavy_save works after filename renames
+            self._source_filepath = data_or_filepath
 
         else:
             # data has been passed in directly
@@ -870,7 +875,7 @@ class Dark(Image):
                 # remove .fits extension
                 orig_input_filename=latest_filename.split(".fits")[0]
                 self.filename="{0}_drk_cal.fits".format(orig_input_filename)
-                self.filename=re.sub('_l[0-9].','',self.filename)
+                self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','',self.filename)
                 # remove dnm_cal if building synthesized dark from detector noise maps
                 self.filename=self.filename.replace("_dnm_cal","")
                 self.pri_hdr['FILENAME']=self.filename
@@ -971,7 +976,7 @@ class FlatField(Image):
             # use latest frame filename to rename
             latest_filename=latest_frame.filename or latest_frame.pri_hdr['FILENAME']
             # use latest frame filename and replace level suffix with calibration suffix
-            self.filename=re.sub('_l[0-9].','_flt_cal',latest_filename)
+            self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','_flt_cal',latest_filename)
             self.pri_hdr['FILENAME'] = self.filename
 
             # Enforce data level = CAL
@@ -1028,7 +1033,7 @@ class SpectroscopyCentroidPSF(Image):
             # remove .fits extension
             base=latest_filename.split(".fits")[0]
             filename = f"{base}_scp_cal.fits"
-            self.filename = re.sub('_l[0-9].', '', filename)
+            self.filename = re.sub(r'_(?:l[0-9][ab_]|im\d+)', '', filename)
             self.pri_hdr['FILENAME'] = self.filename
             if err is None:
                 self.err = np.zeros(self.data.shape)
@@ -1119,7 +1124,7 @@ class LineSpread(Image):
             # remove .fits extension
             base=latest_filename.split(".fits")[0]
             self.filename = f"{base}_lsf_cal.fits"
-            self.filename = re.sub('_l[0-9].', '', self.filename)
+            self.filename = re.sub(r'_(?:l[0-9][ab_]|im\d+)', '', self.filename)
             if gauss_par is not None:
                 if not (gauss_par.ndim == 1 and len(gauss_par) == 6):
                     raise ValueError('The LineSpread calibration gauss_par array must have 6 entries')
@@ -1525,7 +1530,7 @@ class NonLinearityCalibration(Image):
             # use latest frame filename to rename
             latest_filename=latest_frame.filename or latest_frame.pri_hdr['FILENAME']
             # use latest frame filename and replace level suffix with nln calibration suffix
-            self.filename=re.sub('_l[0-9].','_nln_cal',latest_filename)
+            self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','_nln_cal',latest_filename)
             self.pri_hdr['FILENAME'] = self.filename
 
         # double check that this is actually a NonLinearityCalibration file that got read in
@@ -1622,7 +1627,7 @@ class KGain(Image):
                 # use latest frame filename to rename
                 latest_filename=latest_frame.filename or latest_frame.pri_hdr['FILENAME']
                 # use latest frame filename and replace level suffix with krn calibration suffix
-                self.filename=re.sub('_l[0-9].','_krn_cal',latest_filename)
+                self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','_krn_cal',latest_filename)
                 self.pri_hdr['FILENAME'] = self.filename
 
             self.ext_hdr['DATATYPE'] = 'KGain' # corgidrp specific keyword for saving to disk
@@ -1772,7 +1777,7 @@ class BadPixelMap(Image):
             elif "_drk_cal" in latest_filename:
                 self.filename=latest_filename.replace("_drk_cal","_bpm_cal")
             else:
-                self.filename=re.sub('_l[0-9].','_bpm_cal',latest_filename)
+                self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','_bpm_cal',latest_filename)
             self.pri_hdr['FILENAME']=self.filename
 
             # Enforce data level = CAL
@@ -1862,7 +1867,7 @@ class DetectorNoiseMaps(Image):
                 orig_input_filename = self.ext_hdr['FILE0'].split(".fits")[0] 
             
             self.filename = "{0}_dnm_cal.fits".format(orig_input_filename)
-            self.filename = re.sub('_l[0-9].', '', self.filename)
+            self.filename = re.sub(r'_(?:l[0-9][ab_]|im\d+)', '', self.filename)
             self.pri_hdr['FILENAME'] = self.filename
             # Enforce data level = CAL
             self.ext_hdr['DATALVL']    = 'CAL'
@@ -2156,7 +2161,7 @@ class AstrometricCalibration(Image):
             orig_input_filename=latest_filename.split(".fits")[0]
             # append filename convention and set it as new filename
             self.filename = "{0}_ast_cal.fits".format(orig_input_filename)
-            self.filename = re.sub('_l[0-9].', '', self.filename)
+            self.filename = re.sub(r'_(?:l[0-9][ab_]|im\d+)', '', self.filename)
             self.pri_hdr['FILENAME']=self.filename
             
             # Enforce data level = CAL
@@ -2231,7 +2236,7 @@ class TrapCalibration(Image):
             # use latest frame filename to rename
             latest_filename=latest_frame.filename or latest_frame.pri_hdr['FILENAME']
             # use latest frame filename and replace level suffix with tpu calibration suffix
-            self.filename=re.sub('_l[0-9].','_tpu_cal',latest_filename)
+            self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','_tpu_cal',latest_filename)
             self.pri_hdr['FILENAME'] = self.filename
 
             # Enforce data level = CAL
@@ -2332,7 +2337,7 @@ class FluxcalFactor(Image):
             # slight hack for old mocks not in the standard filename format
             if input_dataset is not None:
                 self.filename = "{0}_abf_cal.fits".format(orig_input_filename)
-                self.filename = re.sub('_l[0-9].', '', self.filename)
+                self.filename = re.sub(r'_(?:l[0-9][ab_]|im\d+)', '', self.filename)
             else:
                 self.filename = re.sub(r'\.fits$', '_abf_cal.fits', self.pri_hdr['FILENAME'])
             self.pri_hdr['FILENAME'] = self.filename
@@ -2413,7 +2418,7 @@ class FluxcalFactor(Image):
             # slight hack for old mocks not in the standard filename format
             if input_dataset is not None:
                 self.filename = "{0}_abf_cal.fits".format(orig_input_filename)
-                self.filename = re.sub('_l[0-9].', '', self.filename)
+                self.filename = re.sub(r'_(?:l[0-9][ab_]|im\d+)', '', self.filename)
             else:
                 self.filename = re.sub(r'\.fits$', '_abf_cal.fits', self.pri_hdr['FILENAME'])
             self.pri_hdr['FILENAME'] = self.filename
@@ -2488,7 +2493,7 @@ class SpecFluxCal(Image):
             self.filedir = "."
             # slight hack for old mocks not in the standard filename format
             self.filename = "{0}_sfl_cal.fits".format(orig_input_filename)
-            self.filename = re.sub('_l[0-9].', '', self.filename)
+            self.filename = re.sub(r'_(?:l[0-9][ab_]|im\d+)', '', self.filename)
             self.pri_hdr['FILENAME'] = self.filename
 
         # File format checks
@@ -2559,7 +2564,7 @@ class SpecFluxCal(Image):
             self.filedir = "."
             # slight hack for old mocks not in the standard filename format
             self.filename = "{0}_sfl_cal.fits".format(orig_input_filename)
-            self.filename = re.sub('_l[0-9].', '', self.filename)
+            self.filename = re.sub(r'_(?:l[0-9][ab_]|im\d+)', '', self.filename)
             self.pri_hdr['FILENAME'] = self.filename
 
 class SlitTransmission(Image):
@@ -2623,7 +2628,7 @@ class SlitTransmission(Image):
             # remove .fits extension
             base=latest_filename.split(".fits")[0]
             self.filename=f"{base}_slt_cal.fits"
-            self.filename=re.sub('_l[0-9].','',self.filename)
+            self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','',self.filename)
             # File format checks
             if self.data.ndim != 2:
                 raise ValueError('The slit transmission array must have 2 dimensions') 
@@ -2991,7 +2996,7 @@ class CoreThroughputCalibration(Image):
             # use latest frame filename to rename
             latest_filename=latest_frame.filename or latest_frame.pri_hdr['FILENAME']
             # use latest frame filename and replace level suffix with ctp calibration suffix
-            self.filename=re.sub('_l[0-9].','_ctp_cal',latest_filename)
+            self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','_ctp_cal',latest_filename)
 
             # Enforce data level = CAL
             self.ext_hdr['DATALVL']    = 'CAL'
@@ -3456,7 +3461,7 @@ class CoreThroughputMap(Image):
                 # use latest frame filename to rename
                 latest_filename=latest_frame.filename or latest_frame.pri_hdr['FILENAME']
                 # use latest frame filename and replace suffix with ctm calibration suffix
-                self.filename=re.sub('_l[0-9].','_ctm_cal',latest_filename)
+                self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','_ctm_cal',latest_filename)
                 self.pri_hdr['FILENAME']=self.filename
 
             else:
@@ -3999,7 +4004,7 @@ class NDFilterSweetSpotDataset(Image):
                 # use latest frame filename to rename
                 latest_filename=latest_frame.filename or latest_frame.pri_hdr['FILENAME']
                 # use latest frame filename and replace level suffix with ndf calibration suffix
-                self.filename=re.sub('_l[0-9].','_ndf_cal',latest_filename)
+                self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','_ndf_cal',latest_filename)
             # if no input_dataset is given, do we want to set the filename manually using 
             # header values?
 
@@ -4163,7 +4168,7 @@ class NDSpectroscopy(Image):
                 # use latest frame filename to rename
                 latest_filename=latest_frame.filename or latest_frame.pri_hdr['FILENAME']
                 # use latest frame filename and replace level suffix with ndf calibration suffix
-                self.filename=re.sub('_l[0-9].','_nds_cal',latest_filename)
+                self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','_nds_cal',latest_filename)
             # if no input_dataset is given, do we want to set the filename manually using 
             # header values?
 
@@ -4319,7 +4324,7 @@ class MuellerMatrix(Image):
             # use latest frame filename to rename
             latest_filename=latest_frame.filename or latest_frame.pri_hdr['FILENAME']
             # use latest frame filename and replace level suffix with mmx calibration suffix
-            self.filename=re.sub('_l[0-9].','_mmx_cal',latest_filename)
+            self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','_mmx_cal',latest_filename)
             self.pri_hdr['FILENAME'] = self.filename          
             
             # Enforce data level = CAL
@@ -4400,7 +4405,7 @@ class NDMuellerMatrix(Image):
             # use latest frame filename to rename
             latest_filename=latest_frame.filename or latest_frame.pri_hdr['FILENAME']
             # use latest frame filename and replace level suffix with ndm calibration suffix
-            self.filename=re.sub('_l[0-9].','_ndm_cal',latest_filename)
+            self.filename=re.sub(r'_(?:l[0-9][ab_]|im\d+)','_ndm_cal',latest_filename)
             self.pri_hdr['FILENAME'] = self.filename          
             
             # Enforce data level = CAL

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -1,5 +1,6 @@
 # A file that holds the functions that transmogrify l1 data to l2a data
 from corgidrp.detector import get_relgains, slice_section, detector_areas, flag_cosmics, calc_sat_fwc, imaging_slice, imaging_area_geom
+import re
 import numpy as np
 import corgidrp.data as data
 import corgidrp.check as check
@@ -433,22 +434,49 @@ def remove_sat_images(input_dataset, sat_fwcs, pct_oversat_lim=20, dataset_copy=
 
     return pruned_dataset, pruned_fwcs
 
+def update_to_intermediate(input_dataset, intermediate_level=1):
+    """
+    Updates the data level to an intermediate level (IM1, IM2, ...) for chained
+    recipe outputs that are not final data products.
+
+    Args:
+        input_dataset (corgidrp.data.Dataset): dataset to mark as intermediate
+        intermediate_level (int): which intermediate level (1, 2, ...)
+
+    Returns:
+        corgidrp.data.Dataset: dataset with DATALVL set to IM# and filename updated
+    """
+    updated_dataset = input_dataset.copy(copy_data=False)
+
+    im_tag = f"im{intermediate_level}"
+    for frame in updated_dataset:
+        frame.ext_hdr['DATALVL'] = f"IM{intermediate_level}"
+        # Replace existing data level marker in filename.
+        # Handles _l1_, _l2a, _l2b, _l3_, _l4_, or existing _im#
+        frame.filename = re.sub(r'_(?:l[1234][ab]?_?|im\d+)', f'_{im_tag}', frame.filename, count=1)
+        frame.pri_hdr['FILENAME'] = frame.filename
+
+    history_msg = f"Updated Data Level to IM{intermediate_level} (intermediate)"
+    updated_dataset.update_after_processing_step(history_msg)
+
+    return updated_dataset
+
 def update_to_l2a(input_dataset):
     """
-    Updates the data level to L2a. Only works on L1 data.
+    Updates the data level to L2a. Works on L1 or intermediate (IM#) data.
 
     Applies merge_headers to each frame (removes deleted keywords, applies other
     header rules), then sets DATALVL to L2a and updates filenames.
 
     Args:
-        input_dataset (corgidrp.data.Dataset): a dataset of Images (L1-level)
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L1 or IM-level)
 
     Returns:
         corgidrp.data.Dataset: same dataset now at L2a level
     """
-    # check that we are running this on L1 data
+    # check that we are running this on L1 or intermediate data
     for orig_frame in input_dataset:
-        if orig_frame.ext_hdr['DATALVL'] != "L1":
+        if not re.match(r'^(L1|IM\d+)$', orig_frame.ext_hdr['DATALVL']):
             err_msg = "{0} needs to be L1 data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATALVL'])
             raise ValueError(err_msg)
 
@@ -457,7 +485,7 @@ def update_to_l2a(input_dataset):
 
     for frame in updated_dataset:
         # Merge_headers is called here to delete a subset of keywords that should not be carried past L1
-        
+
         pri_hdr, ext_hdr, err_hdr, dq_hdr = check.merge_headers(data.Dataset([frame]), invalid_keywords=[])
         frame.pri_hdr = pri_hdr
         frame.ext_hdr = ext_hdr
@@ -465,8 +493,8 @@ def update_to_l2a(input_dataset):
         frame.dq_hdr = dq_hdr
         frame.ext_hdr['DATALVL'] = "L2a"
         # update filename convention. The file convention should be
-        # "CGI_[dataleel_*]" so we should be same just replacing the just instance of L1
-        frame.filename = frame.filename.replace("_l1_", "_l2a", 1)
+        # "CGI_[datalevel_*]" so we replace the first data level marker
+        frame.filename = re.sub(r'_(?:l1_|im\d+)', '_l2a', frame.filename, count=1)
         #updating filename in the primary header
         frame.pri_hdr['FILENAME'] = frame.filename
 

--- a/corgidrp/l1_to_l2a.py
+++ b/corgidrp/l1_to_l2a.py
@@ -477,7 +477,7 @@ def update_to_l2a(input_dataset):
     # check that we are running this on L1 or intermediate data
     for orig_frame in input_dataset:
         if not re.match(r'^(L1|IM\d+)$', orig_frame.ext_hdr['DATALVL']):
-            err_msg = "{0} needs to be L1 data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATALVL'])
+            err_msg = "{0} needs to be L1 or IM data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATALVL'])
             raise ValueError(err_msg)
 
     # we aren't altering the data

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -585,7 +585,7 @@ def update_to_l2b(input_dataset):
     # check that we are running this on L2a or intermediate data
     for orig_frame in input_dataset:
         if not re.match(r'^(L2a|IM\d+)$', orig_frame.ext_hdr['DATALVL']):
-            err_msg = "{0} needs to be L2a data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATALVL'])
+            err_msg = "{0} needs to be L2a or IM data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATALVL'])
             raise ValueError(err_msg)
 
     # we aren't altering the data

--- a/corgidrp/l2a_to_l2b.py
+++ b/corgidrp/l2a_to_l2b.py
@@ -1,4 +1,5 @@
 # A file that holds the functions that transmogrify l2a data to l2b data
+import re
 import numpy as np
 from scipy.interpolate import interp1d
 import copy
@@ -573,19 +574,17 @@ def desmear(input_dataset, detector_params):
 
 def update_to_l2b(input_dataset):
     """
-    Updates the data level to L2b. Only works on L2a data.
-
-    Currently only checks that data is at the L2a level
+    Updates the data level to L2b. Works on L2a or intermediate (IM#) data.
 
     Args:
-        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a-level)
+        input_dataset (corgidrp.data.Dataset): a dataset of Images (L2a or IM-level)
 
     Returns:
         corgidrp.data.Dataset: same dataset now at L2b-level
     """
-    # check that we are running this on L1 data
+    # check that we are running this on L2a or intermediate data
     for orig_frame in input_dataset:
-        if orig_frame.ext_hdr['DATALVL'] != "L2a":
+        if not re.match(r'^(L2a|IM\d+)$', orig_frame.ext_hdr['DATALVL']):
             err_msg = "{0} needs to be L2a data, but it is {1} data instead".format(orig_frame.filename, orig_frame.ext_hdr['DATALVL'])
             raise ValueError(err_msg)
 
@@ -596,8 +595,8 @@ def update_to_l2b(input_dataset):
         # update header
         frame.ext_hdr['DATALVL'] = "L2b"
         # update filename convention. The file convention should be
-        # "CGI_[dataleel_*]" so we should be same just replacing the just instance of L1
-        frame.filename = frame.filename.replace("_l2a", "_l2b", 1)
+        # "CGI_[datalevel_*]" so we replace the first data level marker
+        frame.filename = re.sub(r'_(?:l2a|im\d+)', '_l2b', frame.filename, count=1)
         #updating filename in the primary header
         frame.pri_hdr['FILENAME'] = frame.filename
 

--- a/corgidrp/recipe_templates/build_trad_dark_image_1.json
+++ b/corgidrp/recipe_templates/build_trad_dark_image_1.json
@@ -54,6 +54,12 @@
             "name" : "em_gain_division"
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 1
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/recipe_templates/l1_to_kgain_1.json
+++ b/corgidrp/recipe_templates/l1_to_kgain_1.json
@@ -15,9 +15,15 @@
               }
         },
         {
-            "name" : "save",
-			"keywords" : {
-                "ram_heavy_save" : true
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 1
+            }
+        },
+        {
+            "name": "save",
+            "keywords": {
+                "ram_heavy_save": true
             }
         }
     ]

--- a/corgidrp/recipe_templates/l1_to_l2a_noisemap_1.json
+++ b/corgidrp/recipe_templates/l1_to_l2a_noisemap_1.json
@@ -48,6 +48,12 @@
             }
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 1
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/recipe_templates/l1_to_l2a_nonlin_1.json
+++ b/corgidrp/recipe_templates/l1_to_l2a_nonlin_1.json
@@ -14,6 +14,12 @@
               }
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 1
+            }
+        },
+        {
             "name" : "save",
             "keywords" : {
                 "ram_heavy_save" : true

--- a/corgidrp/recipe_templates/l1_to_l2a_nonlin_2.json
+++ b/corgidrp/recipe_templates/l1_to_l2a_nonlin_2.json
@@ -51,6 +51,12 @@
             }
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 2
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/recipe_templates/l1_to_l2b_pc_dark_1.json
+++ b/corgidrp/recipe_templates/l1_to_l2b_pc_dark_1.json
@@ -54,6 +54,12 @@
             }
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 1
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/recipe_templates/l2a_build_trad_dark_image_1.json
+++ b/corgidrp/recipe_templates/l2a_build_trad_dark_image_1.json
@@ -18,6 +18,12 @@
             "name" : "em_gain_division"
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 1
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/recipe_templates/l2a_to_l2a_noisemap_1.json
+++ b/corgidrp/recipe_templates/l2a_to_l2a_noisemap_1.json
@@ -15,6 +15,12 @@
             }
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 1
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/recipe_templates/l2a_to_l2b_pc_1.json
+++ b/corgidrp/recipe_templates/l2a_to_l2b_pc_1.json
@@ -27,6 +27,12 @@
             }
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 1
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/recipe_templates/l2a_to_l2b_pc_2.json
+++ b/corgidrp/recipe_templates/l2a_to_l2b_pc_2.json
@@ -18,6 +18,12 @@
             }
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 2
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/recipe_templates/l2a_to_l2b_pc_dark_1.json
+++ b/corgidrp/recipe_templates/l2a_to_l2b_pc_dark_1.json
@@ -18,6 +18,12 @@
             }
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 1
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/recipe_templates/l2a_to_l2b_pc_spec_1.json
+++ b/corgidrp/recipe_templates/l2a_to_l2b_pc_spec_1.json
@@ -27,6 +27,12 @@
             }
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 1
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/recipe_templates/l2a_to_l2b_pc_spec_2.json
+++ b/corgidrp/recipe_templates/l2a_to_l2b_pc_spec_2.json
@@ -18,6 +18,12 @@
             }
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 2
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/recipe_templates/trap_pump_cal_1.json
+++ b/corgidrp/recipe_templates/trap_pump_cal_1.json
@@ -36,6 +36,12 @@
             "name" : "em_gain_division"
         },
         {
+            "name": "update_to_intermediate",
+            "keywords": {
+                "intermediate_level": 1
+            }
+        },
+        {
             "name" : "save"
         }
     ]

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -34,6 +34,7 @@ all_steps = {
     "calibrate_nonlin": corgidrp.calibrate_nonlin.calibrate_nonlin,
     "correct_nonlinearity" : corgidrp.l1_to_l2a.correct_nonlinearity,
     "update_to_l2a" : corgidrp.l1_to_l2a.update_to_l2a,
+    "update_to_intermediate" : corgidrp.l1_to_l2a.update_to_intermediate,
     "add_shot_noise_to_err" : corgidrp.l2a_to_l2b.add_shot_noise_to_err,
     "dark_subtraction" : corgidrp.l2a_to_l2b.dark_subtraction,
     "flat_division" : corgidrp.l2a_to_l2b.flat_division,

--- a/tests/e2e_tests/trad_dark_e2e.py
+++ b/tests/e2e_tests/trad_dark_e2e.py
@@ -569,7 +569,7 @@ def test_trad_dark_im(e2edata_path, e2eoutput_path):
             key=lambda item: (os.path.basename(item[1]).split('_')[2] if len(os.path.basename(item[1]).split('_')) > 2 else '', item[0]),
         )[1]
     test_filename = os.path.basename(latest_input_file).split('.fits')[0] + '_drk_cal.fits'
-    test_filename = re.sub('_l[0-9].', '', test_filename)
+    test_filename = re.sub(r'_(?:l[0-9][ab_]|im\d+)', '', test_filename)
     assert(trad_dark.filename == test_filename)
     print('e2e test for trad_dark_im calibration passed')
 

--- a/tests/e2e_tests/zz_dataformat_e2e.py
+++ b/tests/e2e_tests/zz_dataformat_e2e.py
@@ -1110,12 +1110,12 @@ def test_ndfilter_spec_dataformat_e2e(e2edata_path, e2eoutput_path):
 @pytest.mark.e2e
 def test_specfluxcal_dataformat_e2e(e2edata_path, e2eoutput_path):
     print("\n=== Testing Spectroscopy Flux Calibration ===")
-    sfl_data_files = glob.glob(os.path.join(e2eoutput_path, "nd_filter_spec_e2e", "*_sfl_cal.fits"))
+    sfl_data_files = glob.glob(os.path.join(e2eoutput_path, "l1_to_spec_fluxcal_e2e", "*_sfl_cal.fits"))
     sfl_data_file = max(sfl_data_files, key=os.path.getmtime)
 
     validate_cgi_filename(sfl_data_file, 'sfl_cal')
 
-    generate_fits_excel_documentation(sfl_data_file, os.path.join(e2eoutput_path, "nd_filter_spec_e2e", "sfl_cal_documentation.xlsx"))
+    generate_fits_excel_documentation(sfl_data_file, os.path.join(e2eoutput_path, "l1_to_spec_fluxcal_e2e", "sfl_cal_documentation.xlsx"))
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):

--- a/tests/test_data_levels.py
+++ b/tests/test_data_levels.py
@@ -53,6 +53,67 @@ def test_l1_to_l4():
         assert frame.ext_hdr['DATALVL'] == "L4"
         assert frame.filename == "cgi_0000011222333ooo111_20250101t12{0:02d}00_l4_.fits".format(i)
 
+def test_update_to_intermediate():
+    """
+    Tests marking data as intermediate (IM1, IM2) and then upgrading to final level.
+    """
+    l1_dataset = mocks.create_prescan_files(arrtype="SCI", numfiles=2)
+    fname_template = "cgi_0000011222333ooo111_20250101t12{0:02d}00_l1_.fits"
+    for i, image in enumerate(l1_dataset):
+        image.filename = fname_template.format(i)
+
+    # Mark as IM1
+    im1_dataset = l1_to_l2a.update_to_intermediate(l1_dataset, intermediate_level=1)
+    for i, frame in enumerate(im1_dataset):
+        assert frame.ext_hdr['DATALVL'] == "IM1"
+        assert "_im1" in frame.filename
+        assert "_l1_" not in frame.filename
+        assert frame.pri_hdr['FILENAME'] == frame.filename
+
+    # Mark as IM2 (from IM1)
+    im2_dataset = l1_to_l2a.update_to_intermediate(im1_dataset, intermediate_level=2)
+    for i, frame in enumerate(im2_dataset):
+        assert frame.ext_hdr['DATALVL'] == "IM2"
+        assert "_im2" in frame.filename
+        assert "_im1" not in frame.filename
+
+    # Upgrade IM2 to L2a (relaxed check)
+    l2a_dataset = l1_to_l2a.update_to_l2a(im2_dataset)
+    for i, frame in enumerate(l2a_dataset):
+        assert frame.ext_hdr['DATALVL'] == "L2a"
+        assert "_l2a" in frame.filename
+        assert "_im" not in frame.filename
+
+
+def test_update_to_l2b_from_intermediate():
+    """
+    Tests upgrading from IM# to L2b (relaxed check).
+    """
+    l1_dataset = mocks.create_prescan_files(arrtype="SCI", numfiles=2)
+    fname_template = "cgi_0000011222333ooo111_20250101t12{0:02d}00_l1_.fits"
+    for i, image in enumerate(l1_dataset):
+        image.filename = fname_template.format(i)
+
+    # L1 -> IM1
+    im1_dataset = l1_to_l2a.update_to_intermediate(l1_dataset, intermediate_level=1)
+
+    # IM1 -> L2a (to get valid L2a filename format)
+    l2a_dataset = l1_to_l2a.update_to_l2a(im1_dataset)
+
+    # L2a -> IM1 again (simulating a second chain)
+    im1_l2a = l1_to_l2a.update_to_intermediate(l2a_dataset, intermediate_level=1)
+    for frame in im1_l2a:
+        assert frame.ext_hdr['DATALVL'] == "IM1"
+        assert "_im1" in frame.filename
+
+    # IM1 -> L2b
+    l2b_dataset = l2a_to_l2b.update_to_l2b(im1_l2a)
+    for i, frame in enumerate(l2b_dataset):
+        assert frame.ext_hdr['DATALVL'] == "L2b"
+        assert "_l2b" in frame.filename
+        assert "_im" not in frame.filename
+
+
 def test_l1_to_l2a_bad():
     """
     Tests an unsuccessful upgrade of L1 to L2a data because the input is not L1
@@ -101,6 +162,8 @@ def test_l3_to_l4_bad():
 
 if __name__ == "__main__":
     test_l1_to_l4()
+    test_update_to_intermediate()
+    test_update_to_l2b_from_intermediate()
     test_l1_to_l2a_bad()
     test_l1a_to_l2b_bad()
     test_l2b_to_l3_bad()

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -599,17 +599,6 @@ def test_chained_recipe_intermediate_levels():
     l2a_dataset.save(filedir=datadir)
     filelist = [frame.filepath for frame in l2a_dataset]
 
-    # Create KGain calibration (required by convert_to_electrons in l2a_to_l2b_pc_1)
-    pri_hdr, ext_hdr = mocks.create_default_L1_headers("SCI")
-    ext_hdr['DRPCTIME'] = time.Time.now().isot
-    ext_hdr['DRPVERSN'] = corgidrp.__version__
-    dummy_dataset = mocks.create_prescan_files()
-    kgain_val = 8.8
-    new_kgain = data.KGain(kgain_val, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=dummy_dataset)
-    new_kgain.save(filedir=os.path.join(os.path.dirname(__file__), "test_data"), filename="kgain.fits")
-    mycaldb = caldb.CalDB()
-    mycaldb.create_entry(new_kgain)
-
     # Load the real l2a_to_l2b_pc chain templates
     template_dir = os.path.join(os.path.dirname(walker.__file__), "recipe_templates")
     template_1 = json.load(open(os.path.join(template_dir, "l2a_to_l2b_pc_1.json"), "r"))
@@ -639,9 +628,6 @@ def test_chained_recipe_intermediate_levels():
     # Verify the inputs are the IM1 files
     for inp in recipe_2['inputs']:
         assert "_im1" in inp
-
-    # clean up
-    mycaldb.remove_entry(new_kgain)
 
 
 def test_cpgs_satspots():

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -575,6 +575,75 @@ def test_generate_multiple_recipes():
     assert len(recipes[0]) == 3 # nonlin chain in 3 parts
     assert len(recipes[1]) == 2 # kgain chain in 2 parts
 
+def test_chained_recipe_intermediate_levels():
+    """
+    Tests that running a chained recipe correctly marks intermediate output
+    files with IM1 level using the real l2a_to_l2b_pc_1.json template, then
+    verifies the next recipe in the chain can accept them.
+    """
+    # create dirs
+    datadir = os.path.join(os.path.dirname(__file__), "simdata")
+    if not os.path.exists(datadir):
+        os.mkdir(datadir)
+    outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
+    if not os.path.exists(outputdir):
+        os.mkdir(outputdir)
+
+    # Create simulated L2a data (l2a_to_l2b_pc chain starts from L2a)
+    l2a_dataset = mocks.create_prescan_files(filedir=datadir, arrtype="SCI", numfiles=2)
+    fname_template = "cgi_0200001999001000{:03d}_20250415t0305102_l2a.fits"
+    for i, image in enumerate(l2a_dataset):
+        image.filename = fname_template.format(i)
+        image.ext_hdr['DATALVL'] = "L2a"
+        image.ext_hdr['ISPC'] = 1  # photon-counting mode (l2a_to_l2b_pc template)
+    l2a_dataset.save(filedir=datadir)
+    filelist = [frame.filepath for frame in l2a_dataset]
+
+    # Create KGain calibration (required by convert_to_electrons in l2a_to_l2b_pc_1)
+    pri_hdr, ext_hdr = mocks.create_default_L1_headers("SCI")
+    ext_hdr['DRPCTIME'] = time.Time.now().isot
+    ext_hdr['DRPVERSN'] = corgidrp.__version__
+    dummy_dataset = mocks.create_prescan_files()
+    kgain_val = 8.8
+    new_kgain = data.KGain(kgain_val, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=dummy_dataset)
+    new_kgain.save(filedir=os.path.join(os.path.dirname(__file__), "test_data"), filename="kgain.fits")
+    mycaldb = caldb.CalDB()
+    mycaldb.create_entry(new_kgain)
+
+    # Load the real l2a_to_l2b_pc chain templates
+    template_dir = os.path.join(os.path.dirname(walker.__file__), "recipe_templates")
+    template_1 = json.load(open(os.path.join(template_dir, "l2a_to_l2b_pc_1.json"), "r"))
+    template_2 = json.load(open(os.path.join(template_dir, "l2a_to_l2b_pc_2.json"), "r"))
+
+    # Generate recipe from template 1
+    recipe_1 = walker.autogen_recipe(filelist, outputdir, template=template_1)
+
+    # Run recipe 1 (frame_select -> convert_to_electrons -> dark_subtraction -> update_to_intermediate -> save)
+    output_filelist = walker.run_recipe(recipe_1)
+
+    # Verify intermediate outputs on disk
+    assert output_filelist is not None
+    assert len(output_filelist) > 0
+    output_dataset = data.Dataset(output_filelist)
+    for frame in output_dataset:
+        assert frame.ext_hdr['DATALVL'] == "IM1", (
+            f"Expected DATALVL='IM1', got '{frame.ext_hdr['DATALVL']}'"
+        )
+        assert "_im1" in frame.filename, (
+            f"Expected '_im1' in filename, got '{frame.filename}'"
+        )
+
+    # Verify chaining: recipe 2 accepts intermediate files as inputs
+    recipe_2 = walker.autogen_recipe(output_filelist, outputdir, template=template_2)
+    assert len(recipe_2['inputs']) > 0
+    # Verify the inputs are the IM1 files
+    for inp in recipe_2['inputs']:
+        assert "_im1" in inp
+
+    # clean up
+    mycaldb.remove_entry(new_kgain)
+
+
 def test_cpgs_satspots():
     """
     Tests passing in sat spot parameters from the CPGS XML into the 
@@ -1181,6 +1250,7 @@ if __name__ == "__main__":#
     test_skip_missing_optional_calib()
     test_jit_calibs()
     test_generate_multiple_recipes()
+    test_chained_recipe_intermediate_levels()
     test_cpgs_satspots()
     test_cpgs_one_satspot()
     test_l1_to_l2b_default_calibs()


### PR DESCRIPTION
## Describe your changes

1: I have added an `update_to_intermediate` step to update the level of intermediate products in chained recipes to an intermediate level IMn with n the intermediate level. 

2: I added this step to all the recipes that have 2 or 3 steps so the middle steps update correctly the products. 

3: I am testing these changes

4: I correct some issues after some e2e tests did not pass. All the tests are still not passing.

5: following comments on this PR, I have updated the error message in case of level mismatch to include IM levels too

6: an e2e test was looking for files in a folder that is no longer populated by another test, I changed the location where it's looking

## Type of change

Please delete options that are not relevant (and this line).

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
solves #927 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
