### PR TITLE
Skip subtract_no_offset_frames warning when already False

### DIFF
--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -1082,8 +1082,9 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
     if not dpamname.startswith("PRISM"):
         raise AttributeError("This is not a spectroscopic observation. but {0}").format(dpamname)
     if dataset.frames[0].ext_hdr["FPAMNAME"] == 'OPEN_34':
-        warnings.warn("The dataset has FPAMNAME = OPEN_34, identicating that this is a non-coronagraphic spectroscopy observation, setting subtract_no_offset_frames = False")
-        subtract_no_offset_frames = False
+        if subtract_no_offset_frames:
+            warnings.warn("The dataset has FPAMNAME = OPEN_34, identicating that this is a non-coronagraphic spectroscopy observation, setting subtract_no_offset_frames = False")
+            subtract_no_offset_frames = False
 
     # Assumed that only narrowband filter (includes sat spots) frames are taken to fit the zeropoint
     narrow_dataset, band = dataset.split_dataset(exthdr_keywords=["CFAMNAME"])

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -560,7 +560,10 @@ def test_determine_zeropoint():
 
     #test it as non-coronagraphic observation of only psf narrowband, so no science frames, a print statement should be raised
     input_dataset2 = Dataset(psf_images)
-    dataset = l3_to_l4.determine_wave_zeropoint(input_dataset2, spec_filter_offset, subtract_no_offset_frames=False)
+    #passing subtract_no_offset_frames=False on OPEN_34 data should not warn about setting it to False, since it is already False
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        dataset = l3_to_l4.determine_wave_zeropoint(input_dataset2, spec_filter_offset, subtract_no_offset_frames=False)
     assert len(dataset) > 0
     
     #only 1 fake science dataset frame


### PR DESCRIPTION
## Describe your changes

`determine_wave_zeropoint` warns "setting subtract_no_offset_frames = False" whenever `FPAMNAME == OPEN_34` (non-coronagraphic data), even when the caller already passed `subtract_no_offset_frames=False`. In that case the value is not actually being changed, so the warning is misleading. This only emits the warning (and reassigns) when `subtract_no_offset_frames` is still `True`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)

Closes #969

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
