### PR TITLE
Created L1 to NDFilterSweetSpot e2e test

### DIFF
--- a/corgidrp/astrom.py
+++ b/corgidrp/astrom.py
@@ -13,6 +13,8 @@ import pyklip.fakes as fakes
 import scipy.ndimage as ndi
 import scipy.optimize as optimize
 from scipy.optimize import OptimizeWarning
+from scipy.ndimage import median_filter
+from astropy.convolution import convolve, Gaussian2DKernel
 
 def centroid(frame):
     """
@@ -35,7 +37,7 @@ def centroid(frame):
     return xcen, ycen
 
 
-def centroid_with_roi(frame, roi_radius=5, centering_initial_guess=None):
+def centroid_with_roi(frame, roi_radius=5, centering_initial_guess=None, gaussian_kernel_size=None):
     """
     Finds the centroid in a sub-region around a given initial guess (or the brightest pixel if no guess is provided).
 
@@ -44,7 +46,8 @@ def centroid_with_roi(frame, roi_radius=5, centering_initial_guess=None):
         roi_radius (int or float): Half-size of the box around the initial guess or brightest pixel.
         centering_initial_guess (tuple or None, optional): (x_init, y_init) as initial guess for centroiding.
                                                            If None, defaults to the brightest pixel.
-
+        gaussian_kernel_size (int or None, optional): Size of the gaussian kernel convolved with the frame through before guessing the center.
+                                                    If None, no filtering is done. 
     Returns:
         tuple:
             xcen (float): X centroid coordinate.
@@ -54,7 +57,13 @@ def centroid_with_roi(frame, roi_radius=5, centering_initial_guess=None):
     # 1) Unpack initial guess or fall back to brightest pixel
     if centering_initial_guess is not None and None not in centering_initial_guess:
         peak_x, peak_y = int(round(centering_initial_guess[0])), int(round(centering_initial_guess[1]))
+    elif gaussian_kernel_size is not None:
+        # smooth out the frame before taking brightest pixel
+        kernel = Gaussian2DKernel(gaussian_kernel_size)
+        filtered_frame = convolve(frame, kernel, nan_treatment='interpolate', preserve_nan=False)
+        peak_y, peak_x = np.unravel_index(np.nanargmax(filtered_frame), frame.shape)
     else:
+        # take the brightest pixel directly with no filtering
         peak_y, peak_x = np.unravel_index(np.nanargmax(frame), frame.shape)
 
     # 2) Define the subarray (region of interest) around the peak

--- a/corgidrp/astrom.py
+++ b/corgidrp/astrom.py
@@ -24,9 +24,7 @@ def centroid(frame):
         frame (np.ndarray): 2D array to compute centering
 
     Returns:
-        tuple:
-            xcen (float): X centroid coordinate
-            ycen (float): Y centroid coordinate
+        tuple: (xcen, ycen) X and Y centroid coordinates.
 
     """
     y, x = np.indices(frame.shape)
@@ -48,10 +46,9 @@ def centroid_with_roi(frame, roi_radius=5, centering_initial_guess=None, gaussia
                                                            If None, defaults to the brightest pixel.
         gaussian_kernel_size (int or None, optional): Size of the gaussian kernel convolved with the frame through before guessing the center.
                                                     If None, no filtering is done. 
+
     Returns:
-        tuple:
-            xcen (float): X centroid coordinate.
-            ycen (float): Y centroid coordinate.
+        tuple: (xcen, ycen) X and Y centroid coordinates.
     """
 
     # 1) Unpack initial guess or fall back to brightest pixel

