### PR TITLE
check on multiple targets before combining datasets

### DIFF
--- a/corgidrp/check.py
+++ b/corgidrp/check.py
@@ -1305,8 +1305,8 @@ def check_uniq_keyword(dataset, keyword):
     checks the uniqueness of a pri_hdr or ext_hdr keyword in the frames of a dataset
     
     Args:
-       dataset(data.Dataset): input dataset to check on
-       keyword(str): pri_hdr or ext_hdr keyword
+       dataset (data.Dataset): input dataset to check on
+       keyword (str): pri_hdr or ext_hdr keyword
        
     Returns:
        boolean: True in case of an unique keyword, False in case not

--- a/corgidrp/check.py
+++ b/corgidrp/check.py
@@ -1309,7 +1309,7 @@ def check_uniq_keyword(dataset, keyword):
        keyword (str): pri_hdr or ext_hdr keyword
        
     Returns:
-       boolean: True in case of an unique keyword, False in case not
+       boolean, list: True in case of an unique keyword, False in case not, additionally list of unique keywords
     """
     uni_hd = []
     for frame in dataset:
@@ -1323,4 +1323,4 @@ def check_uniq_keyword(dataset, keyword):
     if len(np.unique(uni_hd)) == 1:
         uni = True
  
-    return uni
+    return uni, np.unique(uni_hd)

--- a/corgidrp/check.py
+++ b/corgidrp/check.py
@@ -1299,3 +1299,28 @@ def hdr_type_conform(orig_pri_hdr, orig_img_hdr, header_template=None):
         # otherwise, could have been '-999', which is fine (still str)
 
     return (adjusted_pri_hdr, adjusted_img_hdr)
+
+def check_uniq_keyword(dataset, keyword):
+    """
+    checks the uniqueness of a pri_hdr or ext_hdr keyword in the frames of a dataset
+    
+    Args:
+       dataset(data.Dataset): input dataset to check on
+       keyword(str): pri_hdr or ext_hdr keyword
+       
+    Returns:
+       boolean: True in case of an unique keyword, False in case not
+    """
+    uni_hd = []
+    for frame in dataset:
+        if keyword in frame.pri_hdr:
+            uni_hd.append(frame.pri_hdr[keyword])
+        elif keyword in frame.ext_hdr:
+            uni_hd.append(frame.ext_hdr[keyword])
+        else:
+            raise AttributeError("keyword {0} not in header".format(keyword))
+    uni = False
+    if len(np.unique(uni_hd)) == 1:
+        uni = True
+ 
+    return uni

--- a/corgidrp/fluxcal.py
+++ b/corgidrp/fluxcal.py
@@ -481,9 +481,12 @@ def calibrate_fluxcal_aper(dataset_or_image, calspec_file = None, flux_or_irr = 
     """
     d_or_i = dataset_or_image.copy()
     if isinstance(d_or_i, corgidrp.data.Dataset):
-        #take the median of images in the dataset
-        image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
-        dataset = d_or_i
+        if corgidrp.check.check_uniq_keyword(d_or_i, "TARGET"):
+            #take the mean of images in the dataset
+            image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
+            dataset = d_or_i
+        else:
+            raise AttributeError("dataset of different targets cannot be medianed")
     else:
         image = d_or_i
         dataset = corgidrp.data.Dataset([image])
