### PR TITLE
added L1 to polcal e2e test and fixed bugs during testing

### DIFF
--- a/corgidrp/fluxcal.py
+++ b/corgidrp/fluxcal.py
@@ -364,9 +364,24 @@ def aper_phot(image, encircled_radius, frac_enc_energy=1., method='subpixel', su
         method=method,
         subpixels=subpixels
     )
+
+    # compute renormalization factor to account for lost flux if significant amount of NaN shows up in the aperture (for example cosmic rays)
+    # sum all good pixels (non NaNs) over the aperture
+    good_pixels = aper.do_photometry(
+        (~image.dq.astype(bool)).astype(float),
+        method=method,
+        subpixels=subpixels
+    )[0][0]
+
+    # find fraction of the aperture without NaNs
+    if good_pixels > 0:
+        correction_factor = aper.area / good_pixels
+    else:
+        # edge case where the aperture is all NaN, propagate NaN instead of a count of 0
+        correction_factor = np.nan
     
-    flux = aperture_sums[0] / frac_enc_energy
-    flux_err = aperture_sums_errs[0] / frac_enc_energy
+    flux = (correction_factor * aperture_sums[0]) / frac_enc_energy
+    flux_err = (correction_factor * aperture_sums_errs[0]) / frac_enc_energy
     
     if background_sub:
         return flux, flux_err, back

--- a/corgidrp/fluxcal.py
+++ b/corgidrp/fluxcal.py
@@ -364,24 +364,9 @@ def aper_phot(image, encircled_radius, frac_enc_energy=1., method='subpixel', su
         method=method,
         subpixels=subpixels
     )
-
-    # compute renormalization factor to account for lost flux if significant amount of NaN shows up in the aperture (for example cosmic rays)
-    # sum all good pixels (non NaNs) over the aperture
-    good_pixels = aper.do_photometry(
-        (~image.dq.astype(bool)).astype(float),
-        method=method,
-        subpixels=subpixels
-    )[0][0]
-
-    # find fraction of the aperture without NaNs
-    if good_pixels > 0:
-        correction_factor = aper.area / good_pixels
-    else:
-        # edge case where the aperture is all NaN, propagate NaN instead of a count of 0
-        correction_factor = np.nan
     
-    flux = (correction_factor * aperture_sums[0]) / frac_enc_energy
-    flux_err = (correction_factor * aperture_sums_errs[0]) / frac_enc_energy
+    flux = aperture_sums[0] / frac_enc_energy
+    flux_err = aperture_sums_errs[0] / frac_enc_energy
     
     if background_sub:
         return flux, flux_err, back
