### PR TITLE
added test for regular Mueller matrix calibration in L1 to polcal e2e

### DIFF
--- a/tests/e2e_tests/l1_to_polcal_e2e.py
+++ b/tests/e2e_tests/l1_to_polcal_e2e.py
@@ -13,9 +13,9 @@ from corgidrp import caldb, check
 thisfile_dir = os.path.dirname(__file__)
 
 @pytest.mark.e2e
-def test_l1_to_polcal_e2e(e2edata_path, e2eoutput_path):
+def test_l1_to_nd_polcal_e2e(e2edata_path, e2eoutput_path):
     # grab input L1 data, consisting of unocculted unpolarized and polarized stars using ND225 
-    l1_input_data_dir = os.path.join(e2edata_path, "mueller_matrix_sims", "L1")
+    l1_input_data_dir = os.path.join(e2edata_path, "mueller_matrix_sims", "L1_ND")
     l1_input_data_list = glob.glob(os.path.join(l1_input_data_dir, "*_l1_*.fits"))
 
     # Initialize a connection to the calibration database
@@ -32,7 +32,7 @@ def test_l1_to_polcal_e2e(e2edata_path, e2eoutput_path):
     # db.scan_dir_for_new_entries(corgidrp.default_cal_dir) # grab other default files needed
 
     # create empty output directory
-    test_outputdir = os.path.join(e2eoutput_path, "l1_to_polcal_e2e")
+    test_outputdir = os.path.join(e2eoutput_path, "l1_to_ND_polcal_e2e")
     if os.path.exists(test_outputdir):
         shutil.rmtree(test_outputdir)
     os.makedirs(test_outputdir)
@@ -75,6 +75,69 @@ def test_l1_to_polcal_e2e(e2edata_path, e2eoutput_path):
 
     os.remove(tmp_caldb_csv)
 
+    print("L1 to ND polcal E2E test passed")
+
+@pytest.mark.e2e
+def test_l1_to_polcal_e2e(e2edata_path, e2eoutput_path):
+    # grab input L1 data, consisting of unocculted unpolarized and polarized stars using ND225 
+    l1_input_data_dir = os.path.join(e2edata_path, "mueller_matrix_sims", "L1_non_ND")
+    l1_input_data_list = glob.glob(os.path.join(l1_input_data_dir, "*_l1_*.fits"))
+
+    # Initialize a connection to the calibration database
+    tmp_caldb_csv = os.path.join(corgidrp.config_folder, 'tmp_e2e_test_caldb.csv')
+    corgidrp.caldb_filepath = tmp_caldb_csv
+    # remove any existing caldb file so that CalDB() creates a new one
+    if os.path.exists(corgidrp.caldb_filepath):
+        os.remove(tmp_caldb_csv)
+
+    # grab polarimetric calibration files
+    cal_dir =os.path.join(e2edata_path, "mueller_matrix_sims", "Cals") 
+    db = caldb.CalDB()
+    db.scan_dir_for_new_entries(cal_dir) # polarimetric calibration files
+    # db.scan_dir_for_new_entries(corgidrp.default_cal_dir) # grab other default files needed
+
+    # create empty output directory
+    test_outputdir = os.path.join(e2eoutput_path, "l1_to_polcal_e2e")
+    if os.path.exists(test_outputdir):
+        shutil.rmtree(test_outputdir)
+    os.makedirs(test_outputdir)
+    l2b_outputdir = os.path.join(test_outputdir, "l2b_results")
+    os.makedirs(l2b_outputdir)
+
+    with warnings.catch_warnings():
+        # suppress warning about number of detectornoisemap frames
+        warnings.simplefilter("ignore", category=UserWarning)
+        walker.walk_corgidrp(l1_input_data_list, "", l2b_outputdir)
+    
+
+    # grab calibration file
+    mm_file = glob.glob(os.path.join(l2b_outputdir, '*mmx_cal*.fits'))[0]
+    mueller_matrix = data.MuellerMatrix(mm_file)
+    mm = mueller_matrix.data
+
+    # check the mueller matrix elements against the normalized mueller matrix used in corgisim to create the input files
+    assert mm[0,0] == 1 # I->I should be normalized to 1
+
+    rtol = 0.075
+    assert mm[1,1] == pytest.approx(-0.99995, rel=rtol)
+    assert mm[2,2] == pytest.approx(0.99455, rel=rtol)
+
+    atol = 0.1
+    assert mm[0,1] == pytest.approx(0.00926, abs=atol)
+    assert mm[0,2] == pytest.approx(0.00000, abs=atol)
+    assert mm[1,0] == pytest.approx(-0.00926, abs=atol)
+    assert mm[1,2] == pytest.approx(0.00001, abs=atol)
+    assert mm[2,0] == pytest.approx(0.00000, abs=atol)
+    assert mm[2,1] == pytest.approx(0.00000, abs=atol)
+
+    # check headers
+    check.compare_to_mocks_hdrs(mm_file)
+    assert mueller_matrix.ext_hdr["FPAMNAME"] == "OPEN"
+    assert mueller_matrix.ext_hdr["DATALVL"] == "CAL"
+    assert mueller_matrix.ext_hdr["DATATYPE"] == "MuellerMatrix"
+
+    os.remove(tmp_caldb_csv)
+
     print("L1 to polcal E2E test passed")
 
 if __name__ == "__main__":
@@ -88,4 +151,6 @@ if __name__ == "__main__":
                     help='directory to write results to [%(default)s]')
     args = ap.parse_args()
     outputdir = args.outputdir
+
+    test_l1_to_nd_polcal_e2e(args.e2edata_dir, args.outputdir)
     test_l1_to_polcal_e2e(args.e2edata_dir, args.outputdir)


### PR DESCRIPTION
## Describe your changes
- In addition to testing the generation of ND Mueller matrix calibration file, `l1_to_polcal_e2e` now also tests the generation of regular Mueller matrix calibration files with Corgisim input data simulated without the ND filter
- Restructured the E2E data sharepoint to have subfolders for the non ND and ND data

## Reference any relevant issues (don't forget the #)
#964 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