@@ -613,9 +616,12 @@ def calibrate_pol_fluxcal_aper(dataset_or_image,
     """
     d_or_i = dataset_or_image.copy()
     if isinstance(d_or_i, corgidrp.data.Dataset):
-        #take the mean of images in the dataset
-        image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
-        dataset = d_or_i
+        if corgidrp.check.check_uniq_keyword(d_or_i, "TARGET"):
+            #take the mean of images in the dataset
+            image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
+            dataset = d_or_i
+        else:
+            raise AttributeError("dataset of different targets cannot be medianed")
     else:
         image = d_or_i
         dataset = corgidrp.data.Dataset([image])
@@ -849,9 +855,12 @@ def calibrate_fluxcal_gauss2d(dataset_or_image, calspec_file = None, flux_or_irr
     """
     d_or_i = dataset_or_image.copy()
     if isinstance(d_or_i, corgidrp.data.Dataset):
-        #take the mean of images in the dataset
-        image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
-        dataset = d_or_i
+        if corgidrp.check.check_uniq_keyword(d_or_i, "TARGET"):
+            #take the mean of images in the dataset
+            image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
+            dataset = d_or_i
+        else:
+            raise AttributeError("dataset of different targets cannot be medianed")
     else:
         image = d_or_i
         dataset = corgidrp.data.Dataset([image])

--- a/corgidrp/fluxcal.py
+++ b/corgidrp/fluxcal.py
@@ -481,12 +481,13 @@ def calibrate_fluxcal_aper(dataset_or_image, calspec_file = None, flux_or_irr = 
     """
     d_or_i = dataset_or_image.copy()
     if isinstance(d_or_i, corgidrp.data.Dataset):
-        if corgidrp.check.check_uniq_keyword(d_or_i, "TARGET"):
-            #take the mean of images in the dataset
+        uni, uni_list = corgidrp.check.check_uniq_keyword(d_or_i, "VISITID")
+        if uni:
+            #take the median of images in the dataset
             image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
             dataset = d_or_i
         else:
-            raise AttributeError("dataset of different targets cannot be medianed")
+            raise AttributeError("dataset of different VISITIDs {0} cannot be medianed".format(uni_list))
     else:
         image = d_or_i
         dataset = corgidrp.data.Dataset([image])
@@ -616,12 +617,13 @@ def calibrate_pol_fluxcal_aper(dataset_or_image,
     """
     d_or_i = dataset_or_image.copy()
     if isinstance(d_or_i, corgidrp.data.Dataset):
-        if corgidrp.check.check_uniq_keyword(d_or_i, "TARGET"):
-            #take the mean of images in the dataset
+        uni, uni_list = corgidrp.check.check_uniq_keyword(d_or_i, "VISITID")
+        if uni:
+            #take the median of images in the dataset
             image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
             dataset = d_or_i
         else:
-            raise AttributeError("dataset of different targets cannot be medianed")
+            raise AttributeError("dataset of different VISITIDs {0} cannot be medianed".format(uni_list))
     else:
         image = d_or_i
         dataset = corgidrp.data.Dataset([image])
@@ -855,12 +857,13 @@ def calibrate_fluxcal_gauss2d(dataset_or_image, calspec_file = None, flux_or_irr
     """
     d_or_i = dataset_or_image.copy()
     if isinstance(d_or_i, corgidrp.data.Dataset):
-        if corgidrp.check.check_uniq_keyword(d_or_i, "TARGET"):
-            #take the mean of images in the dataset
+        uni, uni_list = corgidrp.check.check_uniq_keyword(d_or_i, "VISITID")
+        if uni:
+            #take the median of images in the dataset
             image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
             dataset = d_or_i
         else:
-            raise AttributeError("dataset of different targets cannot be medianed")
+            raise AttributeError("dataset of different VISITIDs {0} cannot be medianed".format(uni_list))
     else:
         image = d_or_i
         dataset = corgidrp.data.Dataset([image])

--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -34,7 +34,6 @@ from corgidrp.astrom import get_polar_dist, seppa2dxdy, seppa2xy
 import datetime
 import glob
 import shutil
-import random
 from corgidrp import pol
 
 from emccd_detect.emccd_detect import EMCCDDetect
@@ -3019,9 +3018,6 @@ def create_flux_image(star_flux, fwhm, cal_factor, filter='3C', fpamname = 'HOLE
     prihdr['RA'] = target_location[0]
     prihdr['DEC'] = target_location[1]
     prihdr['TARGET'] = target_name
-    # when a new target file is created the VISITID should change
-    if target_name != 'Vega':
-        prihdr['VISITID'] = prihdr['VISITID'][:-1] + str(random.randint(0,9)) 
 
     exthdr['CFAMNAME'] = filter             # Using the variable 'filter' (ensure it's defined)
     exthdr['FPAMNAME'] = fpamname

--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -34,6 +34,7 @@ from corgidrp.astrom import get_polar_dist, seppa2dxdy, seppa2xy
 import datetime
 import glob
 import shutil
+import random
 from corgidrp import pol
 
 from emccd_detect.emccd_detect import EMCCDDetect
@@ -3018,6 +3019,9 @@ def create_flux_image(star_flux, fwhm, cal_factor, filter='3C', fpamname = 'HOLE
     prihdr['RA'] = target_location[0]
     prihdr['DEC'] = target_location[1]
     prihdr['TARGET'] = target_name
+    # when a new target file is created the VISITID should change
+    if target_name != 'Vega':
+        prihdr['VISITID'] = prihdr['VISITID'][:-1] + str(random.randint(0,9)) 
 
     exthdr['CFAMNAME'] = filter             # Using the variable 'filter' (ensure it's defined)
     exthdr['FPAMNAME'] = fpamname

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -9,7 +9,9 @@ import pytest
 
 import numpy as np
 
-from corgidrp import check
+from corgidrp import check, mocks
+from corgidrp.data import Image, Dataset
+from corgidrp.check import check_uniq_keyword
 
 
 # Invalid values
@@ -545,6 +547,26 @@ def test_string_bad_vexc():
         pass
     pass
 
+def test_uniq_keyword():
+    """
+    test check.check_uniq_keyword
+    """
+    img = np.ones([100, 100])
+    err = np.ones([100, 100])
+    dq = np.zeros([100, 100], dtype = np.uint16)
+    prhd, exthd = mocks.create_default_L1_headers()
+    
+    prhd1 = prhd.copy()
+    prhd1["TARGET"] = "star"
+    
+    image1 = Image(img, err = err, dq = dq,pri_hdr = prhd, ext_hdr = exthd)
+    image2 = Image(img, err = err, dq = dq,pri_hdr = prhd1, ext_hdr = exthd)
+    dataset = Dataset([image1, image2])
+    assert check_uniq_keyword(dataset, "TARGET") == False
+    dataset1 = Dataset([image1, image1])
+    assert check_uniq_keyword(dataset1, "TARGET") == True
+
+
 
 if __name__ == '__main__':
     test_nonnegative_scalar_integer_bad_var()
@@ -596,3 +618,4 @@ if __name__ == '__main__':
     test_twoD_square_array_bad_vexc()
     test_twoD_square_array_bad_vname() 
     test_twoD_square_array_good()
+    test_uniq_keyword()

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -562,10 +562,10 @@ def test_uniq_keyword():
     image1 = Image(img, err = err, dq = dq,pri_hdr = prhd, ext_hdr = exthd)
     image2 = Image(img, err = err, dq = dq,pri_hdr = prhd1, ext_hdr = exthd)
     dataset = Dataset([image1, image2])
-    assert check_uniq_keyword(dataset, "TARGET") == False
+    assert check_uniq_keyword(dataset, "TARGET")[0] == False
     dataset1 = Dataset([image1, image1])
-    assert check_uniq_keyword(dataset1, "TARGET") == True
-
+    assert check_uniq_keyword(dataset1, "TARGET")[0] == True
+    assert len(check_uniq_keyword(dataset, "TARGET")[1]) == 2
 
 
 if __name__ == '__main__':

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -1,5 +1,6 @@
 import os
 import glob
+import time
 from pathlib import Path
 import numbers
 import numpy as np
@@ -9,13 +10,11 @@ import re
 import copy
 from termcolor import cprint
 
-import corgidrp
 import corgidrp.fluxcal as fluxcal
 import corgidrp.nd_filter_calibration as nd_filter_calibration
-import corgidrp.l2b_to_l3 as l2b_tol3
 import corgidrp.data as data 
 from corgidrp.data import (Image, Dataset, FluxcalFactor,
-    NDFilterSweetSpotDataset, NDSpectroscopy, FpamFsamCal)
+    NDFilterSweetSpotDataset, NDSpectroscopy)
 import corgidrp.mocks as mocks
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -142,6 +141,8 @@ def mock_dim_dataset_files(dim_exptime, filter_used, cal_factor, save_mocks, out
         flux_image.ext_hdr['BUNIT'] = 'photoelectron/s'
         flux_image.ext_hdr['DATALVL'] = 'L3'
         dim_star_images.append(flux_image)
+        # introduce wait time to have different file names to not overwrite each other 
+        time.sleep(1)
     return dim_star_images
 
 
@@ -187,6 +188,8 @@ def mock_bright_dataset_files(bright_exptime, filter_used, OD, cal_factor, save_
                 flux_image.ext_hdr['BUNIT'] = 'photoelectron/s'
                 flux_image.ext_hdr['DATALVL'] = 'L3'
                 bright_star_images.append(flux_image)
+                # introduce wait time to have different file names to not overwrite each other 
+                time.sleep(1)
     return bright_star_images
 
 

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import time
+import random
 from pathlib import Path
 import numbers
 import numpy as np
@@ -140,6 +141,10 @@ def mock_dim_dataset_files(dim_exptime, filter_used, cal_factor, save_mocks, out
         # ND filter calibration requires photoelectron/s units (L3 data)
         flux_image.ext_hdr['BUNIT'] = 'photoelectron/s'
         flux_image.ext_hdr['DATALVL'] = 'L3'
+        # when a new target file is created the VISITID should change
+        visit_old = flux_image.pri_hdr['VISITID']
+        flux_image.pri_hdr['VISITID'] = visit_old[:-1] + str(random.randint(0,9)) 
+
         dim_star_images.append(flux_image)
         # introduce wait time to have different file names to not overwrite each other 
         time.sleep(1)
@@ -187,6 +192,9 @@ def mock_bright_dataset_files(bright_exptime, filter_used, OD, cal_factor, save_
                 # ND filter calibration requires photoelectron/s units (L3 data)
                 flux_image.ext_hdr['BUNIT'] = 'photoelectron/s'
                 flux_image.ext_hdr['DATALVL'] = 'L3'
+                # when a new target file is created the VISITID should change
+                visit_old = flux_image.pri_hdr['VISITID']
+                flux_image.pri_hdr['VISITID'] = visit_old[:-1] + str(random.randint(0,9)) 
                 bright_star_images.append(flux_image)
                 # introduce wait time to have different file names to not overwrite each other 
                 time.sleep(1)

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -32,8 +32,8 @@ def print_pass():
 # Global variables and constants
 # ---------------------------------------------------------------------------
 BRIGHT_STARS = ['Vega']
-DIM_STARS = ['TYC 4424-1286-1',
-             'GSC 02581-02323']
+DIM_STARS = ['TYC 4424-1286-1']
+            # 'GSC 02581-02323']
 
 # takes a long time to run with all stars
 #BRIGHT_STARS = ['109 Vir', 'Vega', 'Eta Uma', 'Lam Lep']

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -32,8 +32,8 @@ def print_pass():
 # Global variables and constants
 # ---------------------------------------------------------------------------
 BRIGHT_STARS = ['Vega']
-DIM_STARS = ['TYC 4424-1286-1']
-            # 'GSC 02581-02323']
+DIM_STARS = ['TYC 4424-1286-1',
+             'GSC 02581-02323']
 
 # takes a long time to run with all stars
 #BRIGHT_STARS = ['109 Vir', 'Vega', 'Eta Uma', 'Lam Lep']
@@ -481,8 +481,8 @@ def test_nd_filter_calibration_with_fluxcal(dim_dir, stars_dataset_cached, phot_
         img.ext_hdr['DATALVL'] = 'L3'
 
     # Convert list of Image objects into a Dataset
-    dim_dataset = Dataset(dim_images)
-
+    # calibrate_fluxcal_aper can only deal with on target/visitid
+    dim_dataset = Dataset([dim_images[0]])
     # 1) Generate a flux calibration object from the single image
     if phot_method == "Aperture":
         phot_kwargs = {


### PR DESCRIPTION
## Describe your changes
added function check_uniq_keyword() to check whether a header keyword is unique in a dataset. Raise error if dataset in fluxcal.calibrate_flux_xxx has no unique targets.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
#945 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
