### PR TITLE
Fix incorrect input filepath

### DIFF
--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -373,10 +373,10 @@ def autogen_recipe(filelist, outputdir, template=None):
                         for partial_dataset, isPc in zip(split_datasets, unique_vals):
                             if "pc" in recipe["name"] and isPc == 1:
                                 for frame in partial_dataset:
-                                    recipe["inputs"].append(frame.filename)
+                                    recipe["inputs"].append(frame.filepath)
                             elif "pc" not in recipe["name"] and isPc == 0:
                                 for frame in partial_dataset:
-                                    recipe["inputs"].append(frame.filename)
+                                    recipe["inputs"].append(frame.filepath)
 
                     else:
                         for filename in filelist:

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -813,7 +813,7 @@ def test_pc_science_analog_satspots():
 
         all_frames = [sci_frame, satspot_frame]
         dataset = data.Dataset(all_frames)
-        dataset.save()
+        dataset.save(filedir=datadir)
         filelist = [frame.filepath for frame in dataset]
 
         templates, chained = walker.guess_template(dataset)
@@ -824,8 +824,8 @@ def test_pc_science_analog_satspots():
 
         recipes = walker.autogen_recipe(filelist, outputdir)
         assert len(recipes) == 2
-        assert recipes[0][0]["inputs"][0] == sci_frame.filename
-        assert recipes[1][0]["inputs"][0] == satspot_frame.filename
+        assert recipes[0][0]["inputs"][0] == sci_frame.filepath
+        assert recipes[1][0]["inputs"][0] == satspot_frame.filepath
 
         for file in filelist:
             os.remove(file)


### PR DESCRIPTION
## Describe your changes

I haven't created an issue for this. 

In walker.py, in a special case at the L2a level, the filename of inputs in passed instead of the complete filepath. There was a test exercising this but the input directory is same as cwd so this was not seen.  

I have modified walker.py and the corresponding test. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
None

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