@@ -496,9 +481,13 @@ def calibrate_fluxcal_aper(dataset_or_image, calspec_file = None, flux_or_irr = 
     """
     d_or_i = dataset_or_image.copy()
     if isinstance(d_or_i, corgidrp.data.Dataset):
-        #take the median of images in the dataset
-        image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
-        dataset = d_or_i
+        uni, uni_list = corgidrp.check.check_uniq_keyword(d_or_i, "VISITID")
+        if uni:
+            #take the median of images in the dataset
+            image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
+            dataset = d_or_i
+        else:
+            raise AttributeError("dataset of different VISITIDs {0} cannot be medianed".format(uni_list))
     else:
         image = d_or_i
         dataset = corgidrp.data.Dataset([image])
@@ -628,9 +617,13 @@ def calibrate_pol_fluxcal_aper(dataset_or_image,
     """
     d_or_i = dataset_or_image.copy()
     if isinstance(d_or_i, corgidrp.data.Dataset):
-        #take the mean of images in the dataset
-        image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
-        dataset = d_or_i
+        uni, uni_list = corgidrp.check.check_uniq_keyword(d_or_i, "VISITID")
+        if uni:
+            #take the median of images in the dataset
+            image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
+            dataset = d_or_i
+        else:
+            raise AttributeError("dataset of different VISITIDs {0} cannot be medianed".format(uni_list))
     else:
         image = d_or_i
         dataset = corgidrp.data.Dataset([image])
@@ -864,9 +857,13 @@ def calibrate_fluxcal_gauss2d(dataset_or_image, calspec_file = None, flux_or_irr
     """
     d_or_i = dataset_or_image.copy()
     if isinstance(d_or_i, corgidrp.data.Dataset):
-        #take the mean of images in the dataset
-        image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
-        dataset = d_or_i
+        uni, uni_list = corgidrp.check.check_uniq_keyword(d_or_i, "VISITID")
+        if uni:
+            #take the median of images in the dataset
+            image = combine_subexposures(d_or_i, collapse = "median", num_frames_scaling=False)[0]
+            dataset = d_or_i
+        else:
+            raise AttributeError("dataset of different VISITIDs {0} cannot be medianed".format(uni_list))
     else:
         image = d_or_i
         dataset = corgidrp.data.Dataset([image])

--- a/corgidrp/pol.py
+++ b/corgidrp/pol.py
@@ -279,15 +279,13 @@ def generate_mueller_matrix_cal(input_dataset,
     # extract the target names
     pol_ref_targets = pol_ref["TARGET"].tolist()
 
-    # split the datasets into different targets
-    _, targets = dataset.split_dataset(prihdr_keywords=["TARGET"])
+    frame_targets = [image.pri_hdr["TARGET"] for image in dataset]
 
-    n_targets = np.unique(targets).shape[0]
     # check that all the targets from the dataset are in the pol reference file
-    for target in targets:
+    for target in frame_targets:
         if target not in pol_ref_targets:
             raise ValueError(f"Target {target} not found in polarization reference file.")
-    
+
     # measure the normalized difference for each dataset
     stokes_vectors = []
     stokes_vector_errs = []
@@ -302,11 +300,12 @@ def generate_mueller_matrix_cal(input_dataset,
 
     # generate the matrix of meausurements six columns [1 q_star, u_star, 0,0,0] for q_measured
     # and [0,0,0, 1, q_star, u_star] for u_measured #Where Q and U have been rotated by the PA_APER angle: 
-    Q_ref_err_sq = np.zeros(len(targets))
-    U_ref_err_sq = np.zeros(len(targets))
-    cov_QU_ref = np.zeros(len(targets))
+    Q_ref_err_sq = np.zeros(len(dataset))
+    U_ref_err_sq = np.zeros(len(dataset))
+    cov_QU_ref = np.zeros(len(dataset))
     stokes_matrix = np.zeros((2*len(dataset), 6))
-    for i, target in enumerate(targets):
+    for i, image in enumerate(dataset):
+        target = image.pri_hdr["TARGET"]
         pol_row = pol_ref[pol_ref["TARGET"] == target]
         P = pol_row["P"].values[0] / 100.0 # convert from percent to fraction
         PA = pol_row["PA"].values[0] + rotation_angles[i] # in degrees
@@ -357,7 +356,7 @@ def generate_mueller_matrix_cal(input_dataset,
     #   Var(m_k) += c_Q^2 * Var(Q_ref) + 2*c_Q*c_U * Cov(Q_ref,U_ref) + c_U^2 * Var(U_ref)
     # where c_Q = A^+[k,2i]*m[1] + A^+[k,2i+1]*m[4], c_U = A^+[k,2i]*m[2] + A^+[k,2i+1]*m[5].
     ref_var = np.zeros(6)
-    for i in range(len(targets)):
+    for i in range(len(dataset)):
         c_Q = (stokes_matrix_inv[:, 2*i]   * mueller_elements[1] +
                stokes_matrix_inv[:, 2*i+1] * mueller_elements[4])
         c_U = (stokes_matrix_inv[:, 2*i]   * mueller_elements[2] +

--- a/tests/e2e_tests/l1_to_polcal_e2e.py
+++ b/tests/e2e_tests/l1_to_polcal_e2e.py
@@ -1,0 +1,93 @@
+# E2E test for sim L1 pol data to mueller matrix calibration
+import os, shutil, glob, argparse
+import pytest
+import warnings
+import numpy as np
+import corgidrp
+import corgidrp.mocks as mocks
+import corgidrp.data as data
+import corgidrp.walker as walker
+from corgidrp import caldb, check
+
+# this file's folder
+thisfile_dir = os.path.dirname(__file__)
+
+@pytest.mark.e2e
+def test_l1_to_polcal_e2e(e2edata_path, e2eoutput_path):
+    # grab input L1 data, consisting of unocculted unpolarized and polarized stars using ND225 
+    l1_input_data_dir = os.path.join(e2edata_path, "mueller_matrix_sims", "L1")
+    l1_input_data_list = glob.glob(os.path.join(l1_input_data_dir, "*_l1_*.fits"))
+
+    # Initialize a connection to the calibration database
+    tmp_caldb_csv = os.path.join(corgidrp.config_folder, 'tmp_e2e_test_caldb.csv')
+    corgidrp.caldb_filepath = tmp_caldb_csv
+    # remove any existing caldb file so that CalDB() creates a new one
+    if os.path.exists(corgidrp.caldb_filepath):
+        os.remove(tmp_caldb_csv)
+
+    # grab polarimetric calibration files
+    cal_dir =os.path.join(e2edata_path, "mueller_matrix_sims", "Cals") 
+    db = caldb.CalDB()
+    db.scan_dir_for_new_entries(cal_dir) # polarimetric calibration files
+    # db.scan_dir_for_new_entries(corgidrp.default_cal_dir) # grab other default files needed
+
+    # create empty output directory
+    test_outputdir = os.path.join(e2eoutput_path, "l1_to_polcal_e2e")
+    if os.path.exists(test_outputdir):
+        shutil.rmtree(test_outputdir)
+    os.makedirs(test_outputdir)
+    l2b_outputdir = os.path.join(test_outputdir, "l2b_results")
+    os.makedirs(l2b_outputdir)
+
+    with warnings.catch_warnings():
+        # suppress warning about number of detectornoisemap frames
+        warnings.simplefilter("ignore", category=UserWarning)
+        # suppress warnings about frames having different header values
+        # warnings.simplefilter("ignore", category=RuntimeWarning)
+        walker.walk_corgidrp(l1_input_data_list, "", l2b_outputdir)
+    
+
+    # grab calibration file
+    mm_file = glob.glob(os.path.join(l2b_outputdir, '*ndm_cal*.fits'))[0]
+    mueller_matrix = data.NDMuellerMatrix(mm_file)
+    mm = mueller_matrix.data
+
+    # check the mueller matrix elements against the normalized mueller matrix used in corgisim to create the input files
+    # also skip circular polarization elements (row/column 4) since that cannot be detected and calibrated for
+    assert mm[0,0] == 1 # I->I should be normalized to 1
+    # for main diagonal elements, check it is within 5% accuracy
+    rtol = 0.05
+    assert mm[1,1] == pytest.approx(-0.99995, rel=rtol)
+    assert mm[2,2] == pytest.approx(0.99455, rel=rtol)
+
+    # for off-diagonal elements which are basically 0 and noisier, check with absolute tolerance
+    atol = 0.1
+    assert mm[0,1] == pytest.approx(0.00926, abs=atol)
+    assert mm[0,2] == pytest.approx(0.00000, abs=atol)
+    assert mm[1,0] == pytest.approx(-0.00926, abs=atol)
+    assert mm[1,2] == pytest.approx(0.00001, abs=atol)
+    assert mm[2,0] == pytest.approx(0.00000, abs=atol)
+    assert mm[2,1] == pytest.approx(0.00000, abs=atol)
+
+    # check headers
+    check.compare_to_mocks_hdrs(mm_file)
+    assert mueller_matrix.ext_hdr["FPAMNAME"] == "ND225" # input data uses ND225 filter
+    assert mueller_matrix.ext_hdr["DATALVL"] == "CAL"
+    assert mueller_matrix.ext_hdr["DATATYPE"] == "NDMuellerMatrix"
+
+    os.remove(tmp_caldb_csv)
+
+    print("L1 to polcal E2E test passed")
+
+if __name__ == "__main__":
+    outputdir = thisfile_dir
+    e2edata_path = '/home/eshen12345/dev/E2E_Test_Data'
+
+    ap = argparse.ArgumentParser(description='run the l1 to mueller matrix calibration end-to-end test')
+    ap.add_argument('-e2e', '--e2edata_dir', default=e2edata_path,
+                    help='Path to test Data Folder [%(default)s]')
+    ap.add_argument('-o', '--outputdir', default=outputdir,
+                    help='directory to write results to [%(default)s]')
+    args = ap.parse_args()
+    outputdir = args.outputdir
+    test_l1_to_polcal_e2e(args.e2edata_dir, args.outputdir)

--- a/tests/e2e_tests/l1_to_polcal_e2e.py
+++ b/tests/e2e_tests/l1_to_polcal_e2e.py
@@ -42,8 +42,6 @@ def test_l1_to_polcal_e2e(e2edata_path, e2eoutput_path):
     with warnings.catch_warnings():
         # suppress warning about number of detectornoisemap frames
         warnings.simplefilter("ignore", category=UserWarning)
-        # suppress warnings about frames having different header values
-        # warnings.simplefilter("ignore", category=RuntimeWarning)
         walker.walk_corgidrp(l1_input_data_list, "", l2b_outputdir)
     
 
@@ -53,7 +51,7 @@ def test_l1_to_polcal_e2e(e2edata_path, e2eoutput_path):
     mm = mueller_matrix.data
 
     # check the mueller matrix elements against the normalized mueller matrix used in corgisim to create the input files
-    # also skip circular polarization elements (row/column 4) since that cannot be detected and calibrated for
+    # skip circular polarization elements (row/column 4) since that cannot be detected and calibrated for
     assert mm[0,0] == 1 # I->I should be normalized to 1
     # for main diagonal elements, check it is within 5% accuracy
     rtol = 0.05


### PR DESCRIPTION
## Describe your changes
- Added a L1 to mueller matrix calibration e2e test starting from simulated L1 pol data (unocculted polarized and unpolarized stars with ND225 filter)
- uploaded relevant test files to the sharepoint
- Fixed bug in `generate_mueller_matrix_cal` where the number of rows in the measurement matrix is determined by the length of the input dataset but the number of rows that actually get filled with measurement data is determined by the number of unique targets in the observation sequence. This creates an issue where the measurement matrix isn't filled up correctly if there are more input data frames than there are unique targets (for example same target observed with different roll angles). The fix is to simply keep everything referenced to the length of the input dataset rather than the number of unique targets. 
- Made a change to the `aper_phot` function to account for undercounted flux if a large chunk of the aperture consists of bad pixels (most common example being cosmic rays). Currently, the aperture photometry sum does not include pixel values from pixels flagged by the DQ extension, but the flux is always computed with reference to the full aperture size even if a sizable chunk of the aperture didn't contribute to the count. This creates an issue for polarimetric calibration, where if a cosmic ray lands on one of the two Wollaston spots and gets masked out with NaNs, the flux from that spot gets undercounted. The pipeline interprets this as a severe polarization aberration and spits out unphysical values for the Mueller matrix. To account for this to the first order, I modified the pipeline to count the number of bad pixels in the aperture so that the flux is normalized by the ratio of the full aperture size to the effective aperture size with the area taken up by bad pixels removed. (might be better ways of doing this and might want to make this into an optional step since not every single operation requiring aperture photometry might benefit from this, but for now I have it hard coded) Also should I add this change to the list of PRs that could affect existing VAP tests?

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
#708 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