--- a/corgidrp/nd_filter_calibration.py
+++ b/corgidrp/nd_filter_calibration.py
@@ -232,7 +232,7 @@ def _compute_od_for_file(entry, target, phot_method, phot_kwargs, ref_fpam_name,
 
 
 def process_bright_target(target, files, cal_factor, od_raster_threshold,
-                          gaussian_kernel_size, phot_method="Aperture", phot_kwargs=None):
+                          phot_method="Aperture", phot_kwargs=None, gaussian_kernel_size=3):
     """
     Process bright star files for one target to compute optical density (OD)
     and (x, y) centroids for each dithered observation.
@@ -409,10 +409,10 @@ def create_nd_filter_cal(stars_dataset,
                          od_raster_threshold = 0.1,
                          phot_method="Aperture",
                          flux_or_irr="irr",
-                         gaussian_kernel_size=3,
                          phot_kwargs=None,
                          fluxcal_factor=None,
-                         calspec_files = None):
+                         calspec_files = None,
+                         gaussian_kernel_size=3):
     """
     Main ND Filter calibration workflow:
       1. Split dataset into dim and bright stars based on FPAMNAME keyword (or use cal factor input for dim)
@@ -427,13 +427,13 @@ def create_nd_filter_cal(stars_dataset,
         od_raster_threshold (float): Threshold for flagging OD variations.
             # TO DO: figure out what a reasonable value for this should be 
         phot_method (str): Photometry method ("Aperture" or "Gaussian").
-        flux_or_irr (str): Either 'flux' or 'irr' for the calibration approach.
-        gaussian_kernel_size (int): Size of gaussian kernel used to make the PSF centroid algorithm more robust against noise. 
+        flux_or_irr (str): Either 'flux' or 'irr' for the calibration approach. 
         phot_kwargs (dict, optional): Extra arguments for the actual photometry function 
             (e.g., aper_phot).
         fluxcal_factor (corgidrp.Data.FluxcalFactor, optional): A pre-computed flux factor calibration product to use
             if dim stars are not included as part of the input dataset
         calspec_files (list, optional): list of calspec filepaths
+        gaussian_kernel_size (int): Size of gaussian kernel used to make the PSF centroid algorithm more robust against noise.
 
     Returns:
         sweet_spot_dataset (corgidrp.Data.NDFilterSweetSpotDataset): ND Filter calibration product for the dataset given
@@ -484,8 +484,8 @@ def create_nd_filter_cal(stars_dataset,
             continue
         print(f"Processing bright target files: {target}")
         star_data = process_bright_target(target, files, cal_factor,
-                                          od_raster_threshold, gaussian_kernel_size,
-                                          phot_method, phot_kwargs)
+                                          od_raster_threshold, phot_method, 
+                                          phot_kwargs, gaussian_kernel_size=gaussian_kernel_size)
         flux_results[target] = star_data
 
         od_var_flag = star_data['flag']

--- a/corgidrp/nd_filter_calibration.py
+++ b/corgidrp/nd_filter_calibration.py
@@ -170,7 +170,7 @@ def compute_avg_calibration_factor(dim_stars_dataset, phot_method, calspec_files
 # =============================================================================
 
 def _compute_od_for_file(entry, target, phot_method, phot_kwargs, ref_fpam_name,
-                         ref_fpam_h, ref_fpam_v, ref_cfam_name, expected_flux):
+                         ref_fpam_h, ref_fpam_v, ref_cfam_name, expected_flux, gaussian_kernel_size):
     """
     Helper subfunction to:
       1. Validate FPAM/CFAM metadata vs. the reference.
@@ -188,6 +188,7 @@ def _compute_od_for_file(entry, target, phot_method, phot_kwargs, ref_fpam_name,
         ref_fpam_v (float): The reference FPAM vertical position.
         ref_cfam_name (str): The reference CFAM name for validation.
         expected_flux (float): The expected flux value for computing OD in erg/(s*cm^2)
+        gaussian_kernel_size (int): Size of gaussian kernel used to make the PSF centroid algorithm more robust against noise.  
 
     Returns:
         tuple:
@@ -211,16 +212,16 @@ def _compute_od_for_file(entry, target, phot_method, phot_kwargs, ref_fpam_name,
         )
 
     # Centroid
-    x_center, y_center = centroid_with_roi(entry.data)
+    x_center, y_center = centroid_with_roi(entry.data, gaussian_kernel_size=gaussian_kernel_size)
     if np.isnan(x_center) or np.isnan(y_center):
         print(f"Warning: Centroid could not be computed for {entry}")
         return None, None, None
 
     # Photometry
     if phot_method == "Aperture":
-        phot_result = fluxcal.aper_phot(entry, **phot_kwargs)
+        phot_result = fluxcal.aper_phot(entry, centering_initial_guess=(x_center, y_center), **phot_kwargs)
     elif phot_method == "Gaussian":
-        phot_result = fluxcal.phot_by_gauss2d_fit(entry, **phot_kwargs)
+        phot_result = fluxcal.phot_by_gauss2d_fit(entry, centering_initial_guess=(x_center, y_center), **phot_kwargs)
     else:
         raise ValueError("phot_method must be Aperture or Gaussian.")
 
@@ -231,7 +232,7 @@ def _compute_od_for_file(entry, target, phot_method, phot_kwargs, ref_fpam_name,
 
 
 def process_bright_target(target, files, cal_factor, od_raster_threshold,
-                          phot_method="Aperture", phot_kwargs=None):
+                          gaussian_kernel_size, phot_method="Aperture", phot_kwargs=None):
     """
     Process bright star files for one target to compute optical density (OD)
     and (x, y) centroids for each dithered observation.
@@ -245,6 +246,7 @@ def process_bright_target(target, files, cal_factor, od_raster_threshold,
         files (corgidrp.data.Dataset): Dataset of bright star images
         cal_factor (float or corgidrp.data.FluxcalFactor): Calibration factor.
         od_raster_threshold (float): Threshold for flagging OD variations.
+        gaussian_kernel_size (int): Size of gaussian kernel used to make the PSF centroid algorithm more robust against noise.  
         phot_method (str): Photometry method to use ("Aperture" or "Gaussian").
         phot_kwargs (dict, optional): Dictionary of keyword arguments to forward to the photometry function.
     
@@ -276,7 +278,8 @@ def process_bright_target(target, files, cal_factor, od_raster_threshold,
         od, x_center, y_center = _compute_od_for_file(entry, target, phot_method, 
                                                       phot_kwargs, common_fpam_name, 
                                                       common_fpam_h, common_fpam_v, 
-                                                      ref_cfam_name, expected_flux)
+                                                      ref_cfam_name, expected_flux,
+                                                      gaussian_kernel_size)
         
         # Skip if centroid was not valid
         if od is None:
@@ -406,6 +409,7 @@ def create_nd_filter_cal(stars_dataset,
                          od_raster_threshold = 0.1,
                          phot_method="Aperture",
                          flux_or_irr="irr",
+                         gaussian_kernel_size=3,
                          phot_kwargs=None,
                          fluxcal_factor=None,
                          calspec_files = None):
@@ -424,6 +428,7 @@ def create_nd_filter_cal(stars_dataset,
             # TO DO: figure out what a reasonable value for this should be 
         phot_method (str): Photometry method ("Aperture" or "Gaussian").
         flux_or_irr (str): Either 'flux' or 'irr' for the calibration approach.
+        gaussian_kernel_size (int): Size of gaussian kernel used to make the PSF centroid algorithm more robust against noise. 
         phot_kwargs (dict, optional): Extra arguments for the actual photometry function 
             (e.g., aper_phot).
         fluxcal_factor (corgidrp.Data.FluxcalFactor, optional): A pre-computed flux factor calibration product to use
@@ -479,8 +484,8 @@ def create_nd_filter_cal(stars_dataset,
             continue
         print(f"Processing bright target files: {target}")
         star_data = process_bright_target(target, files, cal_factor,
-                                          od_raster_threshold, phot_method,
-                                          phot_kwargs)
+                                          od_raster_threshold, gaussian_kernel_size,
+                                          phot_method, phot_kwargs)
         flux_results[target] = star_data
 
         od_var_flag = star_data['flag']

--- a/tests/e2e_tests/l1_to_nd_filter_e2e.py
+++ b/tests/e2e_tests/l1_to_nd_filter_e2e.py
@@ -39,7 +39,7 @@ def test_l1_to_nd_filter_e2e(e2edata_path, e2eoutput_path):
     
     # suppress warnings in the pipeline
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=UserWarning) # warning about OD variation
+        warnings.simplefilter("ignore", category=UserWarning) # warning about detector noisemap calibration
         warnings.simplefilter("ignore", category=RuntimeWarning) # warning about different EM gain between bright and dark frames
         walker.walk_corgidrp(l1_input_data_list, "", l2b_outputdir)
 

--- a/tests/e2e_tests/l1_to_nd_filter_e2e.py
+++ b/tests/e2e_tests/l1_to_nd_filter_e2e.py
@@ -14,7 +14,7 @@ thisfile_dir = os.path.dirname(__file__)
 @pytest.mark.e2e
 def test_l1_to_nd_filter_e2e(e2edata_path, e2eoutput_path):
     # grab input L1 data, consisting of dim (no ND) and bright (ND 475) stars
-    l1_input_data_dir = os.path.join(e2edata_path, "ND_sims")
+    l1_input_data_dir = os.path.join(e2edata_path, "ND_sims", "L1")
     l1_input_data_list = glob.glob(os.path.join(l1_input_data_dir, "*_l1_*.fits"))
 
     # Initialize a connection to the calibration database
@@ -23,8 +23,11 @@ def test_l1_to_nd_filter_e2e(e2edata_path, e2eoutput_path):
     # remove any existing caldb file so that CalDB() creates a new one
     if os.path.exists(corgidrp.caldb_filepath):
         os.remove(tmp_caldb_csv)
+
+    # grab calibration files for processing L1 data
+    cal_dir =os.path.join(e2edata_path, "ND_sims", "Cals") 
     db = caldb.CalDB()
-    db.scan_dir_for_new_entries(corgidrp.default_cal_dir)
+    db.scan_dir_for_new_entries(cal_dir)
 
     # create empty output directory
     test_outputdir = os.path.join(e2eoutput_path, "l1_to_ND_filter_e2e")
@@ -32,17 +35,12 @@ def test_l1_to_nd_filter_e2e(e2edata_path, e2eoutput_path):
         shutil.rmtree(test_outputdir)
     os.makedirs(test_outputdir)
     l2b_outputdir = os.path.join(test_outputdir, "l2b_results")
-    if not os.path.exists(l2b_outputdir):
-        os.mkdir(l2b_outputdir)
-
-    # clean up by removing old files
-    for file in os.listdir(l2b_outputdir):
-        os.remove(os.path.join(l2b_outputdir, file))
+    os.makedirs(l2b_outputdir)
     
     # suppress warnings in the pipeline
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=UserWarning)
-        warnings.simplefilter("ignore", category=RuntimeWarning)
+        warnings.simplefilter("ignore", category=UserWarning) # warning about OD variation
+        warnings.simplefilter("ignore", category=RuntimeWarning) # warning about different EM gain between bright and dark frames
         walker.walk_corgidrp(l1_input_data_list, "", l2b_outputdir)
 
 
@@ -52,8 +50,9 @@ def test_l1_to_nd_filter_e2e(e2edata_path, e2eoutput_path):
 
     recovered_od = float(nd_cal.od_values[0])  # use the first entry for the check
     assert recovered_od == pytest.approx(4.75, abs=1e-1)
-
     check.compare_to_mocks_hdrs(nd_file[0])
+    assert nd_cal.ext_hdr["DATATYPE"] == "NDFilterSweetSpotDataset"
+    assert nd_cal.ext_hdr["DATALVL"] == "CAL"
     
     # remove temporary caldb file
     os.remove(tmp_caldb_csv)

--- a/tests/e2e_tests/l1_to_nd_filter_e2e.py
+++ b/tests/e2e_tests/l1_to_nd_filter_e2e.py
@@ -6,9 +6,7 @@ import corgidrp
 import corgidrp.mocks as mocks
 import corgidrp.data as data
 import corgidrp.walker as walker
-import corgidrp.nd_filter_calibration as nd_filter_calibration
 from corgidrp import caldb, check
-from astropy.time import Time
 
 # this file's folder
 thisfile_dir = os.path.dirname(__file__)
@@ -16,7 +14,7 @@ thisfile_dir = os.path.dirname(__file__)
 @pytest.mark.e2e
 def test_l1_to_nd_filter_e2e(e2edata_path, e2eoutput_path):
     # grab input L1 data, consisting of dim (no ND) and bright (ND 475) stars
-    l1_input_data_dir = os.path.join(e2edata_path, "ND_sims", "L1")
+    l1_input_data_dir = os.path.join(e2edata_path, "ND_sims")
     l1_input_data_list = glob.glob(os.path.join(l1_input_data_dir, "*_l1_*.fits"))
 
     # Initialize a connection to the calibration database
@@ -25,16 +23,8 @@ def test_l1_to_nd_filter_e2e(e2edata_path, e2eoutput_path):
     # remove any existing caldb file so that CalDB() creates a new one
     if os.path.exists(corgidrp.caldb_filepath):
         os.remove(tmp_caldb_csv)
-
-    # grab calibration files for processing L1 data
-    cal_dir =os.path.join(e2edata_path, "ND_sims", "Cals") 
     db = caldb.CalDB()
-    db.scan_dir_for_new_entries(cal_dir)
-
-    # add detector params to caldb
-    detector_params = data.DetectorParams({}, date_valid=Time("2023-11-01 00:00:00"))
-    detector_params.save(filedir=corgidrp.config_folder)
-    db.create_entry(detector_params)
+    db.scan_dir_for_new_entries(corgidrp.default_cal_dir)
 
     # create empty output directory
     test_outputdir = os.path.join(e2eoutput_path, "l1_to_ND_filter_e2e")

--- a/tests/e2e_tests/l1_to_nd_filter_e2e.py
+++ b/tests/e2e_tests/l1_to_nd_filter_e2e.py
@@ -1,0 +1,84 @@
+import os, shutil, glob, argparse
+import pytest
+
+import corgidrp
+import corgidrp.mocks as mocks
+import corgidrp.data as data
+import corgidrp.walker as walker
+import corgidrp.nd_filter_calibration as nd_filter_calibration
+from corgidrp import caldb, check
+from astropy.time import Time
+
+# this file's folder
+thisfile_dir = os.path.dirname(__file__)
+
+@pytest.mark.e2e
+def test_l1_to_nd_filter_e2e(e2edata_path, e2eoutput_path):
+    # grab input L1 data, consisting of dim (no ND) and bright (ND 475) stars
+    l1_input_data_dir = os.path.join(e2edata_path, "ND_sims", "L1")
+    l1_input_data_list = glob.glob(os.path.join(l1_input_data_dir, "*_l1_*.fits"))
+
+    # Initialize a connection to the calibration database
+    tmp_caldb_csv = os.path.join(corgidrp.config_folder, 'tmp_e2e_test_caldb.csv')
+    corgidrp.caldb_filepath = tmp_caldb_csv
+    # remove any existing caldb file so that CalDB() creates a new one
+    if os.path.exists(corgidrp.caldb_filepath):
+        os.remove(tmp_caldb_csv)
+
+    # grab calibration files for processing L1 data
+    cal_dir =os.path.join(e2edata_path, "ND_sims", "Cals") 
+    db = caldb.CalDB()
+    db.scan_dir_for_new_entries(cal_dir)
+
+    # add detector params to caldb
+    detector_params = data.DetectorParams({}, date_valid=Time("2023-11-01 00:00:00"))
+    detector_params.save(filedir=corgidrp.config_folder)
+    db.create_entry(detector_params)
+
+    # create empty output directory
+    test_outputdir = os.path.join(e2eoutput_path, "l1_to_ND_filter_e2e")
+    if os.path.exists(test_outputdir):
+        shutil.rmtree(test_outputdir)
+    os.makedirs(test_outputdir)
+    l2b_outputdir = os.path.join(test_outputdir, "l2b_results")
+    if not os.path.exists(l2b_outputdir):
+        os.mkdir(l2b_outputdir)
+
+    # clean up by removing old files
+    for file in os.listdir(l2b_outputdir):
+        os.remove(os.path.join(l2b_outputdir, file))
+    
+    # run walker
+    walker.walk_corgidrp(l1_input_data_list, "", l2b_outputdir)
+
+    """
+    # 5. Load product & assert if calculated OD matches the input
+    nd_file = glob.glob(os.path.join(simdata_dir, "*_ndf_cal*.fits"))
+    nd_cal  = data.NDFilterSweetSpotDataset(nd_file[0])
+
+    recovered_od = float(nd_cal.od_values[0])  # use the first entry for the check
+    print("Calculated OD:", recovered_od)
+    print("Input OD:", od_truth)
+    assert recovered_od == pytest.approx(od_truth, abs=1e-1)
+
+    check.compare_to_mocks_hdrs(nd_file[0])
+    """
+    
+    # remove temporary caldb file
+    os.remove(tmp_caldb_csv)
+
+    print("ND‑filter E2E test passed")
+
+# ----------------------------------------------------------------------
+if __name__ == "__main__":
+    outputdir = thisfile_dir
+    e2edata_path = '/home/eshen12345/dev/E2E_Test_Data'
+
+    ap = argparse.ArgumentParser(description='run the l1 to NDFilterSweetSpot end-to-end test')
+    ap.add_argument('-e2e', '--e2edata_dir', default=e2edata_path,
+                    help='Path to test Data Folder [%(default)s]')
+    ap.add_argument('-o', '--outputdir', default=outputdir,
+                    help='directory to write results to [%(default)s]')
+    args = ap.parse_args()
+    outputdir = args.outputdir
+    test_l1_to_nd_filter_e2e(args.e2edata_dir, args.outputdir)

--- a/tests/e2e_tests/l1_to_nd_filter_e2e.py
+++ b/tests/e2e_tests/l1_to_nd_filter_e2e.py
@@ -1,5 +1,6 @@
 import os, shutil, glob, argparse
 import pytest
+import warnings
 
 import corgidrp
 import corgidrp.mocks as mocks
@@ -48,26 +49,26 @@ def test_l1_to_nd_filter_e2e(e2edata_path, e2eoutput_path):
     for file in os.listdir(l2b_outputdir):
         os.remove(os.path.join(l2b_outputdir, file))
     
-    # run walker
-    walker.walk_corgidrp(l1_input_data_list, "", l2b_outputdir)
+    # suppress warnings in the pipeline
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        walker.walk_corgidrp(l1_input_data_list, "", l2b_outputdir)
 
-    """
-    # 5. Load product & assert if calculated OD matches the input
-    nd_file = glob.glob(os.path.join(simdata_dir, "*_ndf_cal*.fits"))
+
+    # 5. Load product & assert if calculated OD matches what is expected
+    nd_file = glob.glob(os.path.join(l2b_outputdir, "*_ndf_cal*.fits"))
     nd_cal  = data.NDFilterSweetSpotDataset(nd_file[0])
 
     recovered_od = float(nd_cal.od_values[0])  # use the first entry for the check
-    print("Calculated OD:", recovered_od)
-    print("Input OD:", od_truth)
-    assert recovered_od == pytest.approx(od_truth, abs=1e-1)
+    assert recovered_od == pytest.approx(4.75, abs=1e-1)
 
     check.compare_to_mocks_hdrs(nd_file[0])
-    """
     
     # remove temporary caldb file
     os.remove(tmp_caldb_csv)
 
-    print("ND‑filter E2E test passed")
+    print("L1 to ND‑filter E2E test passed")
 
 # ----------------------------------------------------------------------
 if __name__ == "__main__":


### PR DESCRIPTION
## Describe your changes
- Created a new E2E test to test running L1 corgisim data through the DRP to obtain an NDFilterSweetSpot calibration
- Check that the output calibration file is formatted correctly and the calculated OD is correct
- The dataset consists of a set of unocculted simulations of dim and bright targets. Bright targets were simulated with the ND475 filter
- Uploaded simulated dataset to the E2E testing dropbox folder


## Reference any relevant issues (don't forget the #)
#707 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
