### PR TITLE
accommodate new version of emccd_detect

### DIFF
--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -2035,7 +2035,15 @@ def generate_mock_pump_trap_data(output_dir,meta_path, EMgain=10,
             eperdn=eperdn,
             nbits=nbits,
             numel_gain_register=604,
-            meta_path=meta_path
+            meta_path=meta_path,
+            upstream_spill_prob=None,
+            fpn_path=None,
+            bias_sigma_row=0,
+            bias_sigma_col=0,
+            fast_gain_mode=True,
+            row_read_time=0,
+            gain_CIC_Q=0,
+            tail_length=40
         )
     #190K: gain of 10-20
     emccd[190] = EMCCDDetect(
@@ -2052,7 +2060,15 @@ def generate_mock_pump_trap_data(output_dir,meta_path, EMgain=10,
             eperdn=eperdn,
             nbits=nbits,
             numel_gain_register=604,
-            meta_path=meta_path
+            meta_path=meta_path,
+            upstream_spill_prob=None,
+            fpn_path=None,
+            bias_sigma_row=0,
+            bias_sigma_col=0,
+            fast_gain_mode=True,
+            row_read_time=0,
+            gain_CIC_Q=0,
+            tail_length=40
         )
     #195K: gain of 10-20
     # emccd[195] = EMCCDDetect(
@@ -2086,7 +2102,15 @@ def generate_mock_pump_trap_data(output_dir,meta_path, EMgain=10,
             eperdn=eperdn,
             nbits=nbits,
             numel_gain_register=604,
-            meta_path=meta_path
+            meta_path=meta_path,
+            upstream_spill_prob=None,
+            fpn_path=None,
+            bias_sigma_row=0,
+            bias_sigma_col=0,
+            fast_gain_mode=True,
+            row_read_time=0,
+            gain_CIC_Q=0,
+            tail_length=40
         )
     #210K: gain of 10-20
     emccd[210] = EMCCDDetect(
@@ -2103,7 +2127,15 @@ def generate_mock_pump_trap_data(output_dir,meta_path, EMgain=10,
             eperdn=eperdn,
             nbits=nbits,
             numel_gain_register=604,
-            meta_path=meta_path
+            meta_path=meta_path,
+            upstream_spill_prob=None,
+            fpn_path=None,
+            bias_sigma_row=0,
+            bias_sigma_col=0,
+            fast_gain_mode=True,
+            row_read_time=0,
+            gain_CIC_Q=0,
+            tail_length=40
         )
     #220K: gain of 10-20
     emccd[220] = EMCCDDetect(
@@ -2120,7 +2152,16 @@ def generate_mock_pump_trap_data(output_dir,meta_path, EMgain=10,
             eperdn=eperdn,
             nbits=nbits,
             numel_gain_register=604,
-            meta_path=meta_path
+            meta_path=meta_path,
+            upstream_spill_prob=None,
+            fpn_path=None,
+            bias_sigma_row=0,
+            bias_sigma_col=0,
+            fast_gain_mode=True,
+            row_read_time=0,
+            gain_CIC_Q=0,
+            tail_length=40
+            
         )
 
     #when tauc is 3e-3, that gives a mean e- field of 2090 e-
@@ -2681,7 +2722,15 @@ def generate_mock_pump_trap_data(output_dir,meta_path, EMgain=10,
                 nbits=nbits,
                 numel_gain_register=604,
                 meta_path=meta_path,
-                nonlin_path=nonlin_path
+                nonlin_path=nonlin_path,
+                upstream_spill_prob=None,
+                fpn_path=None,
+                bias_sigma_row=0,
+                bias_sigma_col=0,
+                fast_gain_mode=True,
+                row_read_time=0,
+                gain_CIC_Q=0,
+                tail_length=40
                 )
         # save to FITS files
         for sc in [1,2,3,4]:
@@ -2693,7 +2742,7 @@ def generate_mock_pump_trap_data(output_dir,meta_path, EMgain=10,
                     gain_counts = np.reshape(readout_emccd._gain_register_elements(temps[temp][sc][i].ravel()),temps[temp][sc][i].shape)
                     if gain_counts.any() >= full_well_serial:
                         raise Exception('Saturated after EM gain applied.')
-                    output_dn = readout_emccd.readout(gain_counts)
+                    output_dn = readout_emccd.readout(gain_counts,frametime)
                 else:
                     output_dn = temps[temp][sc][i]
                 prihdr, exthdr = create_default_L1_TrapPump_headers(arrtype)
@@ -2781,7 +2830,15 @@ def create_photon_countable_frames(Nbrights=30, Ndarks=40, EMgain=5000., kgain=7
         pixel_pitch=13e-6,  # m
         eperdn=kgain,
         nbits=64, # number of ADU bits
-        numel_gain_register=604 #number of gain register elements
+        numel_gain_register=604, #number of gain register elements
+        upstream_spill_prob=None,
+        fpn_path=None,
+        bias_sigma_row=0,
+        bias_sigma_col=0,
+        fast_gain_mode=True,
+        row_read_time=0,
+        gain_CIC_Q=0,
+        tail_length=40
         )
 
     thresh = emccd.em_gain/10 # threshold

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ scipy
 photutils >= 3.0.0
 statsmodels
 pyklip
-emccd-detect >= 2.5.0
+emccd-detect >= 2.6.1
 tqdm
 termcolor


### PR DESCRIPTION
## Describe your changes
I changed the specification of the calls to emccd_detect to be consistent with the calls to the previous version of emccd-detect so that the tests pass.  The only calls to emccd-detect in the DRP are made in 2 functions in mocks.py: generate_mock_pump_trap_data and create_photon_countable_frames.  I changed requirements.txt to specify emccd-detect >= 2.6.1.  The Linux issue with FPN_path vs fpn_path is also resolved in version 2.6.1 of emccd-detect (its latest version).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
N/A

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
