### PR TITLE
fix: only warn about setting subtract_no_offset_frames=False when it is actually being changed

### DIFF
--- a/corgidrp/l3_to_l4.py
+++ b/corgidrp/l3_to_l4.py
@@ -1081,7 +1081,7 @@ def determine_wave_zeropoint(input_dataset, spec_filter_offset, template_dataset
     dpamname = dataset.frames[0].ext_hdr["DPAMNAME"]
     if not dpamname.startswith("PRISM"):
         raise AttributeError("This is not a spectroscopic observation. but {0}").format(dpamname)
-    if dataset.frames[0].ext_hdr["FPAMNAME"] == 'OPEN_34':
+    if dataset.frames[0].ext_hdr["FPAMNAME"] == 'OPEN_34' and subtract_no_offset_frames:
         warnings.warn("The dataset has FPAMNAME = OPEN_34, identicating that this is a non-coronagraphic spectroscopy observation, setting subtract_no_offset_frames = False")
         subtract_no_offset_frames = False
 


### PR DESCRIPTION
# fix: only warn about setting subtract_no_offset_frames=False when it is actually being changed

## Summary

The determine_wave_zeropoint function in corgidrp/l3_to_l4.py was issuing an unnecessary warning when the subtract_no_offset_frames parameter was already set to False and the FPAMNAME header was 'OPEN_34'. This fix adds a condition to only warn when the parameter is actually being changed from True to False.

Fixes #969

## Changes

- Modified the condition in determine_wave_zeropoint (line 1084) to only show the warning about setting subtract_no_offset_frames=False when FPAMNAME='OPEN_34' AND subtract_no_offset_frames is currently True
- This prevents unnecessary warnings when the parameter is already False

## Testing

- Verified the change introduces no syntax errors by running: python3 -m py_compile corgidrp/l3_to_l4.py
- Confirmed the logic is correct:
  - When FPAMNAME='OPEN_34' and subtract_no_offset_frames=True: Warning is shown and parameter set to False
  - When FPAMNAME='OPEN_34' and subtract_no_offset_frames=False: No warning, parameter unchanged
  - When FPAMNAME!='OPEN_34': No warning, parameter unchanged
- Existing test cases in tests/test_spec.py that use FPAMNAME='OPEN_34' with subtract_no_offset_frames=False will now pass without generating warnings

### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
