### PR TITLE
Enable parallel unit and e2e testing

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest flake8-docstrings-complete
+        pip install flake8 pytest pytest-xdist flake8-docstrings-complete
         if [ -f requirements.txt ]; then pip install -r requirements.txt .; fi
         pip install -r requirements_e2etests.txt corgidrp
     - name: Download E2E test data
@@ -37,6 +37,14 @@ jobs:
         # download file
         wget -O E2E_Test_Data.tar.xz https://zenodo.org/records/20634613/files/E2E_Test_Data.tar.xz?download=1
         tar -xvf E2E_Test_Data.tar.xz -C e2e_test_data
-    - name: Test with pytest
+    - name: Test with pytest (parallel producers)
+      env:
+        CORGIDRP_DO_NOT_AUTO_INIT_CALDB: "1"
+        PYTEST_XDIST_WORKER_START_METHOD: fork
+        # e2e are RAM-heavy: cap `-n auto` low on CI; local dev leaves this unset
+        PYTEST_XDIST_AUTO_NUM_WORKERS: "2"
       run: |
-        pytest --which e2e --e2edata_path e2e_test_data/E2E_Test_Data/ --e2eoutput_path tests/e2e_tests/ tests/e2e_tests/
+        pytest --which e2e -n auto -m "not serial" --e2edata_path e2e_test_data/E2E_Test_Data/ --e2eoutput_path tests/e2e_tests/ tests/e2e_tests/
+    - name: Test with pytest (serial consumer - data format docs)
+      run: |
+        pytest --which e2e -m "serial" --e2edata_path e2e_test_data/E2E_Test_Data/ --e2eoutput_path tests/e2e_tests/ tests/e2e_tests/

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,12 +30,46 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest flake8-docstrings-complete
+        pip install flake8 pytest pytest-xdist flake8-docstrings-complete
         if [ -f requirements.txt ]; then pip install -r requirements.txt .; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82,DCO020,DCO021,DCO022,DCO023,DCO024,DCO030,DCO031,DCO032,DCO060,DCO061,DCO062,DCO063,DCO064,DCO065 --show-source --statistics
-    - name: Test with pytest
+    - name: Start memory monitor
       run: |
-        pytest
+        # log memory every 5s in the background so we can see growth before a cancel/OOM
+        ( while true; do
+            echo "[$(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB free="$4"MB avail="$7"MB"}')";
+            sleep 5;
+          done ) > mem.log 2>&1 &
+        echo "MEM_MON_PID=$!" >> "$GITHUB_ENV"
+    - name: Test with pytest (parallel)
+      env:
+        CORGIDRP_DO_NOT_AUTO_INIT_CALDB: "1"
+        PYTEST_XDIST_WORKER_START_METHOD: fork
+        # cap `-n auto` on the CI runner; local dev leaves this unset to use all cores
+        PYTEST_XDIST_AUTO_NUM_WORKERS: "2"
+      run: |
+        pytest -n auto -vv -ra --durations=20 --max-worker-restart=0 -m "not serial"
+    - name: Test with pytest (serial)
+      env:
+        CORGIDRP_DO_NOT_AUTO_INIT_CALDB: "1"
+      run: |
+        pytest -vv -ra --durations=20 -m "serial"
+    - name: Memory log
+      if: always()
+      run: |
+        echo "===== memory timeline ====="
+        cat mem.log || echo "no mem log"
+        echo "===== peak ====="
+        sort -t= -k2 -n mem.log 2>/dev/null | tail -1 || true
+    - name: Check for OOM kills
+      if: always()
+      run: |
+        echo "===== dmesg OOM check ====="
+        sudo dmesg | grep -iE "killed process|out of memory|oom" || echo "No OOM events found in dmesg"
+    - name: Stop memory monitor
+      if: always()
+      run: |
+        kill "$MEM_MON_PID" 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -14,6 +14,205 @@ Install the latest release with `pip install corgidrp`. See the [Installation gu
 
 See the [Contributing guide](https://corgidrp.readthedocs.io/en/latest/contributing.html) on ReadTheDocs for the full contributor workflow, including pipeline step conventions, unit testing, end-to-end testing, linting, design principles, AI policy, and FAQ.
 
+Below is a quick tutorial  that outlines the general contribution process. 
+
+### The basics of getting setup
+#### Find a task to work on
+Check out the [Github issues page](https://github.com/roman-corgi/corgidrp/issues) for tasks that need attention. Alternatively, contact Jason (@semaphoreP). _Make sure to tag yourself on the issue and mention in the comments if you start working on it._ 
+
+#### Clone the git repository and install
+
+See install instructions above. Contact Jason (@semaphoreP) if you need write access to push changes as you make edits.  If you do not have write access to the repository, you can still contribute by creating a fork of the repository under your own GitHub user.  See here for details: https://docs.github.com/en/get-started/quickstart/fork-a-repo.  You can then use the same commands given below, but just replace `roman-corgi` with your own GitHub username. If you fork the repository, you will need to make sure that your fork is up to date with the main repository (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
+
+To quickly get up an running with the repository, execute the following commands in a terminal (or command prompt - you will need to have the git executable installed on your system):
+```
+> git clone https://github.com/roman-corgi/corgidrp.git
+> cd corgidrp
+> pip install -e .
+```
+
+##### Make a new git branch to work on
+
+You will create a "feature branch" so you can develop your feature without impacting other people's code. Let's say I'm working on dark subtraction. I could create a feature branch and switch to it like this
+
+```
+> git branch dark-sub
+> git checkout dark-sub
+```
+
+### Write your pipeline step
+
+In `corgidrp`, each pipeline step is a function, that is contained in one of the lX_to_lY.py files (where X and Y are various data levels). 
+Think about how your feature can be implemented as a function that takes in some data and outputs processed data. Please see below for some 
+`corgidrp` design principles. 
+
+All functions should follow this example:
+
+```
+def example_step(dataset, calib_data, tuneable_arg=1, another_arg="test"):
+    """
+    Function docstrings are required and should follow Google style docstrings. 
+    We will not demonstrate it here for brevity.
+    """
+    # unless you don't alter the input dataset at all, plan to make a copy of the data
+    # this is to ensure functions are reproducible
+    processed_dataset = input_dataset.copy()
+
+    ### Your code here that does the real work
+    # here is a convience field to grab all the data in a dataset
+    all_data = processed_dataset.all_data
+    ### End of your code that does the real work
+
+    # update the header of the new dataset with your processing step
+    history_msg = "I did an example step"
+    # update the output dataset with the new data and update the history
+    processed_dataset.update_after_processing_step(history_msg, new_all_data=all_data)
+
+    # return the processed data
+    return processed_dataset
+```
+
+Inside the function can be nearly anything you want, but the function signature and start/end of the function should follow a few rules.
+
+  * Each function should include a docstring that describes what the function is doing, what the inputs (including units if appropriate) are and what the outputs (also with units). The dosctrings should be [google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). 
+  * The input dataset should always be the first input
+  * Additional arguments and keywords exist only if you need them--many relevant parameters might already by in Dataset headers. A pipeline step can only have a single argument (the input dataset) if needed.
+  * All additional function arguments/keywords should only consist of the following types: int, float, str, or a class defined in corgidrp.Data. 
+    * (Long explanation for the curious: The reason for this is that pipeline steps can be written out as text files. Int/float/str are easily represented succinctly by textfiles. All classes in corgidrp.Data can be created simply by passing in a filepath. Therefore, all pipeline steps have easily recordable arguments for easy reproducibility.)
+  * The first line of the function generally should be creating a copy of the dataset (which will be the output dataset). This way, the output dataset is not the same instance as the input dataset. This will make it easier to ensure reproducibility. 
+  * The function should always end with updating the header and (typically) the data of the output dataset. The history of running this pipeline step should be recorded in the header. 
+
+You can check out `corgidrp.l2a_to_l2b.dark_subtraction` function as an example of a basic pipeline step.
+
+### Write a unit test to debug your pipeline step
+
+We are required to write tests to verify the functionality of the code. Instead of seeing this as an extra chore, I encourage you to write unit tests to be your debug script to get your code working (this is called "test-driven development"). 
+
+All tests are stored in the `tests` folder and each test is a function that starts with `test_`. See `tests/test_dark_sub.py` as an example. Within each test, you will likely need to simulate some mock data, run it through your function you wrote, and verify it ran correctly using assert statements. Your tests should cover the primary use cases of your code, and check that the function outputs what you expect. You do not need high fidelity data for your test: focus on making sure the data is in the correct format as real data, and less on making sure the data values are simulated to high fidelity (see the examples in the `mocks.py` module). 
+
+Importantly, these tests will allow code reviewers to test and understand your code. We will also run these tests in an automated test suite (continuous integration) with the pipeline to verify the functions continue to work (e.g., as dependencies change).
+
+#### How to run your tests locally
+
+You can either run tests individually yourself (to debug individual tests) or run the entire test suite to make sure you didn't break anything.
+
+To run an individual test, call the test function you want to test at the bottom of its `test_*.py` script. Then, you just need to run the `test_*.py` script. See `tests/test_dark_sub.py` for an example.
+
+To run all the tests in the test suite, go to the base corgidrp folder in a terminal and run the `pytest` command. 
+
+#### Running tests in parallel
+
+The suite can run in parallel with [`pytest-xdist`](https://pytest-xdist.readthedocs.io/) (`pip install pytest-xdist`), which is much faster. Each worker is isolated into its own calibration database, so parallel runs do not interfere with each other.
+
+A small number of tests are marked `serial` because they must run one after another (they share on-disk state or depend on execution order). The recommended way to run everything is therefore two commands: the parallel tests first, then the serial ones.
+
+```bash
+# 1. run everything except the serial tests, in parallel across all CPU cores
+pytest -n auto -m "not serial"
+
+# 2. run the serial tests on their own
+pytest -m "serial"
+```
+
+Notes:
+- `-n auto` uses one worker per logical CPU core. Replace `auto` with a number to set the worker count explicitly, e.g. `pytest -n 4 -m "not serial"`.
+- To cap `-n auto` without changing the command (useful in CI or on low-memory machines), set the environment variable `PYTEST_XDIST_AUTO_NUM_WORKERS`, e.g. `PYTEST_XDIST_AUTO_NUM_WORKERS=2 pytest -n auto -m "not serial"`.
+- `--dist loadscope` is applied automatically (see `pytest.ini`); it keeps all tests from one file on the same worker, which the serial ordering relies on.
+- To run the whole suite **serially** (no parallelism), just run `pytest` with no `-n` flag.
+
+The same pattern works for the end-to-end suite (see below), which also has one serial consumer test:
+
+```bash
+pytest --which e2e -n auto -m "not serial" --e2edata_path <DATA> --e2eoutput_path tests/e2e_tests/ tests/e2e_tests/
+pytest --which e2e         -m "serial"     --e2edata_path <DATA> --e2eoutput_path tests/e2e_tests/ tests/e2e_tests/
+```
+
+### End-to-End Testing
+
+End-to-end testing refers to processing data as one would when we get the real data (i.e., starting from L1 data). If applicable, write an end-to-end test following the `l1_to_l2a_e2e.py` and `l1_to_l2b_e2e.py` examples in the `tests/e2e_tests` folder. For example, if you wrote a step that generates a calibration function, write an end-to-end test that produces the calibration file from L1 data. The steps are as follows:
+ 
+  1. Write a recipe that produces the desired processed data product starting from L1 data. You will need to determine the series of step functions that need to be run, and what kind of arguments should be modified (e.g., whether prescan columns pixels should be cropped). Refer to the existing recipes in `corgidrp/recipe_templates` as examples and double check all the necessary steps in the FDD. 
+  2. Obtain TVAC L1 data from our Box folder (ask Alex Greenbaum or Jason if you don't have access). For some situations (e.g., boresight), there may not be appropriate TVAC data. In those cases, write a piece of code that uses the images from TVAC to provide realistic noise and add it to mock data (i.e., the ones generated for the unit testing) to create mock L1 data. Please be mindful to not override the original data on Box (e.g., if you sync the data with the Box app, some of the existing e2e tests will edit the files, and the Box app will propogate those changes to the server, which we don't want). 
+  3. Write an end-to-end test that processes the L1 data through the new recipe you created using the corgidrp.walker framework
+      - You will probably need to modify the `corgidrp.walker.guess_template()` function to add logic for determining when to use your recipe based on header keywords (e.g., VISTYPE). Ask Jason, who developed this framework, if it is not clear what should be done. 
+      - Your recipe may require other calibratio files. For now, create them as part of the setup process during the script (see `tests/e2e_tests/l1_to_l2b_e2e.py` for examples of how to do this for each type of calibration)
+      - if you need to create mock L1 data, please do it in the script as well. 
+      - See the existing tests in `tests/e2e_tests/` for how to structure this script. You should only need to write a single script.
+  4. Test that the script runs successfully on your local machine and produces the expected output. Debug as necessary. When appropriate, test your results against those obtained from the II&T/TVAC pipeline using the same input data. 
+  5. Determine how resource intensive your recipe is. There are many ways to do this, but Linux users can run `/usr/bin/time -v python your_e2e_test.py` and Mac users can run `/usr/bin/time -l -h -p python <your_e2e_test.py>`. Record elapsed (wall clock) time, the percent of CPU this job got (only if parallelization was used), and total memory used (labelled "Maximum resident set size"). 
+  6. Document your recipe on the "Corgi-DRP Implementation Document" on Confluence (see the big table in Section 2.0). You should fill out an entire row with your recipe. Under addition notes, note if your recipe took significant run time (> 1 minute) and significant memory (> 1 GB). 
+  7. PR! 
+
+To run the existing end-to-end tests, you need to have downloaded all the TVAC data to your computer. In a terminal, go to the base directory of the corgidrp repo and run the following command, substituting paths for paths on your computer as desired:
+
+```
+pytest --which e2e --e2edata_path /path/to/CGI_TVAC_Data --e2eoutput_path tests/e2e_tests/ tests/e2e_tests/
+```
+
+### Linting
+
+In addition to unit tests, your code will need to pass a static analysis before being merged.  `corgidrp` currently runs a subset of flake8 tests, which you can replicate on your local system by running:
+
+```
+flake8 . --count --select=E9,F63,F7,F82,DCO020,DCO021,DCO022,DCO023,DCO024,DCO030,DCO031,DCO032,DCO060,DCO061,DCO062,DCO063,DCO064,DCO065 --show-source --statistics
+```
+from the top-level directory of the repository.  In order to run these tests you will need to have `flake8` and `flake8-docstrings-complete` installed (both are pip-installable).  Note that the test subset may be updated in the future.  To see the current set of tests being applied, look in the continuous integration GitHub action, located in the repository in file `.github/workflows/python-app.yml`.
+
+### AI Policy
+We require that you understand all code you contribute, regardless of how it is generated. We have the following rules with regard to code generated by AI tools: 
+
+ * Please review line-by-line all changes made by an AI coding tool. 
+ * Please make sure you understand line-by-line what all code generated by an AI coding tool is doing. Don't commit code you don't understand!
+ * If AI-generated code is unclear, refactor it to make the code easier to understand.
+
+Please ease the burden on the code maintainers by reviewing and cleaning up all AI-generated code before you submit a PR!
+
+
+### Create a pull request to merge your changes
+Before creating a pull request, review the design Principles below. Use the Github pull request feature to request that your changes get merged into the `main` branch. Assign Jason/Max to be your reviewers. Your changes will be reviewed, and possibly some edits will be requested. You can simply make additional pushes to your branch to update the pull request with those changes (you don't need to delete the PR and make a new one). When the branch is satisfactory, we will pull your changes in. When preparing your pull request, you may find it helpful to follow this checklist:
+
+- [ ] If working with a fork, sync your fork to the upstream repository
+- [ ] Ensure that your pull can be merged automatically by merging main onto the branch you wish to pull from
+- [ ] Ensure that all of your new additions have properly formatted docstrings (this will happen automatically if you run the `flake8` command given above
+- [ ] Ensure that all of the commits going in to your pull have informative messages
+- [ ] Ensure that all unit tests pass locally, and that you have provided new unit tests for all new functionality in your pull
+- [ ] Create a new pull request, fully describing all changes/additions
+
+
+## Overarching Design Principles
+* Minimize the use of external packages, unless it saves us a lot of time. If you need to use something external, default to well-established and maintained packages, such as `numpy`, `scipy` or `Astropy`. If you think you need to use something else, please check with Jason and Max. 
+* Minimize the use of new classes, with the exception of new classes that extend the existing data framework.
+* The python module files (i.e. the *.py files) should typically hold on the order of 5-10 different functions. You can create new ones if need be, but the new files should be general enough in topic to encapsulate other future functions as well.
+* All the image data in the Dataset and Image objects should be saved as standard numpy arrays. Other types of arrays (such as masked arrays) can be used as intermediate products within a function.
+* Keep things simple
+* Use _descriptive_ variable names **always**.
+* Comments should be used to describe a section of the code where it's not immediately obvious what the code is doing. Using descriptive variable names will minimize the amount of comments required.
+* Make pull requests as small as possible. It makes code easier to review, when only a small fraction of the code is being modified. You can do multiple PRs on the same task (e.g., a first very simplistic implementation, followed by a separate PR adding some new features and options.)
+
+## FAQ
+
+* Does my pipeline function need to save files?
+  * Files will be saved by a higher level pipeline code. As long as you output an object that's an instance of a `corgidrp.Data` class, it will have a `save()` function that will be used.
+* Can I create new data classes?
+  * Yes, you can feel free to make new data classes. Generally, they should be a subclass of the `Image` class, and you can look at the `Dark` class as an example. Each calibration type should have its own `Image` subclass defined. Talk with Jason and Max to discuss how your class should be implemented!
+  * You do not necessarily need to write a copy function for subclasses of the `Image` class. If you need to copy calibration objects at all, you can use the copy function of the Image class.
+* What python version should I develop in?
+  * Python 3.12
+    
+* How should I treat different kinds of function parameters:
+  * Constants - things that are highly unlikely to change - can be included in modules, like detector.py
+  * Properties of the system - things we need to measure that might change in time - would go into a calibration file like DetectorParams
+  * Function parameters - choices that we might make and want to have more flexibility that apply to a specific function (e.g. exactly what area of a detector we might use to calculate something) - would be keyword arguments to that function.
+  * If it is a setting about pipeline behavior that may change, it should be implemented in the config file (examples are location of the calibration database and whether to save individual error terms in the output FITS files).
+ 
+* Where should I store computed variables so they can be referenced later in the pipeline?
+  * If possible, in the header of the dataset being processed or in a hew HDU extension
+  * If not possible, then let's chat!
+ 
+* Where do I save FITS files or other data files I need to use for my tests?
+  * Auxiliary data to run tests should be stored in the tests/test_data folder
+  * If they are larger than 1 MB, they should be stored using `git lfs`. Ask Jason about setting up git lfs (as of writing, we have not set up git lfs yet).
+ 
 ## Change Log
 
 See the [Change Log](https://corgidrp.readthedocs.io/en/latest/changelog.html) on ReadTheDocs.

--- a/conftest.py
+++ b/conftest.py
@@ -84,3 +84,25 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if not "e2e" in item.keywords:
                 item.add_marker(skip_unit)
+
+@pytest.fixture(scope="session", autouse=True)
+def caldb_initialized():
+    """
+    Ensure caldb is initialized once per worker process.
+    This is autouse=True so it runs before any test that might need caldb.
+    """
+    import corgidrp.caldb as caldb
+    import corgidrp
+    import os
+
+    # Ensure the directories exist (should already be created by corgidrp.__init__)
+    os.makedirs(corgidrp.config_folder, exist_ok=True)
+    os.makedirs(corgidrp.default_cal_dir, exist_ok=True)
+
+    # Force initialization if not already done
+    if not caldb.initialized:
+        caldb.initialize()
+
+    yield
+
+    # No cleanup needed - worker temp dirs are cleaned up by pytest-xdist

--- a/corgidrp/__init__.py
+++ b/corgidrp/__init__.py
@@ -6,14 +6,20 @@ import numpy as np
 __version__ = "5.0"
 version = __version__ # temporary backwards compatability 
 
-#### Create a configuration file for the corgidrp if it doesn't exist. 
+#### Create a configuration file for the corgidrp if it doesn't exist.
 def create_config_dir():
     """
     Checks if the default .corgidrp directory exists, and if not, it sets it up
     """
     global config_folder
-    homedir = pathlib.Path.home()
-    config_folder = os.path.join(homedir, ".corgidrp")
+
+    # Use worker-specific temp dir if running under pytest-xdist
+    worker_tmp = os.environ.get('CORGIDRP_WORKER_TMP')
+    if worker_tmp:
+        config_folder = os.path.join(worker_tmp, ".corgidrp")
+    else:
+        homedir = pathlib.Path.home()
+        config_folder = os.path.join(homedir, ".corgidrp")
     # replace legacy file with folder if needed
     if os.path.isfile(config_folder):
         oldconfig = configparser.ConfigParser()
@@ -24,12 +30,12 @@ def create_config_dir():
 
     # make folder if doesn't exist
     if not os.path.isdir(config_folder):
-        os.mkdir(config_folder)
+        os.makedirs(config_folder, exist_ok=True)
 
     # make default calibrations folder if it doesn't exist
     default_cal_dir = os.path.join(config_folder, "default_calibs")
     if not os.path.exists(default_cal_dir):
-        os.mkdir(default_cal_dir)
+        os.makedirs(default_cal_dir, exist_ok=True)
 
     # make user templates folder if it doesn't exist
     user_templates_dir = os.path.join(config_folder, "user_templates")
@@ -71,7 +77,7 @@ def update_pipeline_settings():
     global caldb_filepath, default_cal_dir, user_templates_dir, track_individual_errors, chunk_size, image_dtype, dq_dtype, skip_missing_cal_steps, jit_calib_id, enforce_template_structure
     # borrowed from the kpicdrp caldb
     # load in default caldbs based on configuration file
-    config_filepath = os.path.join(pathlib.Path.home(), ".corgidrp", "corgidrp.cfg")
+    config_filepath = os.path.join(config_folder, "corgidrp.cfg")
     config = configparser.ConfigParser()
     config.read(config_filepath)
 
@@ -83,6 +89,13 @@ def update_pipeline_settings():
     caldb_filepath = config.get("PATH", "caldb", fallback=None) # path to calibration db
     default_cal_dir = config.get("PATH", "default_calibs", fallback=None) # path to default calibrations directory
     user_templates_dir = config.get("PATH", "user_templates", fallback=os.path.join(pathlib.Path.home(), ".corgidrp", "user_templates")) # path to user templates directory
+
+    # Override paths for pytest-xdist workers to ensure isolation
+    worker_tmp = os.environ.get('CORGIDRP_WORKER_TMP')
+    if worker_tmp:
+        worker_config_dir = os.path.join(worker_tmp, ".corgidrp")
+        caldb_filepath = os.path.join(worker_config_dir, "caldb.csv")
+        default_cal_dir = os.path.join(worker_config_dir, "default_calibs")
     track_individual_errors = _bool_map[config.get("DATA", "track_individual_errors", fallback='false').lower()] # save each individual error component separately?
     chunk_size = int(float(config.get("DATA", "chunk_size", fallback="200"))) # number of frames to process at a time if pocessing in chunks for RAM conservation
     image_dtype = image_datatype_map[config.get("DATA", "image_dtype", fallback="32")] # bit size for image and error data

--- a/corgidrp/calibrate_kgain.py
+++ b/corgidrp/calibrate_kgain.py
@@ -461,7 +461,7 @@ def calibrate_kgain(dataset_kgain,
         import matplotlib.pyplot as plt
         # Output directory
         if os.path.exists(plot_outdir) is False:
-            os.mkdir(plot_outdir)
+            os.makedirs(plot_outdir, exist_ok=True)
             if verbose:
                 print('Output directory for figures created in ', os.getcwd())
     

--- a/corgidrp/calibrate_nonlin.py
+++ b/corgidrp/calibrate_nonlin.py
@@ -396,7 +396,7 @@ def calibrate_nonlin(dataset_nl,
         import matplotlib.pyplot as plt
         # Output directory
         if os.path.exists(plot_outdir) is False:
-            os.mkdir(plot_outdir)
+            os.makedirs(plot_outdir, exist_ok=True)
             if verbose:
                 print('Output directory for figures created in ', os.getcwd())
     

--- a/corgidrp/fluxcal.py
+++ b/corgidrp/fluxcal.py
@@ -57,7 +57,7 @@ def get_calspec_file(star_name):
     names_file = os.path.join(calspec_dir, "calspec_names.json")
     calspec_names_ff = calspec_names
     if not os.path.exists(calspec_dir):
-        os.mkdir(calspec_dir)
+        os.makedirs(calspec_dir, exist_ok=True)
         with open(names_file, 'w') as f:
             json.dump(calspec_names_ff, f)
     else:

--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -874,7 +874,7 @@ def create_dark_calib_files(filedir=None, numfiles=10):
     """
     # Make filedir if it does not exist
     if (filedir is not None) and (not os.path.exists(filedir)):
-        os.mkdir(filedir)
+        os.makedirs(filedir, exist_ok=True)
 
     frames = []
     for i in range(numfiles):
@@ -913,7 +913,7 @@ def create_simflat_dataset(filedir=None, numfiles=10):
     """
     # Make filedir if it does not exist
     if (filedir is not None) and (not os.path.exists(filedir)):
-        os.mkdir(filedir)
+        os.makedirs(filedir, exist_ok=True)
 
     frames = []
     for i in range(numfiles):
@@ -1128,7 +1128,7 @@ def create_flatfield_dummy(filedir=None, numfiles=2):
     """
     ## Make filedir if it does not exist
     if (filedir is not None) and (not os.path.exists(filedir)):
-        os.mkdir(filedir)
+        os.makedirs(filedir, exist_ok=True)
 
     frames=[]
     for i in range(numfiles):
@@ -1166,7 +1166,7 @@ def create_nonlinear_dataset(nonlin_filepath, filedir=None, numfiles=2,em_gain=2
 
     # Make filedir if it does not exist
     if (filedir is not None) and (not os.path.exists(filedir)):
-        os.mkdir(filedir)
+        os.makedirs(filedir, exist_ok=True)
 
     frames = []
     for i in range(numfiles):
@@ -1296,7 +1296,7 @@ def create_prescan_files(filedir=None, numfiles=2, arrtype="SCI"):
     """
     # Make filedir if it does not exist
     if (filedir is not None) and (not os.path.exists(filedir)):
-        os.mkdir(filedir)
+        os.makedirs(filedir, exist_ok=True)
 
     if arrtype == "SCI":
         size = (1200, 2200)
@@ -1347,7 +1347,7 @@ def create_badpixelmap_files(filedir=None, col_bp=None, row_bp=None):
     """
     # Make filedir if it does not exist
     if (filedir is not None) and (not os.path.exists(filedir)):
-        os.mkdir(filedir)
+        os.makedirs(filedir, exist_ok=True)
 
     prihdr, exthdr, errhdr, dqhdr = create_default_calibration_product_headers()
     exthdr['DATATYPE']      = 'BadPixelMap'
@@ -1540,8 +1540,8 @@ def create_astrom_data(field_path, filedir=None, image_shape=(1024, 1024), targe
 
     # Make filedir if it does not exist
     if (filedir is not None) and (not os.path.exists(filedir)):
-        os.mkdir(filedir)
-
+        os.makedirs(filedir, exist_ok=True)
+    
     # hard coded image properties
     sim_data = np.zeros(image_shape)
     ny, nx = image_shape
@@ -3000,7 +3000,7 @@ def create_flux_image(star_flux, fwhm, cal_factor, filter='3C', fpamname = 'HOLE
 
     # Create directory if needed
     if filedir is not None and not os.path.exists(filedir):
-        os.mkdir(filedir)
+        os.makedirs(filedir, exist_ok=True)
 
     # Image properties
     size = (1024, 1024)
@@ -3129,7 +3129,7 @@ def create_pol_flux_image(star_flux_left, star_flux_right, fwhm, cal_factor, fil
 
     # Create directory if needed
     if filedir is not None and not os.path.exists(filedir):
-        os.mkdir(filedir)
+        os.makedirs(filedir, exist_ok=True)
 
     # Image properties
     size = (1024, 1024)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,9 @@
 [pytest]
 norecursedirs = .git .vscode build docs dist
 python_files = test_*.py *e2e.py
+# loadscope keeps all tests from one module on the same worker (required for
+# module-level state and correct serial ordering). It only takes effect when
+# running under xdist (-n ...); harmless for a plain sequential run.
+addopts = --dist loadscope
+markers =
+    serial: mark test to run serially (not in parallel with pytest-xdist)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,59 @@
+"""
+Shared pytest fixtures for corgidrp tests.
+
+Session-scoped fixtures eliminate redundant data generation and significantly
+improve test suite performance.
+"""
+import pytest
+import os
+import tempfile
+
+
+def pytest_configure(config):
+    """
+    Isolate each pytest-xdist worker into its own ``.corgidrp`` config/caldb dir.
+
+    This runs inside every worker process after it starts. ``config.workerinput``
+    is populated in workers under both the ``spawn`` and ``fork`` start methods, so
+    the isolation activates even when workers are forked (as in CI) and did not
+    re-run corgidrp's import-time setup. We recompute corgidrp's path globals off a
+    worker-specific temp dir here rather than at import time, because under ``fork``
+    the controller imports corgidrp while ``PYTEST_XDIST_WORKER`` is still unset and
+    the forked workers inherit those already-bound paths.
+
+    Args:
+        config: pytest Config object; has a ``workerinput`` attribute in xdist workers.
+    """
+    workerinput = getattr(config, "workerinput", None)
+    if workerinput is None:
+        return  # controller / non-xdist run: use the real ~/.corgidrp
+
+    import corgidrp
+
+    worker_id = workerinput.get("workerid", "gw")
+    worker_tmp = tempfile.mkdtemp(prefix=f"corgidrp_worker_{worker_id}_")
+    os.environ["CORGIDRP_WORKER_TMP"] = worker_tmp
+    # Re-derive config_folder, caldb_filepath and default_cal_dir from the env var
+    # so this worker points at its private dir instead of the inherited ~/.corgidrp.
+    corgidrp.create_config_dir()
+    corgidrp.update_pipeline_settings()
+
+
+def pytest_collection_modifyitems(config, items):
+    """
+    Modify test collection to handle serial marker with pytest-xdist.
+
+    Tests marked with @pytest.mark.serial are sorted by file and line number
+    to ensure they run in the correct order when using --dist loadscope.
+
+    Note: You MUST use `pytest -n auto --dist loadscope` for serial tests to work correctly.
+    The loadscope distribution ensures all tests from the same module run on the same worker
+    in collection order, which is critical for tests with module-level state dependencies.
+
+    Args:
+        config: pytest Config object containing configuration values
+        items: list of pytest Item objects representing collected tests
+    """
+    # Sort all items to ensure consistent ordering
+    # Particularly important for serial tests that depend on execution order
+    items.sort(key=lambda item: (item.nodeid.split("::")[0], item.location[1]))

--- a/tests/e2e_tests/astrom_e2e.py
+++ b/tests/e2e_tests/astrom_e2e.py
@@ -68,7 +68,7 @@ def test_astrom_e2e(e2edata_path, e2eoutput_path):
     # Create calibrations subfolder for mock calibration products
     calibrations_dir = os.path.join(astrom_cal_outputdir, "calibrations")
     if not os.path.exists(calibrations_dir):
-        os.mkdir(calibrations_dir)
+        os.makedirs(calibrations_dir, exist_ok=True)
 
     # assume all cals are in the same directory
     nonlin_path = os.path.join(processed_cal_path, "nonlin_table_240322.txt")
@@ -85,7 +85,7 @@ def test_astrom_e2e(e2edata_path, e2eoutput_path):
     # create a directory in the output dir to hold the simulated data files
     input_data_dir = os.path.join(astrom_cal_outputdir, 'input_l1')
     if not os.path.exists(input_data_dir):
-        os.mkdir(input_data_dir)
+        os.makedirs(input_data_dir, exist_ok=True)
     # clean out any files from a previous run
     for f in os.listdir(input_data_dir):
         file_path = os.path.join(input_data_dir, f)

--- a/tests/e2e_tests/bp_map_e2e.py
+++ b/tests/e2e_tests/bp_map_e2e.py
@@ -39,7 +39,7 @@ def test_bp_map_master_dark_e2e(e2edata_path, e2eoutput_path):
     os.makedirs(input_data_dir)
 
     calibrations_dir = os.path.join(bp_map_outputdir, "calibrations")
-    os.mkdir(calibrations_dir)
+    os.makedirs(calibrations_dir, exist_ok=True)
 
     # Paths to calibration files
     dark_current_path = os.path.join(processed_cal_path, "dark_current_20240322.fits")
@@ -242,7 +242,7 @@ def test_bp_map_simulated_dark_e2e(e2edata_path, e2eoutput_path):
     os.makedirs(input_data_dir)
 
     calibrations_dir = os.path.join(bp_map_outputdir, "calibrations")
-    os.mkdir(calibrations_dir)
+    os.makedirs(calibrations_dir, exist_ok=True)
 
     # Paths to calibration files
     dark_current_path = os.path.join(processed_cal_path, "dark_current_20240322.fits")

--- a/tests/e2e_tests/ctmap_e2e.py
+++ b/tests/e2e_tests/ctmap_e2e.py
@@ -98,14 +98,14 @@ def test_expected_results_e2e(e2edata_path, e2eoutput_path):
     ctmap_outputdir = os.path.join(e2eoutput_path, 'ctmap_cal_e2e')
     if os.path.exists(ctmap_outputdir):
         shutil.rmtree(ctmap_outputdir)
-    os.mkdir(ctmap_outputdir)
+    os.makedirs(ctmap_outputdir, exist_ok=True)
     
     # Define directory to store the individual frames under the output directory
     output_dir = os.path.join(ctmap_outputdir, 'input_l2b')
-    os.mkdir(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
 
     calibrations_dir = os.path.join(ctmap_outputdir, 'calibrations')
-    os.mkdir(calibrations_dir)
+    os.makedirs(calibrations_dir, exist_ok=True)
     
     renamed_files = mocks.rename_files_to_cgi_format(list_of_fits=list(corDataset), output_dir=output_dir, level_suffix="l2a")
     

--- a/tests/e2e_tests/l1_to_dispersion_e2e.py
+++ b/tests/e2e_tests/l1_to_dispersion_e2e.py
@@ -187,7 +187,7 @@ def test_l1_to_dispersion(e2edata_path, e2eoutput_path):
 
     l2b_outputdir = os.path.join(test_outputdir, "l2b_results")
     if not os.path.exists(l2b_outputdir):
-        os.mkdir(l2b_outputdir)
+        os.makedirs(l2b_outputdir, exist_ok=True)
 
     # clean up by removing old files
     for file in os.listdir(l2b_outputdir):

--- a/tests/e2e_tests/l1_to_fluxcal_e2e.py
+++ b/tests/e2e_tests/l1_to_fluxcal_e2e.py
@@ -36,7 +36,7 @@ def test_l1_to_fluxcal(e2edata_path, e2eoutput_path):
 
     l2b_outputdir = os.path.join(test_outputdir, "l2b_results")
     if not os.path.exists(l2b_outputdir):
-        os.mkdir(l2b_outputdir)
+        os.makedirs(l2b_outputdir, exist_ok=True)
     # clean up by removing old files
     for file in os.listdir(l2b_outputdir):
         os.remove(os.path.join(l2b_outputdir, file))

--- a/tests/e2e_tests/l1_to_l2b_e2e.py
+++ b/tests/e2e_tests/l1_to_l2b_e2e.py
@@ -57,7 +57,7 @@ def test_l1_to_l2b(e2edata_path, e2eoutput_path):
     # separate L2a and L2b outputdirs
     l2a_outputdir = os.path.join(test_outputdir, "l1_to_l2a")
     if not os.path.exists(l2a_outputdir):
-        os.mkdir(l2a_outputdir)
+        os.makedirs(l2a_outputdir, exist_ok=True)
     # clean up by removing old files
     for file in os.listdir(l2a_outputdir):
         os.remove(os.path.join(l2a_outputdir, file))

--- a/tests/e2e_tests/l1_to_l4_spec_noncoron_e2e.py
+++ b/tests/e2e_tests/l1_to_l4_spec_noncoron_e2e.py
@@ -752,7 +752,7 @@ if __name__ == "__main__":
     # defaults allowing the use to edit the file if that is their preferred
     # workflow.
     thisfile_dir = os.path.dirname(__file__)
-    e2edata_dir = '/home/ababuraj/roman/E2E_Test_Data'
+    e2edata_dir = './E2E_Test_Data'
     outputdir = thisfile_dir
 
     ap = argparse.ArgumentParser(description="run the l1->l4 non-coronographic spectroscopy end-to-end test with recipe chaining")

--- a/tests/e2e_tests/l1_to_linespread_e2e.py
+++ b/tests/e2e_tests/l1_to_linespread_e2e.py
@@ -191,7 +191,7 @@ def test_l1_to_linespread(e2edata_path, e2eoutput_path):
 
     l2b_outputdir = os.path.join(test_outputdir, "l2b_results")
     if not os.path.exists(l2b_outputdir):
-        os.mkdir(l2b_outputdir)
+        os.makedirs(l2b_outputdir, exist_ok=True)
 
     # clean up by removing old files
     for file in os.listdir(l2b_outputdir):

--- a/tests/e2e_tests/l2b_to_l4_e2e.py
+++ b/tests/e2e_tests/l2b_to_l4_e2e.py
@@ -405,7 +405,7 @@ def test_l2b_to_l3(e2edata_path, e2eoutput_path):
     # Organize L3 files into l2b_to_l3 subfolder
     l2b_to_l3_dir = os.path.join(main_output_dir, "l2b_to_l3")
     if not os.path.exists(l2b_to_l3_dir):
-        os.mkdir(l2b_to_l3_dir)
+        os.makedirs(l2b_to_l3_dir, exist_ok=True)
     
     walker.walk_corgidrp(l2b_data_filelist, "",l2b_to_l3_dir)
 

--- a/tests/e2e_tests/l3_to_l4_pol_e2e.py
+++ b/tests/e2e_tests/l3_to_l4_pol_e2e.py
@@ -158,7 +158,7 @@ def test_l3_to_l4_pol_e2e(e2edata_path, e2eoutput_path):
     # Create calibrations subfolder for mock calibration products
     calibrations_dir = os.path.join(output_dir, "calibrations")
     if not os.path.exists(calibrations_dir):
-        os.mkdir(calibrations_dir)
+        os.makedirs(calibrations_dir, exist_ok=True)
 
     ###### Setup necessary calibration files
     tmp_caldb_csv = os.path.join(corgidrp.config_folder, 'tmp_e2e_test_caldb.csv')

--- a/tests/e2e_tests/polflatfield_e2e.py
+++ b/tests/e2e_tests/polflatfield_e2e.py
@@ -1,15 +1,12 @@
 import argparse
-import os
 import glob
 import pytest
 import os, shutil
 import numpy as np
-import scipy.ndimage
 import datetime
 import astropy.time as time
 import astropy.io.fits as fits
 import corgidrp
-import re
 import logging
 import warnings
 import corgidrp.data as data
@@ -17,7 +14,7 @@ import corgidrp.mocks as mocks
 import corgidrp.walker as walker
 import corgidrp.caldb as caldb
 import corgidrp.detector as detector
-from corgidrp.check import (check_filename_convention, check_dimensions, verify_header_keywords, compare_to_mocks_hdrs)
+from corgidrp.check import (compare_to_mocks_hdrs)
 
 #Get path to this file
 current_file_path = os.path.dirname(os.path.abspath(__file__))
@@ -550,7 +547,7 @@ def test_flat_creation_neptune_POL45(e2edata_path, e2eoutput_path):
 if __name__ == "__main__":
     
     outputdir = thisfile_dir
-    e2edata_dir =  '/Users/jmilton/Documents/CGI/E2E_Test_Data2'
+    e2edata_dir =  'E2E_Test_Data2'
 
     ap = argparse.ArgumentParser(description="run the l2b-> PolFlatfield end-to-end test")
     ap.add_argument("-tvac", "--e2edata_dir", default=e2edata_dir,

--- a/tests/e2e_tests/trap_pump_cal_e2e.py
+++ b/tests/e2e_tests/trap_pump_cal_e2e.py
@@ -81,12 +81,12 @@ def test_trap_pump_cal(e2edata_path, e2eoutput_path):
     # Create separate directory for trap pump mock data (for tpump_analysis)
     trap_pump_datadir = os.path.join(trap_pump_outputdir, "input_l1")
     if not os.path.exists(trap_pump_datadir):
-        os.mkdir(trap_pump_datadir)
+        os.makedirs(trap_pump_datadir, exist_ok=True)
         
     # Create calibrations subfolder for mock calibration products
     calibrations_dir = os.path.join(trap_pump_outputdir, "calibrations")
     if not os.path.exists(calibrations_dir):
-        os.mkdir(calibrations_dir)
+        os.makedirs(calibrations_dir, exist_ok=True)
     
     # Remove all files ending with .json and .fits in the mock data directory
     for root, _, files in os.walk(trap_pump_datadir):
@@ -118,7 +118,7 @@ def test_trap_pump_cal(e2edata_path, e2eoutput_path):
     for temp, temp_files in file_info.items():
         temp_dir = os.path.join(trap_pump_datadir, temp)
         if not os.path.exists(temp_dir):
-            os.mkdir(temp_dir)
+            os.makedirs(temp_dir, exist_ok=True)
         
         # Sort files within each temperature to maintain consistent order
         temp_files.sort()
@@ -130,7 +130,7 @@ def test_trap_pump_cal(e2edata_path, e2eoutput_path):
         for i, sc in enumerate(schemes):
             sch_dir = os.path.join(temp_dir, f'Scheme_{sc}')
             if not os.path.exists(sch_dir):
-                os.mkdir(sch_dir)
+                os.makedirs(sch_dir, exist_ok=True)
             
             # Move files for this scheme
             start_idx = i * files_per_scheme

--- a/tests/e2e_tests/zz_dataformat_e2e.py
+++ b/tests/e2e_tests/zz_dataformat_e2e.py
@@ -12,6 +12,11 @@ import csv
 
 thisfile_dir = os.path.dirname(__file__) # this file's folder
 
+# Run serially in a second phase: this file is a pure consumer that reads the
+# output directories produced by the other (parallelized) e2e tests, so it must
+# run after they have all completed.
+pytestmark = pytest.mark.serial
+
 def generate_template(hdulist, dtype_name=None):
     """
     Generates an rst documentation page of the data entries
@@ -454,7 +459,7 @@ def test_l2a_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_output_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_output_dir):
-        os.mkdir(doc_output_dir)
+        os.makedirs(doc_output_dir, exist_ok=True)
 
 
     with fits.open(l2a_data_file) as hdulist:
@@ -485,7 +490,7 @@ def test_l2b_analog_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(l2b_data_file) as hdulist:
@@ -516,7 +521,7 @@ def test_l2b_pc_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(l2b_data_file) as hdulist:
@@ -548,7 +553,7 @@ def test_l3_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(l3_data_file) as hdulist:
@@ -579,7 +584,7 @@ def test_l3_spec_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(l3_spec_data_file) as hdulist:
         doc_contents = generate_template(hdulist)
@@ -609,7 +614,7 @@ def test_l3_pol_dataformat_e2e(e2edata_path, e2eoutput_path):
     
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(l3_pol_data_file) as hdulist:
         doc_contents = generate_template(hdulist)
@@ -639,7 +644,7 @@ def test_l4_coron_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(l4_data_file) as hdulist:
@@ -669,7 +674,7 @@ def test_l4_noncoron_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(kgain_data_file) as hdulist:
@@ -700,7 +705,7 @@ def test_l4_pol_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(l4_pol_data_file) as hdulist:
         doc_contents = generate_template(hdulist)
@@ -730,7 +735,7 @@ def test_l4_spec_coron_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(l4_spec_coron_data_file) as hdulist:
         doc_contents = generate_template(hdulist, dtype_name="L4-Spec-Coronagraphic")
@@ -760,7 +765,7 @@ def test_l4_spec_noncoron_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(l4_spec_noncoron_data_file) as hdulist:
         doc_contents = generate_template(hdulist, dtype_name="L4-Spec-Noncoron")
@@ -789,7 +794,7 @@ def test_astrom_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(astrom_data_file) as hdulist:
@@ -820,7 +825,7 @@ def test_bpmap_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(bpmap_data_file) as hdulist:
@@ -851,7 +856,7 @@ def test_flat_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(flat_data_file) as hdulist:
@@ -881,7 +886,7 @@ def test_polflat_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(polflat_data_file) as hdulist:
         doc_contents = generate_template(hdulist, dtype_name="PolFlatField")
@@ -911,7 +916,7 @@ def test_ct_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(ct_data_file) as hdulist:
@@ -941,7 +946,7 @@ def test_ctmap_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(ctmap_data_file) as hdulist:
@@ -973,7 +978,7 @@ def test_fluxcal_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(fluxcal_data_file) as hdulist:
@@ -1003,7 +1008,7 @@ def test_kgain_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(kgain_data_file) as hdulist:
@@ -1034,7 +1039,7 @@ def test_nonlin_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(nonlin_data_file) as hdulist:
@@ -1064,7 +1069,7 @@ def test_ndfilter_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(nd_data_file) as hdulist:
@@ -1094,7 +1099,7 @@ def test_ndfilter_spec_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(nds_data_file) as hdulist:
         doc_contents = generate_template(hdulist)
@@ -1122,7 +1127,7 @@ def test_specfluxcal_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(sfl_data_file) as hdulist:
         doc_contents = generate_template(hdulist)
@@ -1150,7 +1155,7 @@ def test_noisemaps_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(noisemaps_data_file) as hdulist:
@@ -1181,7 +1186,7 @@ def test_dark_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(dark_data_file) as hdulist:
@@ -1219,7 +1224,7 @@ def test_darks_comparison_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(trad_data_file) as hdulist:
@@ -1246,7 +1251,7 @@ def test_tpump_dataformat_e2e(e2edata_path, e2eoutput_path):
 
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
 
     with fits.open(tpump_data_file) as hdulist:
@@ -1303,7 +1308,7 @@ def test_mueller_matrix_dataformat_e2e(e2edata_path, e2eoutput_path):
     
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(polcal_data_file) as hdulist:
         doc_contents = generate_template(hdulist)
@@ -1332,7 +1337,7 @@ def test_nd_mueller_dataformat_e2e(e2edata_path, e2eoutput_path):
     
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(polcal_data_file) as hdulist:
         doc_contents = generate_template(hdulist)
@@ -1362,7 +1367,7 @@ def test_spec_linespread_dataformat_e2e(e2edata_path, e2eoutput_path):
     
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(spec_linespread_data_file) as hdulist:
         doc_contents = generate_template(hdulist)
@@ -1391,7 +1396,7 @@ def test_spec_prism_disp_dataformat_e2e(e2edata_path, e2eoutput_path):
     
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
     if not os.path.exists(doc_dir):
-        os.mkdir(doc_dir)
+        os.makedirs(doc_dir, exist_ok=True)
 
     with fits.open(spec_prism_disp_data_file) as hdulist:
         doc_contents = generate_template(hdulist)

--- a/tests/test_astrom.py
+++ b/tests/test_astrom.py
@@ -18,16 +18,14 @@ def print_pass():
     cprint(' PASS ', "black", "on_green")
 
 
-def test_astrom():
-    """ 
+def test_astrom(tmp_path):
+    """
     Generate a simulated image and test the astrometric calibration computation.
-    
+
     """
     # create a simulated image with source guesses and true positions
-    # check that the simulated image folder exists and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "test_data", "simastrom")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
+    datadir = tmp_path / "simastrom"
+    datadir.mkdir(parents=True, exist_ok=True)
 
     field_path = os.path.join(os.path.dirname(__file__), "test_data", "JWST_CALFIELD2020.csv")
     
@@ -78,16 +76,14 @@ def test_astrom():
     pickled_astrom = pickle.loads(pickled)
     assert np.all((astrom_cal.data == pickled_astrom.data)) # check it is the same as the original
 
-def test_astrom_vignette(vignette_radius=3_460):
-    """ 
+def test_astrom_vignette(tmp_path, vignette_radius=3_460):
+    """
     Generate a simulated image and test the astrometric calibration computation.
-    
+
     """
     # create a simulated image with source guesses and true positions
-    # check that the simulated image folder exists and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "test_data", "simastrom")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
+    datadir = tmp_path / "simastrom"
+    datadir.mkdir(parents=True, exist_ok=True)
 
     field_path = os.path.join(os.path.dirname(__file__), "test_data", "JWST_CALFIELD2020.csv")
     
@@ -130,25 +126,22 @@ def test_astrom_vignette(vignette_radius=3_460):
     assert np.all((astrom_cal.data == pickled_astrom.data))
 
     # save and check it can be pickled after save
-    astrom_cal.save(filedir=datadir, filename="astrom_cal_output.fits")
-    astrom_cal_2 = data.AstrometricCalibration(os.path.join(datadir, "astrom_cal_output.fits"))
+    astrom_cal.save(filedir=str(datadir), filename="astrom_cal_output.fits")
+    astrom_cal_2 = data.AstrometricCalibration(str(datadir / "astrom_cal_output.fits"))
 
     # check they can be pickled (for CTC operations)
     pickled = pickle.dumps(astrom_cal_2)
     pickled_astrom = pickle.loads(pickled)
     assert np.all((astrom_cal.data == pickled_astrom.data)) # check it is the same as the original
 
-
-def test_distortion():
-    """ 
+def test_distortion(tmp_path):
+    """
     Generate a simulated image and test the distortion map creation as part of the boresight calibration.
-    
+
     """
     # create a simulated image with source guesses and true positions
-    # check that the simulated image folder exists and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "test_data", "simastrom")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
+    datadir = tmp_path / "simastrom"
+    datadir.mkdir(parents=True, exist_ok=True)
 
     field_path = os.path.join(os.path.dirname(__file__), "test_data", "JWST_CALFIELD2020.csv")
     distortion_coeffs_path = os.path.join(os.path.dirname(__file__), "test_data", "distortion_expected_coeffs.csv")
@@ -246,8 +239,8 @@ def test_distortion():
     assert np.all((astrom_cal.data == pickled_astrom.data))
 
     # save and check it can be pickled after save
-    astrom_cal.save(filedir=datadir, filename="astrom_cal_output.fits")
-    astrom_cal_2 = data.AstrometricCalibration(os.path.join(datadir, "astrom_cal_output.fits"))
+    astrom_cal.save(filedir=str(datadir), filename="astrom_cal_output.fits")
+    astrom_cal_2 = data.AstrometricCalibration(str(datadir / "astrom_cal_output.fits"))
 
     # check they can be pickled (for CTC operations)
     pickled = pickle.dumps(astrom_cal_2)

--- a/tests/test_badpixel_correction.py
+++ b/tests/test_badpixel_correction.py
@@ -20,7 +20,7 @@ constant = 10.
 xgradient = np.arange(30)
 
 
-def test_bad_pixels():
+def test_bad_pixels(tmp_path):
     corgidrp.track_individual_errors = False
 
     print("UT for pipeline step correct_bad_pixels")
@@ -46,15 +46,12 @@ def test_bad_pixels():
     assert type(dataset) == corgidrp.data.Dataset
 
     # Generate bad pixel detector mask
-    datadir = os.path.join(os.path.dirname(__file__), "testcalib")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    outputdir = os.path.join(os.path.dirname(__file__), "testcalib")
-    if not os.path.exists(outputdir):
-        os.mkdir(outputdir)
+    datadir = tmp_path / "testcalib"
+    datadir.mkdir(parents=True, exist_ok=True)
+    outputdir = datadir
     col_bp_test = [12, 120, 234, 450, 678, 990]
     row_bp_test = [546, 89, 123, 243, 447, 675]
-    bp_mask = mocks.create_badpixelmap_files(filedir=datadir,
+    bp_mask = mocks.create_badpixelmap_files(filedir=str(datadir),
                                              col_bp=col_bp_test, row_bp=row_bp_test)
     # BadPixelMap requires a dark(-like) frame
     dark_pri, dark_ext, _, _ = create_default_calibration_product_headers()

--- a/tests/test_badpixelmap.py
+++ b/tests/test_badpixelmap.py
@@ -15,25 +15,22 @@ np.random.seed(456)
 FLAG_TO_BIT_MAP = data.get_flag_to_bit_map()
 FLAG_TO_VALUE_MAP = data.get_flag_to_value_map()
 
-def generate_badpixel_map(datadir=None, dthresh=6):
+def generate_badpixel_map(datadir, dthresh=6):
     """
     Create simulated dark and flat calibration data, inject hot and dead pixels,
     and then generate a bad pixel map. Returns the bad pixel map,
     the dark frame, and the flat field frame.
-    
+
     Args:
-        datadir (str, optional): Directory to store simulated data. If None,
-                                 a "simdata" folder in the current directory is used.
+        datadir (str or Path): Directory to store simulated data.
         dthresh (int, optional): Threshold parameter to pass into create_bad_pixel_map.
                                  Defaults to 6.
-    
+
     Returns:
         tuple: (badpixelmap, dark_frame, flat_frame)
     """
-    # Set the data directory.
-    if datadir is None:
-        datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    os.makedirs(datadir, exist_ok=True)
+    # Ensure datadir is a string for legacy API compatibility
+    datadir = str(datadir)
     
     # --- Create and load dark data ---
     dark_dataset = mocks.create_dark_calib_files(filedir=datadir)
@@ -69,7 +66,7 @@ def generate_badpixel_map(datadir=None, dthresh=6):
     return bpm, dark_frame, flat_frame
 
 
-def test_badpixelmap(): 
+def test_badpixelmap(tmp_path):
     '''
 
     Tests the creation of badpixelmaps.
@@ -78,9 +75,11 @@ def test_badpixelmap():
     to create a master bad pixel map. 
 
     '''
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
 
     ###### make the badpixel map (input the flat_dataset just as a dummy):
-    badpixelmap, dark_frame, flat_frame = generate_badpixel_map()
+    badpixelmap, dark_frame, flat_frame = generate_badpixel_map(datadir)
 
     # # Use np.unpackbits to unpack the bits - big endien demical to binary
     badpixelmap_bits = data.unpackbits_64uint(badpixelmap.data[:, :, np.newaxis], axis=2)  # unit64 to binary
@@ -141,12 +140,12 @@ def test_packing_unpacking_uint64():
     assert np.sum(unpacked_bits[0, 0]) == 1, "Only one bit should be set"
 
 
-def test_output_filename_convention():
+def test_output_filename_convention(tmp_path):
     print("**Testing output filename naming conventions**")
 
     bp_fake_data = np.array([
-        [0,  1,  0],   
-        [1,  0, 0],  
+        [0,  1,  0],
+        [1,  0, 0],
         [0, 0, 0]
     ], dtype=float)
 
@@ -172,10 +171,11 @@ def test_output_filename_convention():
     fake_input_dataset = data.Dataset(frames_or_filepaths=[fake_dark, fake_input_image])
 
     bpcal_prihdr, bpcal_exthdr, errhdr, dqhdr = mocks.create_default_calibration_product_headers()
-    
-    # Create test output directory
-    test_output_dir = os.path.join(os.path.dirname(__file__), "testcalib")
-    os.makedirs(test_output_dir, exist_ok=True)
+
+    # Create test output directory using tmp_path
+    test_output_dir = tmp_path / "testcalib"
+    test_output_dir.mkdir(parents=True, exist_ok=True)
+    test_output_dir = str(test_output_dir)
     
     badpixelmap = data.BadPixelMap(bp_fake_data, pri_hdr=bpcal_prihdr, ext_hdr=bpcal_exthdr, input_dataset=fake_input_dataset)
     badpixelmap.save(filedir=test_output_dir)

--- a/tests/test_bit_depth.py
+++ b/tests/test_bit_depth.py
@@ -6,7 +6,7 @@ import corgidrp
 from corgidrp.mocks import generate_coron_dataset_with_companions
 from corgidrp.data import Image
 
-def test_bit_depth():
+def test_bit_depth(tmp_path):
     """
     Modifies the configuration file with different bit depth settings,
     generate and save mock image, check if image data is of the right type
@@ -32,13 +32,11 @@ def test_bit_depth():
     corgidrp.update_pipeline_settings()
 
     # create output directory
-    output_dir = os.path.join(os.path.dirname(__file__), 'bit_depth_test_data')
-    if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
-    os.mkdir(output_dir)
+    output_dir = tmp_path / 'bit_depth_test_data'
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     # generate mock image for testing
-    dataset = generate_coron_dataset_with_companions(outdir=output_dir)
+    dataset = generate_coron_dataset_with_companions(outdir=str(output_dir))
     
     # reset configuration file to its original state
     # reset the file before assert statements so that if the test fails the config file will not be affected

--- a/tests/test_caldb.py
+++ b/tests/test_caldb.py
@@ -9,34 +9,44 @@ import corgidrp.caldb as caldb
 import corgidrp.data as data
 import corgidrp.mocks as mocks
 
-datadir = os.path.join(os.path.dirname(__file__), "simdata")
-calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
 
-if not os.path.exists(datadir):
-    os.mkdir(datadir)
-if not os.path.exists(calibdir):
-    os.mkdir(calibdir)
+@pytest.fixture(scope="module")
+def test_dirs(tmp_path_factory):
+    """Create module-scoped temporary directories for test data and calibrations."""
+    base_dir = tmp_path_factory.mktemp("caldb_test")
+    datadir = base_dir / "simdata"
+    calibdir = base_dir / "testcalib"
+    datadir.mkdir()
+    calibdir.mkdir()
 
-testcaldb_filepath = os.path.join(calibdir, "test_caldb.csv")
+    # make some fake test data to use
+    np.random.seed(456)
+    dark_dataset = mocks.create_dark_calib_files()
+    master_dark = data.Dark(dark_dataset[0].data, dark_dataset[0].pri_hdr, dark_dataset[0].ext_hdr, dark_dataset)
+    # save master dark to disk to be loaded later
+    master_dark.save(filedir=str(calibdir), filename="mockdark.fits")
 
-# make some fake test data to use
-np.random.seed(456)
-dark_dataset = mocks.create_dark_calib_files()
-master_dark = data.Dark(dark_dataset[0].data, dark_dataset[0].pri_hdr, dark_dataset[0].ext_hdr, dark_dataset)
-# save master dark to disk to be loaded later
-master_dark.save(filedir=calibdir, filename="mockdark.fits")
+    return {
+        'datadir': datadir,
+        'calibdir': calibdir,
+        'testcaldb_filepath': calibdir / "test_caldb.csv",
+        'dark_dataset': dark_dataset,
+        'master_dark': master_dark
+    }
 
-def test_caldb_init():
+def test_caldb_init(caldb_initialized):
     """
     Tests that caldb has been initialized. It has to be if it's being imported.
     """
     assert caldb.initialized
 
 
-def test_caldb_create_default():
+def test_caldb_create_default(test_dirs):
     """
     Test caldb creation when no filepath is passed in (uses default path)
     """
+    testcaldb_filepath = str(test_dirs['testcaldb_filepath'])
+
     # remove any stranded testcaldb if needed
     if os.path.exists(testcaldb_filepath):
         os.remove(testcaldb_filepath)
@@ -57,10 +67,12 @@ def test_caldb_create_default():
     corgidrp.caldb_filepath = old_path
 
 
-def test_caldb_custom_filepath():
+def test_caldb_custom_filepath(test_dirs):
     """
     Test caldb creation when filepath is passed in (should be an edge case)
     """
+    testcaldb_filepath = str(test_dirs['testcaldb_filepath'])
+
     # remove any stranded testcaldb if needed
     if os.path.exists(testcaldb_filepath):
         os.remove(testcaldb_filepath)
@@ -76,10 +88,13 @@ def test_caldb_custom_filepath():
     # remove db and restore path
     os.remove(testcaldb_filepath)
 
-def test_caldb_insert_and_remove():
+def test_caldb_insert_and_remove(test_dirs):
     """
     Tests the ability to add and remove an entry successfully
     """
+    testcaldb_filepath = str(test_dirs['testcaldb_filepath'])
+    master_dark = test_dirs['master_dark']
+
     # remove any stranded testcaldb if needed
     if os.path.exists(testcaldb_filepath):
         os.remove(testcaldb_filepath)
@@ -111,10 +126,15 @@ def test_caldb_insert_and_remove():
     master_dark.ext_hdr['EXPTIME'] = orig_exptime
     os.remove(testcaldb_filepath)
 
-def test_get_calib():
+def test_get_calib(test_dirs):
     """
     Tests ability to load a calibration file from disk
     """
+    testcaldb_filepath = str(test_dirs['testcaldb_filepath'])
+    calibdir = str(test_dirs['calibdir'])
+    master_dark = test_dirs['master_dark']
+    dark_dataset = test_dirs['dark_dataset']
+
     # remove any stranded testcaldb if needed
     if os.path.exists(testcaldb_filepath):
         os.remove(testcaldb_filepath)
@@ -150,10 +170,14 @@ def test_get_calib():
 
 
 
-def test_create_entry_file_not_on_disk():
+def test_create_entry_file_not_on_disk(test_dirs):
     """
     Tests that create_entry raises FileNotFoundError when the file does not exist on disk.
     """
+    testcaldb_filepath = str(test_dirs['testcaldb_filepath'])
+    calibdir = str(test_dirs['calibdir'])
+    dark_dataset = test_dirs['dark_dataset']
+
     if os.path.exists(testcaldb_filepath):
         os.remove(testcaldb_filepath)
     testcaldb = caldb.CalDB(filepath=testcaldb_filepath)
@@ -169,11 +193,15 @@ def test_create_entry_file_not_on_disk():
     os.remove(testcaldb_filepath)
 
 
-def test_get_calib_missing_file():
+def test_get_calib_missing_file(test_dirs):
     """
     Tests that get_calib falls back to the next best calibration when the
     best-matching file no longer exists on disk, rather than crashing.
     """
+    testcaldb_filepath = str(test_dirs['testcaldb_filepath'])
+    calibdir = str(test_dirs['calibdir'])
+    dark_dataset = test_dirs['dark_dataset']
+
     if os.path.exists(testcaldb_filepath):
         os.remove(testcaldb_filepath)
     testcaldb = caldb.CalDB(filepath=testcaldb_filepath)
@@ -215,10 +243,14 @@ def test_get_calib_missing_file():
     os.remove(testcaldb_filepath)
 
 
-def test_caldb_scan():
+def test_caldb_scan(test_dirs):
     """
     Tests ability to scan a folder to look for calibration files
     """
+    testcaldb_filepath = str(test_dirs['testcaldb_filepath'])
+    datadir = str(test_dirs['datadir'])
+    calibdir = str(test_dirs['calibdir'])
+
     # remove any stranded testcaldb if needed
     if os.path.exists(testcaldb_filepath):
         os.remove(testcaldb_filepath)
@@ -239,18 +271,21 @@ def test_caldb_scan():
     # reset everything
     os.remove(testcaldb_filepath)
 
-def test_default_calibs():
+def test_default_calibs(test_dirs):
     """
     Tests that the default calibration files are created if they don't exist.
     """
+    testcaldb_filepath = str(test_dirs['testcaldb_filepath'])
+
     # Ensure the test caldb starts fresh (a failing earlier test may leave it behind)
     if os.path.exists(testcaldb_filepath):
         os.remove(testcaldb_filepath)
 
     # Copy all files in corgidrp.default_cal_dir to a temporary directory,
     # then clear out corgidrp.default_cal_dir for this test and restore it at the end
-    current_dir = os.path.dirname(__file__)
-    temp_dir = os.path.join(current_dir, "temp_test_dir")
+    temp_dir = test_dirs['calibdir'] / "temp_test_dir"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    temp_dir = str(temp_dir)
     shutil.copy2(corgidrp.caldb_filepath, os.path.join(corgidrp.config_folder, "temp_caldb.csv"))
     os.makedirs(temp_dir, exist_ok=True)
     for filename in os.listdir(corgidrp.default_cal_dir):
@@ -296,11 +331,13 @@ def test_default_calibs():
     shutil.copy2(os.path.join(corgidrp.config_folder, "temp_caldb.csv"), corgidrp.caldb_filepath)
     os.remove(os.path.join(corgidrp.config_folder, "temp_caldb.csv"))
 
-def test_caldb_filter():
+def test_caldb_filter(test_dirs):
     '''
     test that the filter function works correctly to select the best
-    calibration file 
+    calibration file
     '''
+    testcaldb_filepath = str(test_dirs['testcaldb_filepath'])
+    calibdir = str(test_dirs['calibdir'])
 
     # create mock calibration files
     ct_cal_nfov = mocks.create_ct_cal(3)

--- a/tests/test_calibrate_darks_lsq.py
+++ b/tests/test_calibrate_darks_lsq.py
@@ -49,9 +49,12 @@ def setup_module():
     np.random.seed(4567)  # make test reproducible
     dataset = create_synthesized_master_dark_calib(dat)
     # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
+    # Use worker-specific directories for pytest-xdist isolation
+    _worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'master')
+    _worker_suffix = f"_{_worker_id}" if _worker_id != 'master' else ""
+    datadir = os.path.join(os.path.dirname(__file__), f"simdata{_worker_suffix}")
     if not os.path.exists(datadir):
-        os.mkdir(datadir)
+        os.makedirs(datadir, exist_ok=True)
     if os.path.exists(datadir):
         for name in os.listdir(datadir):
             path = os.path.join(datadir, name)
@@ -126,10 +129,13 @@ def test_expected_results_sub():
         assert np.all((noise_maps.data == pickled_noisemap.data) | np.isnan(noise_maps.data))
 
         # save noise map
-        calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
+        # Use worker-specific directories for pytest-xdist isolation
+        _worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'master')
+        _worker_suffix = f"_{_worker_id}" if _worker_id != 'master' else ""
+        calibdir = os.path.join(os.path.dirname(__file__), f"testcalib{_worker_suffix}")
         nm_filename = noise_maps.filename
         if not os.path.exists(calibdir):
-            os.mkdir(calibdir)
+            os.makedirs(calibdir, exist_ok=True)
         noise_maps.save(filedir=calibdir, filename=nm_filename)
         nm_filepath = os.path.join(calibdir, nm_filename)
         nm_f = DetectorNoiseMaps(nm_filepath)

--- a/tests/test_corethroughput.py
+++ b/tests/test_corethroughput.py
@@ -406,17 +406,14 @@ def test_fpm_pos():
 
     print('Tests about FPAM/FSAM to EXCAM passed')
 
-def test_cal_file():
+def test_cal_file(tmp_path):
     """ Test creation of core throughput calibration file. """
 
     # Write core throughput calibration file
     ct_cal_file_in = corethroughput.generate_ct_cal(dataset_ct)
-    test_dir = os.path.join(here, 'simdata')
-    # Start with all clean
-    if os.path.exists(test_dir):
-        shutil.rmtree(test_dir)
-    os.mkdir(test_dir) 
-    ct_cal_file_in.save(filedir=test_dir)
+    test_dir = tmp_path / 'simdata'
+    test_dir.mkdir(parents=True, exist_ok=True)
+    ct_cal_file_in.save(filedir=str(test_dir))
 
     # Check that the filename is based on the latest input frame timestamp.
     sctsrt_values = [frame.ext_hdr.get('SCTSRT') for frame in dataset_ct
@@ -433,7 +430,7 @@ def test_cal_file():
                                item[0]))[1]
     latest_filename = latest_frame.filename or latest_frame.pri_hdr['FILENAME']
     ct_cal_filename = re.sub('_l[0-9].', '_ctp_cal', latest_filename)
-    ct_cal_filepath = os.path.join(test_dir,ct_cal_filename)
+    ct_cal_filepath = os.path.join(str(test_dir), ct_cal_filename)
     if os.path.exists(ct_cal_filepath) is False:
         raise IOError(f'Core throughput calibration file {ct_cal_filepath} does not exist.')
     # Load the calibration file to check it has the same data contents
@@ -784,7 +781,7 @@ def test_get_1d_ct():
     for i,arg in enumerate(expected_args):
         assert ct_1d[1,i] == ctcal.ct_excam[2,arg]
 
-def test_ct_map():
+def test_ct_map(tmp_path):
     """ Tests the creation of a core throughput map. The method InterpolateCT()
       has its own unit test and can be considered as tested in the following. """
 
@@ -843,11 +840,9 @@ def test_ct_map():
         assert ct_cal.ct_excam[2] == pytest.approx(ct_map_targ.data[2], abs=1e-14)
 
     # Test it can be saved
-    test_dir = os.path.join(here, 'simdata')
-    if os.path.exists(test_dir):
-        shutil.rmtree(test_dir)
-    os.mkdir(test_dir)
-    ct_map_def.save(filedir=test_dir)
+    test_dir = tmp_path / 'simdata'
+    test_dir.mkdir(parents=True, exist_ok=True)
+    ct_map_def.save(filedir=str(test_dir))
     assert os.path.exists(ct_map_def.filepath), f"File not found: {ct_map_def.filepath}"
 
     # Add open the file and compare content

--- a/tests/test_cr_detection.py
+++ b/tests/test_cr_detection.py
@@ -1,5 +1,7 @@
 from astropy.io import fits
 import os
+import tempfile
+import pytest
 
 import corgidrp.data as data
 import corgidrp.mocks as mocks
@@ -15,6 +17,11 @@ from pytest import approx
 
 from collections import Counter
 
+# Per-process scratch dir for all files this module writes. Using a unique temp
+# dir (instead of a shared path under tests/) keeps pytest-xdist workers from
+# racing on the same files during parallel collection/execution.
+_scratch_dir = tempfile.mkdtemp(prefix="cr_detection_")
+
 ###########################################
 ### Create a dummy non-linearity file ####
 #Create a mock dataset because it is a required input when creating a NonLinearityCalibration
@@ -24,7 +31,7 @@ dummy_dataset = mocks.create_prescan_files()
 input_non_linearity_filename = "nonlin_table_TVAC.txt"
 input_non_linearity_path = os.path.join(os.path.dirname(__file__), "test_data", input_non_linearity_filename)
 test_non_linearity_filename = input_non_linearity_filename.split(".")[0] + ".fits"
-nonlin_fits_filepath = os.path.join(os.path.dirname(__file__), "test_data", test_non_linearity_filename)
+nonlin_fits_filepath = os.path.join(_scratch_dir, test_non_linearity_filename)
 tvac_nonlin_data = np.genfromtxt(input_non_linearity_path, delimiter=",")
 
 pri_hdr, ext_hdr, errhdr, dqhdr = mocks.create_default_calibration_product_headers()
@@ -340,7 +347,8 @@ def remove_cosmics_iit(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_bo
 ## Run tests ##
 
 ###### create simulated data
-datadir = os.path.join(os.path.dirname(__file__), "simdata")
+datadir = os.path.join(_scratch_dir, "simdata")
+os.makedirs(datadir, exist_ok=True)
 
 detector_params = data.DetectorParams({}, date_valid=Time("2023-11-01 00:00:00"))
 

--- a/tests/test_create_flatfield.py
+++ b/tests/test_create_flatfield.py
@@ -14,27 +14,23 @@ import photutils.centroids as centr
 
 old_err_tracking = corgidrp.track_individual_errors
 
-def test_create_flatfield_neptune():
+def test_create_flatfield_neptune(tmp_path):
     """
     Generate mock input data and pass into flat division function
     """
     corgidrp.track_individual_errors = True # this test uses individual error components
 
     ###### create simulated data
-    # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir) 
-    
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+
     # simulated images to be checked in flat division
-    simflat_dataset = mocks.create_simflat_dataset(filedir=datadir)
-    
+    simflat_dataset = mocks.create_simflat_dataset(filedir=str(datadir))
+
     ###### create simulated raster scanned data
-    # check that simulated raster scanned data folder exists, and create if not
-    file_dir = os.path.join(os.path.dirname(__file__), "simdata_rasterscan")
-    data_dir = os.path.join(os.path.dirname(__file__),"test_data/")
-    if not os.path.exists(file_dir):
-        os.mkdir(file_dir) 
+    file_dir = tmp_path / "simdata_rasterscan"
+    file_dir.mkdir(parents=True, exist_ok=True)
+    data_dir = os.path.join(os.path.dirname(__file__),"test_data/") 
     filenames = glob.glob(os.path.join(data_dir, "med*.fits"))
     data_set = data.Dataset(filenames)
     # creating flatfield for neptune for band 1
@@ -52,11 +48,9 @@ def test_create_flatfield_neptune():
     pickled_flat = pickle.loads(pickled)
     assert np.all(onskyflat_field.data == pickled_flat.data)
 
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
-    
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    onskyflat_field.save(filedir=calibdir)
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
+    onskyflat_field.save(filedir=str(calibdir))
     
     ###### perform flat division
     # load in the flatfield
@@ -98,24 +92,20 @@ def test_create_flatfield_neptune():
     
      #creating flatfield using uranus for band4 
     
-def test_create_flatfield_uranus():
+def test_create_flatfield_uranus(tmp_path):
 
     corgidrp.track_individual_errors = True
     ###### create simulated data
-    # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir) 
-    
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+
     # simulated images to be checked in flat division
-    simflat_dataset = mocks.create_simflat_dataset(filedir=datadir)
-    
+    simflat_dataset = mocks.create_simflat_dataset(filedir=str(datadir))
+
     ###### create simulated raster scanned data
-    # check that simulated raster scanned data folder exists, and create if not
-    file_dir = os.path.join(os.path.dirname(__file__), "simdata_rasterscan")
+    file_dir = tmp_path / "simdata_rasterscan"
+    file_dir.mkdir(parents=True, exist_ok=True)
     data_dir = os.path.join(os.path.dirname(__file__),"test_data/")
-    if not os.path.exists(file_dir):
-        os.mkdir(file_dir) 
     filenames = glob.glob(os.path.join(data_dir, "med*.fits"))
     data_set = data.Dataset(filenames)
     planet='uranus'; band='4'
@@ -128,11 +118,9 @@ def test_create_flatfield_uranus():
     assert np.size(np.where(np.isnan(onskyflat_field.data))) == 0 # no bad pixels
     
     
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
-    
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    onskyflat_field.save(filedir=calibdir)
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
+    onskyflat_field.save(filedir=str(calibdir))
     
     ###### perform flat division
     # load in the flatfield

--- a/tests/test_create_polflatfield.py
+++ b/tests/test_create_polflatfield.py
@@ -13,27 +13,23 @@ import photutils.centroids as centr
 
 old_err_tracking = corgidrp.track_individual_errors
 
-def test_create_polflatfield_pol0_neptune():
+def test_create_polflatfield_pol0_neptune(tmp_path):
     """
     Generate mock input data and pass into flat division function
     """
     corgidrp.track_individual_errors = True # this test uses individual error components
 
     ###### create simulated data
-    # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir) 
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
     # simulated images to be checked in flat division
     # create_simflat_dataset returns a Dataset, so use that directly
-    simflat_dataset = mocks.create_simflat_dataset(filedir=datadir)
-    
+    simflat_dataset = mocks.create_simflat_dataset(filedir=str(datadir))
+
     ###### create simulated raster scanned data
-    # check that simulated raster scanned data folder exists, and create if not
-    file_dir = os.path.join(os.path.dirname(__file__), "simdata_rasterscan_pol")
-    data_dir = os.path.join(os.path.dirname(__file__),"test_data/")
-    if not os.path.exists(file_dir):
-        os.mkdir(file_dir) 
+    file_dir = tmp_path / "simdata_rasterscan_pol"
+    file_dir.mkdir(parents=True, exist_ok=True)
+    data_dir = os.path.join(os.path.dirname(__file__),"test_data/") 
     filenames = glob.glob(os.path.join(data_dir, "med*.fits"))
     data_set = data.Dataset(filenames)
 
@@ -42,7 +38,7 @@ def test_create_polflatfield_pol0_neptune():
     #creates a planet image with spatial variation of polarization for POL0 
     pol_image=mocks.create_spatial_pol(data_set,filedir=None,nr=60,pfov_size=140,image_center_x=512,image_center_y=512,separation_diameter_arcsec=7.5,alignment_angle_WP1=0,alignment_angle_WP2=45,planet='neptune',band='1',dpamname='POL0')
     #creates raster scanned images for POL0 
-    polraster_dataset = mocks.create_onsky_rasterscans(pol_image,filedir=file_dir,planet='neptune',band='1',im_size=800,d=40, n_dith=2,radius=55,snr=250,snr_constant=4.55,flat_map=None, raster_radius=40, raster_subexps=1)
+    polraster_dataset = mocks.create_onsky_rasterscans(pol_image,filedir=str(file_dir),planet='neptune',band='1',im_size=800,d=40, n_dith=2,radius=55,snr=250,snr_constant=4.55,flat_map=None, raster_radius=40, raster_subexps=1)
      #creates flatfield for POL0 
     polflatfield_pol0=flat.create_onsky_pol_flatfield(polraster_dataset,planet='neptune',band='1',up_radius=55,im_size=1024,N=1,rad_mask=1.26, planet_rad=50, n_pix=174, observing_mode='NFOV', n_pad=0,fwhm_guess=20, sky_annulus_rin=2, sky_annulus_rout=4,plate_scale=0.0218,image_center_x=512,image_center_y=512,separation_diameter_arcsec=7.5,alignment_angle_WP1=0,alignment_angle_WP2=45,dpamname='POL0')
 
@@ -54,17 +50,15 @@ def test_create_polflatfield_pol0_neptune():
     pickled_flat = pickle.loads(pickled)
     assert np.all(polflatfield_pol0.data == pickled_flat.data)
 
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
-    
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    polflatfield_pol0.save(filedir=calibdir)
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
+    polflatfield_pol0.save(filedir=str(calibdir))
     
     ###### perform flat division
     # load in the flatfield
     # check that the filename is what we expect
     flat_filename = polraster_dataset[-1].filename.replace("_l2a", "_flt_cal")
-    flat_filepath = os.path.join(calibdir, flat_filename)
+    flat_filepath = str(calibdir / flat_filename)
     polflatfield_pol0 = data.FlatField(flat_filepath)
 
     # check the flat can be pickled (for CTC operations)
@@ -98,27 +92,23 @@ def test_create_polflatfield_pol0_neptune():
 
     return
 
-def test_create_polflatfield_pol45_neptune():
+def test_create_polflatfield_pol45_neptune(tmp_path):
     """
     Generate mock input data and pass into flat division function
     """
     corgidrp.track_individual_errors = True # this test uses individual error components
 
     ###### create simulated data
-    # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir) 
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
     # simulated images to be checked in flat division
     # create_simflat_dataset returns a Dataset, so use that directly
-    simflat_dataset = mocks.create_simflat_dataset(filedir=datadir)
-    
+    simflat_dataset = mocks.create_simflat_dataset(filedir=str(datadir))
+
     ###### create simulated raster scanned data
-    # check that simulated raster scanned data folder exists, and create if not
-    file_dir = os.path.join(os.path.dirname(__file__), "simdata_rasterscan_pol")
+    file_dir = tmp_path / "simdata_rasterscan_pol"
+    file_dir.mkdir(parents=True, exist_ok=True)
     data_dir = os.path.join(os.path.dirname(__file__),"test_data/")
-    if not os.path.exists(file_dir):
-        os.mkdir(file_dir) 
     filenames = glob.glob(os.path.join(data_dir, "med*.fits"))
     data_set = data.Dataset(filenames)
 
@@ -127,7 +117,7 @@ def test_create_polflatfield_pol45_neptune():
     #creates a planet image with spatial variation of polarization for POL45
     pol_image=mocks.create_spatial_pol(data_set,nr=60,filedir=None,pfov_size=140,image_center_x=512,image_center_y=512,separation_diameter_arcsec=7.5,alignment_angle_WP1=0,alignment_angle_WP2=45,planet='neptune',band='1',dpamname='POL45')
     #creates raster scanned images for POL45
-    polraster_dataset = mocks.create_onsky_rasterscans(pol_image,filedir=file_dir,planet='neptune',band='1',im_size=800,d=50, n_dith=2,radius=55,snr=250,snr_constant=4.55,flat_map=None, raster_radius=40, raster_subexps=1)
+    polraster_dataset = mocks.create_onsky_rasterscans(pol_image,filedir=str(file_dir),planet='neptune',band='1',im_size=800,d=50, n_dith=2,radius=55,snr=250,snr_constant=4.55,flat_map=None, raster_radius=40, raster_subexps=1)
      #creates flatfield for  POL45
     polflatfield_pol45=flat.create_onsky_pol_flatfield(polraster_dataset,planet='neptune',band='1',up_radius=55,im_size=1024,N=1,rad_mask=1.26, planet_rad=50, n_pix=174,observing_mode='NFOV', n_pad=0,fwhm_guess=20, sky_annulus_rin=2, sky_annulus_rout=4,plate_scale=0.0218,image_center_x=512,image_center_y=512,separation_diameter_arcsec=7.5,alignment_angle_WP1=0,alignment_angle_WP2=45,dpamname='POL45')
     assert np.nanmean(polflatfield_pol45.data) == pytest.approx(1, abs=1e-2)
@@ -138,17 +128,15 @@ def test_create_polflatfield_pol45_neptune():
     pickled_flat = pickle.loads(pickled)
     assert np.all(polflatfield_pol45.data == pickled_flat.data)
 
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
-    
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    polflatfield_pol45.save(filedir=calibdir)
-    
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
+    polflatfield_pol45.save(filedir=str(calibdir))
+
     ###### perform flat division
     # load in the flatfield
     # check that the filename is what we expect
     flat_filename = polraster_dataset[-1].filename.replace("_l2a", "_flt_cal")
-    flat_filepath = os.path.join(calibdir, flat_filename)
+    flat_filepath = str(calibdir / flat_filename)
     polflatfield_pol45 = data.FlatField(flat_filepath)
 
     # check the flat can be pickled (for CTC operations)
@@ -181,29 +169,25 @@ def test_create_polflatfield_pol45_neptune():
     return
 
 
-def test_create_polflatfield_pol0_uranus():
+def test_create_polflatfield_pol0_uranus(tmp_path):
 
     corgidrp.track_individual_errors = True
     ###### create simulated data
-    # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir) 
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
     # simulated images to be checked in flat division
     # create_simflat_dataset returns a Dataset, so use that directly
-    simflat_dataset = mocks.create_simflat_dataset(filedir=datadir)
-    
+    simflat_dataset = mocks.create_simflat_dataset(filedir=str(datadir))
+
     ###### create simulated raster scanned data
-    # check that simulated raster scanned data folder exists, and create if not
-    file_dir = os.path.join(os.path.dirname(__file__), "simdata_rasterscan")
+    file_dir = tmp_path / "simdata_rasterscan"
+    file_dir.mkdir(parents=True, exist_ok=True)
     data_dir = os.path.join(os.path.dirname(__file__),"test_data/")
-    if not os.path.exists(file_dir):
-        os.mkdir(file_dir) 
     filenames = glob.glob(os.path.join(data_dir, "med*.fits"))
     data_set = data.Dataset(filenames)
     planet='uranus'; band='1'
     pol_image=mocks.create_spatial_pol(data_set,filedir=None,nr=90,pfov_size=200,image_center_x=512,image_center_y=512,separation_diameter_arcsec=7.5,alignment_angle_WP1=0,alignment_angle_WP2=45,planet='uranus',band='1',dpamname='POL0')
-    polraster_dataset = mocks.create_onsky_rasterscans(pol_image,filedir=file_dir,planet='uranus',band='1',im_size=900,d=65, n_dith=2,radius=90,snr=250,snr_constant=9.66,flat_map=None, raster_radius=40, raster_subexps=1)
+    polraster_dataset = mocks.create_onsky_rasterscans(pol_image,filedir=str(file_dir),planet='uranus',band='1',im_size=900,d=65, n_dith=2,radius=90,snr=250,snr_constant=9.66,flat_map=None, raster_radius=40, raster_subexps=1)
     polflatfield_pol0=flat.create_onsky_pol_flatfield(polraster_dataset,planet='uranus',band='1',up_radius=55,im_size=1024,N=1,rad_mask=1.26, planet_rad=50, n_pix=174,observing_mode='NFOV', n_pad=0, fwhm_guess=25,sky_annulus_rin=2, sky_annulus_rout=4,plate_scale=0.0218,image_center_x=512,image_center_y=512,separation_diameter_arcsec=7.5,alignment_angle_WP1=0,alignment_angle_WP2=45,dpamname='POL0')
 
     assert np.nanmean(polflatfield_pol0.data) == pytest.approx(1, abs=1e-2)
@@ -214,17 +198,15 @@ def test_create_polflatfield_pol0_uranus():
     pickled_flat = pickle.loads(pickled)
     assert np.all(polflatfield_pol0.data == pickled_flat.data)
 
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
-    
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    polflatfield_pol0.save(filedir=calibdir)
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
+    polflatfield_pol0.save(filedir=str(calibdir))
     
     ###### perform flat division
     # load in the flatfield
     # check that the filename is what we expect
     flat_filename = polraster_dataset[-1].filename.replace("_l2a", "_flt_cal")
-    flat_filepath = os.path.join(calibdir, flat_filename)
+    flat_filepath = str(calibdir / flat_filename)
     polflatfield_pol0 = data.FlatField(flat_filepath)
 
     # check the flat can be pickled (for CTC operations)
@@ -259,29 +241,25 @@ def test_create_polflatfield_pol0_uranus():
 
     return
 
-def test_create_polflatfield_pol45_uranus():
+def test_create_polflatfield_pol45_uranus(tmp_path):
 
     corgidrp.track_individual_errors = True
     ###### create simulated data
-    # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir) 
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
     # simulated images to be checked in flat division
     # create_simflat_dataset returns a Dataset, so use that directly
-    simflat_dataset = mocks.create_simflat_dataset(filedir=datadir)
-    
+    simflat_dataset = mocks.create_simflat_dataset(filedir=str(datadir))
+
     ###### create simulated raster scanned data
-    # check that simulated raster scanned data folder exists, and create if not
-    file_dir = os.path.join(os.path.dirname(__file__), "simdata_rasterscan")
+    file_dir = tmp_path / "simdata_rasterscan"
+    file_dir.mkdir(parents=True, exist_ok=True)
     data_dir = os.path.join(os.path.dirname(__file__),"test_data/")
-    if not os.path.exists(file_dir):
-        os.mkdir(file_dir) 
     filenames = glob.glob(os.path.join(data_dir, "med*.fits"))
     data_set = data.Dataset(filenames)
     planet='uranus'; band='1'
     pol_image=mocks.create_spatial_pol(data_set,filedir=None,nr=90,pfov_size=200,image_center_x=512,image_center_y=512,separation_diameter_arcsec=7.5,alignment_angle_WP1=0,alignment_angle_WP2=45,planet='uranus',band='1',dpamname='POL45')
-    polraster_dataset = mocks.create_onsky_rasterscans(pol_image,filedir=file_dir,planet='uranus',band='1',im_size=900,d=65, n_dith=2,radius=90,snr=250,snr_constant=9.66,flat_map=None, raster_radius=40, raster_subexps=1)
+    polraster_dataset = mocks.create_onsky_rasterscans(pol_image,filedir=str(file_dir),planet='uranus',band='1',im_size=900,d=65, n_dith=2,radius=90,snr=250,snr_constant=9.66,flat_map=None, raster_radius=40, raster_subexps=1)
     polflatfield_pol45=flat.create_onsky_pol_flatfield(polraster_dataset,planet='uranus',band='1',up_radius=55,im_size=1024,N=1,rad_mask=1.26, planet_rad=50, n_pix=174,observing_mode='NFOV', n_pad=0,fwhm_guess=25, sky_annulus_rin=2, sky_annulus_rout=4,plate_scale=0.021,image_center_x=512,image_center_y=512,separation_diameter_arcsec=7.5,alignment_angle_WP1=0,alignment_angle_WP2=45,dpamname='POL45')
 
     assert np.nanmean(polflatfield_pol45.data) == pytest.approx(1, abs=1e-2)
@@ -292,17 +270,15 @@ def test_create_polflatfield_pol45_uranus():
     pickled_flat = pickle.loads(pickled)
     assert np.all(polflatfield_pol45.data == pickled_flat.data)
 
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
-    
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    polflatfield_pol45.save(filedir=calibdir)
-    
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
+    polflatfield_pol45.save(filedir=str(calibdir))
+
     ###### perform flat division
     # load in the flatfield
     # check that the filename is what we expect
     flat_filename = polraster_dataset[-1].filename.replace("_l2a", "_flt_cal")
-    flat_filepath = os.path.join(calibdir, flat_filename)
+    flat_filepath = str(calibdir / flat_filename)
     polflatfield_pol45 = data.FlatField(flat_filepath)
 
     # check the flat can be pickled (for CTC operations)

--- a/tests/test_dark_sub.py
+++ b/tests/test_dark_sub.py
@@ -10,7 +10,10 @@ import corgidrp.detector as detector
 import corgidrp.l2a_to_l2b as l2a_to_l2b
 from corgidrp.darks import build_trad_dark
 
-np.random.seed(456)
+# Mark all tests in this file to run serially (not in parallel)
+# This file uses shared simdata/testcalib directories without worker isolation
+# Also has non-deterministic behavior with random data generation
+pytestmark = pytest.mark.serial
 
 old_err_tracking = corgidrp.track_individual_errors
 # use default parameters
@@ -34,22 +37,17 @@ Cdq = Cerr.copy().astype(int)
 noise_maps = mocks.create_noise_maps(Fd, Ferr, Fdq, Cd,
                                             Cerr, Cdq, Dd, Derr, Ddq)
 
-def test_dark_sub():
+def test_dark_sub(tmp_path):
     """
     Generate mock input data and pass into dark subtraction function
     """
-    # Reset random seed to ensure deterministic behavior regardless of test execution order
-    np.random.seed(456)
+    np.random.seed(456)  # Reset seed at function start for reproducibility
     corgidrp.track_individual_errors = True # this test uses individual error components
 
     ###### create simulated data
-    # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    for name in os.listdir(datadir):
-            path = os.path.join(datadir, name)
-            os.remove(path)
+    # Use worker-isolated temporary directory to avoid race conditions with parallel tests
+    datadir = str(tmp_path / "simdata")
+    os.makedirs(datadir, exist_ok=True)
 
     ####### test data architecture
     dark_dataset = mocks.create_dark_calib_files(filedir=datadir)
@@ -86,10 +84,9 @@ def test_dark_sub():
     assert np.allclose(np.std(dark_dataset_notelem, axis = 0)/np.sqrt(len(dark_dataset_notelem)), dark_frame_full.err[0][0:-1, :], rtol=1e-6)
 
     # save dark
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
+    calibdir = str(tmp_path / "testcalib")
     dark_filename = "sim_dark_calib.fits"
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
+    os.makedirs(calibdir, exist_ok=True)
     dark_frame_full.save(filedir=calibdir, filename=dark_filename)
 
     ###### perform dark subtraction
@@ -187,15 +184,15 @@ def test_dark_sub():
 
     corgidrp.track_individual_errors = old_err_tracking
 
-def test_dark_sub_multi_config():
+def test_dark_sub_multi_config(tmp_path):
     """
     Verify that dark_subtraction handles a dataset with multiple EMGAIN/EXPTIME
     configurations when noisemaps is provided, and that the traditional-dark path
     still rejects multi-config input.
     """
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
+    np.random.seed(789)  # Use different seed to ensure test independence
+    calibdir = str(tmp_path / "testcalib")
+    os.makedirs(calibdir, exist_ok=True)
 
     configs = [
         {"EMGAIN_C": 10, "EXPTIME": 4},
@@ -221,10 +218,8 @@ def test_dark_sub_multi_config():
     multi_config_dataset = data.Dataset(frames)
 
     # use a fresh empty directory so every dark saved by the call is attributable to it
-    darkout = os.path.join(os.path.dirname(__file__), "testcalib_multiconfig")
-    if os.path.exists(darkout):
-        shutil.rmtree(darkout)
-    os.mkdir(darkout)
+    darkout = str(tmp_path / "testcalib_multiconfig")
+    os.makedirs(darkout, exist_ok=True)
 
     # noisemaps path: must succeed and produce ~0 result for each frame
     result = l2a_to_l2b.dark_subtraction(multi_config_dataset, noisemaps=noise_maps, outputdir=darkout)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -127,15 +127,15 @@ def test_split_dataset():
 
 
 
-def test_pickling():
+def test_pickling(tmp_path):
     """
     Test that datasets and images can be pickled
     """
     ###### create simulated data
-    # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
+    # Use tmp_path for test isolation
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+    datadir = str(datadir)
 
     ####### test data architecture
     dark_dataset = create_dark_calib_files(filedir=datadir)

--- a/tests/test_detector_params.py
+++ b/tests/test_detector_params.py
@@ -34,7 +34,7 @@ def test_hashing():
     new_detparams = data.DetectorParams({'FWC_EM_E' : 200000}, date_valid=time.Time("2023-11-01 00:00:00", scale='utc'))
     assert default_detparams.get_hash() != new_detparams.get_hash()
 
-def test_pickling():
+def test_pickling(caldb_initialized):
     """
     Test detector params can be pickled
     """

--- a/tests/test_err_dq.py
+++ b/tests/test_err_dq.py
@@ -10,6 +10,10 @@ from corgidrp.data import Image, Dataset, DetectorParams
 import corgidrp.caldb as caldb
 from corgidrp.darks import build_trad_dark
 
+# Mark all tests in this file to run serially (not in parallel)
+# This file uses shared simdata/testcalib directories without worker isolation
+pytestmark = pytest.mark.serial
+
 np.random.seed(123)
 
 float_data = 2.
@@ -273,7 +277,7 @@ def test_read_many_errors_notrack():
         assert image_test.err_hdr["Layer_3"] == "error_nuts"
 
 
-def test_err_array_sizes():
+def test_err_array_sizes(tmp_path):
     '''
     Check that we're robust to 2D error arrays
 
@@ -283,31 +287,29 @@ def test_err_array_sizes():
     '''
 
     ##### Create a master Dark #####
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    dark_dataset = mocks.create_dark_calib_files(filedir=datadir)
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+    dark_dataset = mocks.create_dark_calib_files(filedir=str(datadir))
     dark_frame = build_trad_dark(dark_dataset, detector_params, detector_regions=None, full_frame=True)
 
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
     # clean out directory of old cals .fits files
-    for filename in os.listdir(calibdir):
-        if filename.endswith(".fits"):
-            os.remove(os.path.join(calibdir, filename))
-            
+    for filename in calibdir.iterdir():
+        if filename.suffix == ".fits":
+            filename.unlink()
+
     dark_filename = "sim_dark_calib.fits"
-    if not os.path.exists(calibdir):
-            os.mkdir(calibdir)
-    dark_frame.save(filedir=calibdir, filename=dark_filename)
+    dark_frame.save(filedir=str(calibdir), filename=dark_filename)
 
     ##### Scan the caldb ##### - This tests for previous bug that darks weren't in the right format.
-    testcaldb_filepath = os.path.join(calibdir, "test_caldb.csv")
+    testcaldb_filepath = str(calibdir / "test_caldb.csv")
     testcaldb = caldb.CalDB(filepath=testcaldb_filepath)
-    testcaldb.scan_dir_for_new_entries(calibdir)
+    testcaldb.scan_dir_for_new_entries(str(calibdir))
 
     ##### Force it to be 2D ##### - This tests to maks sure we're robust to 2D error arrays in general
     dark_frame.err = np.ones(dark_frame.data.shape)
-    dark_frame.save(filedir=calibdir, filename=dark_filename)
+    dark_frame.save(filedir=str(calibdir), filename=dark_filename)
     testcaldb.scan_dir_for_new_entries(calibdir)
 
 

--- a/tests/test_exptime_normalization.py
+++ b/tests/test_exptime_normalization.py
@@ -10,18 +10,16 @@ import corgidrp.l2b_to_l3 as l2b_to_l3
 
 #%%
 
-def test_exptime_normalization():
+def test_exptime_normalization(tmp_path):
     """
     Generate mock input data and pass into exposure_time_normalization function
     """
     ###### create simulated data
-    # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+
     #create simulated data
-    not_normalized_dataset = mocks.create_not_normalized_dataset(filedir=datadir)
+    not_normalized_dataset = mocks.create_not_normalized_dataset(filedir=str(datadir))
 
     # extract the exposure time from each Image and check that it is >0
     exposure_times = np.zeros(len(not_normalized_dataset.frames))

--- a/tests/test_flat_div.py
+++ b/tests/test_flat_div.py
@@ -11,24 +11,22 @@ import corgidrp.l2a_to_l2b as l2a_to_l2b
 old_err_tracking = corgidrp.track_individual_errors
 
 np.random.seed(9292)
-def test_flat_div():
+def test_flat_div(tmp_path):
     """
     Generate mock input data and pass into flat division function
     """
     corgidrp.track_individual_errors = True # this test uses individual error components
 
     ###### create simulated data
-    # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir) 
-    
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+
     # simulated images to be checked in flat division
-    simflat_dataset = mocks.create_simflat_dataset(filedir=datadir)
+    simflat_dataset = mocks.create_simflat_dataset(filedir=str(datadir))
      
     # creat one dummy flat field perform flat division
     #test data architecture
-    flat_dataset = mocks.create_flatfield_dummy(filedir=datadir)
+    flat_dataset = mocks.create_flatfield_dummy(filedir=str(datadir))
     #check that data is consistently modified
     flat_dataset.all_data[0,0,0] = 1
     assert flat_dataset[0].data[0,0] == 1
@@ -42,15 +40,14 @@ def test_flat_div():
     # check that the error is determined correctly
     assert np.array_equal(np.std(flat_dataset.all_data, axis = 0)/np.sqrt(len(flat_dataset)), flat_frame.err[0])
 	# save flatfield
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
     flat_filename = "sim_flat_calib.fits"
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    flat_frame.save(filedir=calibdir, filename=flat_filename)
-    
+    flat_frame.save(filedir=str(calibdir), filename=flat_filename)
+
     ###### perform flat division
     # load in the flatfield
-    flat_filepath = os.path.join(calibdir, flat_filename)
+    flat_filepath = str(calibdir / flat_filename)
     flatfield = data.FlatField(flat_filepath)
     # divide the simulated dataset with the dummy flatfield
     flatdivided_dataset = l2a_to_l2b.flat_division(simflat_dataset, flatfield)

--- a/tests/test_fluxcal.py
+++ b/tests/test_fluxcal.py
@@ -32,6 +32,10 @@ import astropy.units as u
 from termcolor import cprint
 import numpy as np
 
+# Mark all tests in this file to run serially (not in parallel)
+# This file has module-level shared state that causes race conditions in parallel
+pytestmark = pytest.mark.serial
+
 # Suppress all warnings for all tests in this file
 # warnings.filterwarnings("ignore")
 
@@ -49,6 +53,13 @@ image2.filename = "cgi_0000000000000090527_20240101t1201000_l4_.fits"
 dataset=Dataset([image1, image2])
 calspec_filepath = os.path.join(os.path.dirname(__file__), "test_data", "alpha_lyr_stis_012.fits")
 
+# Initialize module-level variables used across tests
+# These are set by test_get_filter_name and test_flux_calc, and used by later tests
+filepath = fluxcal.get_filter_name(image1)
+wave, transmission = fluxcal.read_filter_curve(filepath)
+calspec_flux = fluxcal.read_cal_spec(calspec_filepath, wave)
+band_flux = fluxcal.calculate_band_flux(transmission, calspec_flux, wave)
+
 
 def print_fail():
     cprint(' FAIL ', "black", "on_red")
@@ -62,34 +73,31 @@ def test_get_filter_name():
     """
     test that the correct filter curve file is selected
     """
-    global wave
-    global transmission
-    filepath = fluxcal.get_filter_name(image1)
-    assert filepath.split("/")[-1] == 'transmission_ID-21_3C_v0.csv'
-    
-    wave, transmission = fluxcal.read_filter_curve(filepath)
-    
-    assert np.any(wave>=7130)
-    assert np.any(transmission < 1.)
-    
+    test_filepath = fluxcal.get_filter_name(image1)
+    assert test_filepath.split("/")[-1] == 'transmission_ID-21_3C_v0.csv'
+
+    test_wave, test_transmission = fluxcal.read_filter_curve(test_filepath)
+
+    assert np.any(test_wave>=7130)
+    assert np.any(test_transmission < 1.)
+
     #test a wrong filter name
     image3 = image1.copy()
     image3.ext_hdr["CFAMNAME"] = '5C'
     with pytest.raises(ValueError):
         filepath = fluxcal.get_filter_name(image3)
         pass
-    
+
 
 def test_flux_calc():
     """
     test that the calspec data is read correctly
     """
-    global band_flux
-    calspec_flux = fluxcal.read_cal_spec(calspec_filepath, wave)
-    assert calspec_flux[0] == pytest.approx(1.6121e-09, 1e-15) 
-    
-    band_flux = fluxcal.calculate_band_flux(transmission, calspec_flux, wave)
-    eff_lambda = fluxcal.calculate_effective_lambda(transmission, calspec_flux, wave)
+    test_calspec_flux = fluxcal.read_cal_spec(calspec_filepath, wave)
+    assert test_calspec_flux[0] == pytest.approx(1.6121e-09, 1e-15)
+
+    test_band_flux = fluxcal.calculate_band_flux(transmission, test_calspec_flux, wave)
+    eff_lambda = fluxcal.calculate_effective_lambda(transmission, test_calspec_flux, wave)
     assert eff_lambda == pytest.approx((wave[0]+wave[-1])/2., 3)
     
 def test_colorcor():
@@ -182,8 +190,8 @@ def test_app_mag():
     assert 'alpha_lyr_stis' in str(output_dataset[0].ext_hdr['HISTORY'])
     assert '109vir_stis_005.fits' in str(output_dataset[0].ext_hdr['HISTORY'])
     
-def test_fluxcal_file():
-    """ 
+def test_fluxcal_file(tmp_path):
+    """
     Generate a mock fluxcal factor cal object and test the content and functionality.
     """
     fluxcal_factor = 2e-12
@@ -193,14 +201,13 @@ def test_fluxcal_file():
     assert fluxcal_fac.fluxcal_fac == fluxcal_factor
     assert fluxcal_fac.fluxcal_err == fluxcal_factor_error
     assert(fluxcal_fac.filename.endswith("_abf_cal.fits"))
-    
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
+
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
     filename = fluxcal_fac.filename
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    fluxcal_fac.save(filedir=calibdir, filename=filename)        
+    fluxcal_fac.save(filedir=str(calibdir), filename=filename)        
         
-    fluxcal_filepath = os.path.join(calibdir, filename)
+    fluxcal_filepath = str(calibdir / filename)
 
     fluxcal_fac_file = FluxcalFactor(fluxcal_filepath)
     assert fluxcal_fac_file.filter == '3C'
@@ -553,23 +560,20 @@ def test_compute_spec_flux_ratio_weighted():
     print_pass() if result else print_fail()
     assert result
 
-def test_abs_fluxcal():
-    """ 
+def test_abs_fluxcal(tmp_path):
+    """
     Generate a simulated image and test the flux calibration computation.
-    
+
     """
     rel_tol_flux = 0.05
 
     # create a simulated image with source guesses and true positions
-    # check that the simulated image folder exists and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "test_data", "sim_fluxcal")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
+    datadir = tmp_path / "sim_fluxcal"
+    datadir.mkdir(parents=True, exist_ok=True)
 
     # check that the results folder exists and create if not
-    resdir = os.path.join(os.path.dirname(__file__), "test_data", "results")
-    if not os.path.exists(resdir):
-        os.mkdir(resdir)
+    resdir = tmp_path / "results"
+    resdir.mkdir(parents=True, exist_ok=True)
 
     fwhm = 3
     flux_ratio = 200
@@ -579,7 +583,7 @@ def test_abs_fluxcal():
     # that results in a total extracted count of 200 photo electrons
     flux_image = create_flux_image(
         band_flux, fwhm, cal_factor, filter='3C', target_name='Vega',
-        fsm_x=0.0, fsm_y=0.0, exptime=1.0, filedir=datadir, platescale=21.8,
+        fsm_x=0.0, fsm_y=0.0, exptime=1.0, filedir=str(datadir), platescale=21.8,
         background=0, add_gauss_noise=True, noise_scale=1., file_save=True)
     # bunit needs to be photoelectron/s for later tests, so set that now
     flux_image.ext_hdr['BUNIT'] = 'photoelectron/s'
@@ -772,24 +776,21 @@ def test_abs_fluxcal():
     
     corgidrp.track_individual_errors = old_ind
 
-def test_pol_abs_fluxcal():
-    """ 
+def test_pol_abs_fluxcal(tmp_path):
+    """
     Generate a simulated polarimetric image and test the flux calibration computation.
     Adapted from test_abs_fluxcal()
-    
+
     """
     rel_tol_flux = 0.05
 
     # create a simulated polarimetric flux image
-    # check that the simulated image folder exists and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "test_data", "sim_fluxcal")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
+    datadir = tmp_path / "sim_fluxcal"
+    datadir.mkdir(parents=True, exist_ok=True)
 
     # check that the results folder exists and create if not
-    resdir = os.path.join(os.path.dirname(__file__), "test_data", "results")
-    if not os.path.exists(resdir):
-        os.mkdir(resdir)
+    resdir = tmp_path / "results"
+    resdir.mkdir(parents=True, exist_ok=True)
     
     fwhm = 3
     flux_ratio = 400
@@ -802,11 +803,11 @@ def test_pol_abs_fluxcal():
     #right PSF should have count of 160 photo electons
     flux_image_WP1 = create_pol_flux_image(
         band_flux_left, band_flux_right, fwhm, cal_factor, filter='3C', dpamname='POL0', target_name='Vega',
-        fsm_x=0.0, fsm_y=0.0, exptime=1.0, filedir=datadir, platescale=21.8,
+        fsm_x=0.0, fsm_y=0.0, exptime=1.0, filedir=str(datadir), platescale=21.8,
         background=0, add_gauss_noise=True, noise_scale=1., file_save=True)
     flux_image_WP2 = create_pol_flux_image(
         band_flux_left, band_flux_right, fwhm, cal_factor, filter='3C', dpamname='POL45', target_name='Vega',
-        fsm_x=0.0, fsm_y=0.0, exptime=1.0, filedir=datadir, platescale=21.8,
+        fsm_x=0.0, fsm_y=0.0, exptime=1.0, filedir=str(datadir), platescale=21.8,
         background=0, add_gauss_noise=True, noise_scale=1., file_save=True)
     # bunit needs to be photoelectron/s for later tests, so set that now
     flux_image_WP1.ext_hdr['BUNIT'] = 'photoelectron/s'

--- a/tests/test_kgain.py
+++ b/tests/test_kgain.py
@@ -8,7 +8,11 @@ import corgidrp.l2a_to_l2b as l2a_to_l2b
 import pytest
 import astropy.io.fits as fits
 
-def test_kgain():
+# Mark all tests in this file to run serially (not in parallel)
+# This file has shared state dependencies that cause race conditions in parallel
+pytestmark = pytest.mark.serial
+
+def test_kgain(tmp_path):
     """
     test the KGain class and the calibration file and the unit conversion
     """
@@ -67,13 +71,12 @@ def test_kgain():
     assert kgain_ptc_copy.err_hdr is not None
     
     # save KGain
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
     kgain_filename = "kgain_calib.fits"
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    kgain_ptc.save(filedir=calibdir, filename=kgain_filename)        
-        
-    kgain_filepath = os.path.join(calibdir, kgain_filename)
+    kgain_ptc.save(filedir=str(calibdir), filename=kgain_filename)
+
+    kgain_filepath = str(calibdir / kgain_filename)
     kgain_open = data.KGain(kgain_filepath)
     # use isclose to deal with 64 bit vs 32 bit precision 
     assert np.isclose(kgain_open.value, gain_value, rtol=1e-6)

--- a/tests/test_klipthrupt.py
+++ b/tests/test_klipthrupt.py
@@ -12,6 +12,10 @@ import pytest
 import numpy as np
 import os
 import itertools
+
+# Mark all tests in this file to run serially (not in parallel)
+# This file has module-level variables and test dependencies that cause issues in parallel
+pytestmark = pytest.mark.serial
 ## Helper functions/quantities
 
 lam = 573.8e-9 #m
@@ -57,8 +61,14 @@ calibrate_flux = False
 # max_thrupt_tolerance = 1 + (noise_amp * (2*fwhm_pix)**2)
 max_thrupt_tolerance = 1.05
 
+# Module-level variables set by test_meas_klip_ADI, test_meas_klip_RDI
+# and used by test_compare_RDI_ADI
+kt_adi = None
+kt_rdi = None
+kt_adirdi = None
+
 if not os.path.exists(outdir):
-    os.mkdir(outdir)
+    os.makedirs(outdir, exist_ok=True)
    
 ## pyKLIP data class tests
 

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -18,6 +18,10 @@ from corgidrp.data import (Image, Dataset, FluxcalFactor,
     NDFilterSweetSpotDataset, NDSpectroscopy)
 import corgidrp.mocks as mocks
 
+# Mark all tests in this file to run serially (not in parallel)
+# This file uses shared testcalib directory without worker isolation
+pytestmark = pytest.mark.serial
+
 here = os.path.abspath(os.path.dirname(__file__))
 
 def print_fail():
@@ -608,7 +612,7 @@ def test_background_effect(tmp_path):
     
     output_directory = str(tmp_path / "output")
     if not os.path.exists(output_directory):
-        os.mkdir(output_directory)
+        os.makedirs(output_directory, exist_ok=True)
     
     results_no = nd_filter_calibration.create_nd_filter_cal(
         ds_no, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 

--- a/tests/test_non_linearity_correction.py
+++ b/tests/test_non_linearity_correction.py
@@ -116,7 +116,7 @@ def get_relgains(frame, em_gain, nonlin_path):
 
     return counts_flat.reshape(frame.shape)
 
-def test_non_linearity_correction():
+def test_non_linearity_correction(tmp_path):
     """
     Generate a non-linearity correction calibration and test the correction 
     
@@ -146,13 +146,11 @@ def test_non_linearity_correction():
     # import IPython; IPython.embed()
 
     ###### create a simulated dataset that is non-linear
-    # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
 
     emgain = 2000
-    nonlinear_dataset = mocks.create_nonlinear_dataset(test_non_linearity_path, filedir=datadir, em_gain=emgain)
+    nonlinear_dataset = mocks.create_nonlinear_dataset(test_non_linearity_path, filedir=str(datadir), em_gain=emgain)
     
     assert len(nonlinear_dataset) == 2
 

--- a/tests/test_nonlin_cal.py
+++ b/tests/test_nonlin_cal.py
@@ -163,7 +163,7 @@ def setup_module():
     min_write = 800
     max_write = 10000
 
-def test_expected_results_nom_sub():
+def test_expected_results_nom_sub(tmp_path):
     """Outputs are as expected for the provided frames with nominal arrays."""
 
     with warnings.catch_warnings():
@@ -211,12 +211,11 @@ def test_expected_results_nom_sub():
         f"Expected norm_val={norm_val}, min_write={min_write}, or max_write={max_write}, but got {actual_val}"
 
     # Test filename follows convention (as of R3.0.2)
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    nonlin_out.save(filedir=datadir)
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+    nonlin_out.save(filedir=str(datadir))
     nln_cal_filename = dataset_nl[-1].filename.replace("_l2b", "_nln_cal")
-    nln_cal_filepath = os.path.join(datadir, nln_cal_filename)
+    nln_cal_filepath = str(datadir / nln_cal_filename)
     if os.path.exists(nln_cal_filepath) is False:
         raise IOError(f'NonLinearity calibration file {nln_cal_filepath} does not exist.')
     # Load the calibration file to check it has the same data contents

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -10,29 +10,29 @@ import corgidrp.caldb as caldb
 import corgidrp.mocks as mocks
 
 
-def _setup_ops_test_data():
+def _setup_ops_test_data(tmp_path):
     """
-    Tests that the ops module produces the expected files. Based on test_autoreducingin test_walker.py
+    Build the L1 dataset + nonlinearity calibration used by the ops tests.
+
+    Returns:
+        tuple: (filelist, main_cal_dir, outputdir, new_nonlinearity)
     """
 
     # create dirs
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    outputdir = os.path.join(os.path.dirname(__file__), "ops_output")
-    if not os.path.exists(outputdir):
-        os.mkdir(outputdir)
-    main_cal_dir = os.path.join(os.path.dirname(__file__), "ops_cal_dir")
-    if not os.path.exists(main_cal_dir):
-        os.mkdir(main_cal_dir)
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+    outputdir = tmp_path / "ops_output"
+    outputdir.mkdir(parents=True, exist_ok=True)
+    main_cal_dir = tmp_path / "ops_cal_dir"
+    main_cal_dir.mkdir(parents=True, exist_ok=True)
 
     # create simulated data
-    l1_dataset = mocks.create_prescan_files(filedir=datadir, arrtype="SCI", numfiles=2)
+    l1_dataset = mocks.create_prescan_files(filedir=str(datadir), arrtype="SCI", numfiles=2)
     # simulate the expected CGI naming convention
     fname_template = "cgi_0200001999001000{:03d}_20250415t0305102_l1_.fits"
     for i, image in enumerate(l1_dataset):
         image.filename = fname_template.format(i)
-    l1_dataset.save(filedir=datadir)
+    l1_dataset.save(filedir=str(datadir))
     filelist = [frame.filepath for frame in l1_dataset]
 
 
@@ -46,7 +46,7 @@ def _setup_ops_test_data():
     input_non_linearity_filename = "nonlin_table_TVAC.txt"
     input_non_linearity_path = os.path.join(os.path.dirname(__file__), "test_data", input_non_linearity_filename)
     test_non_linearity_filename = input_non_linearity_filename.split(".")[0] + ".fits"
-    nonlin_fits_filepath = os.path.join(os.path.dirname(__file__), main_cal_dir, test_non_linearity_filename)
+    nonlin_fits_filepath = str(main_cal_dir / test_non_linearity_filename)
     tvac_nonlin_data = np.genfromtxt(input_non_linearity_path, delimiter=",")
 
     pri_hdr, ext_hdr, errhdr, dqhdr = mocks.create_default_calibration_product_headers()
@@ -66,11 +66,11 @@ def _setup_ops_test_data():
     return filelist, main_cal_dir, outputdir, new_nonlinearity
 
 
-def test_ops_produces_expected_file():
+def test_ops_produces_expected_file(tmp_path):
     """
     Tests that the ops module produces the expected files. Based on test_autoreducing in test_walker.py
     """
-    filelist, main_cal_dir, outputdir, new_nonlinearity = _setup_ops_test_data()
+    filelist, main_cal_dir, outputdir, new_nonlinearity = _setup_ops_test_data(tmp_path)
 
     CPGS_XML_filepath = "" # not yet implemented
 
@@ -84,7 +84,7 @@ def test_ops_produces_expected_file():
 
     #Process the data. Ops generally won't have a template, but a template-less 
     # test would require generating more calibrations than are necessary for just testing this functionality.
-    ops.step_3_process_data(filelist, CPGS_XML_filepath, outputdir,template="l1_to_l2a_basic.json")
+    ops.step_3_process_data(filelist, CPGS_XML_filepath, str(outputdir),template="l1_to_l2a_basic.json")
 
     #Check that the output files are as expected. 
     output_filelist = [os.path.join(outputdir,os.path.basename(filename).replace("_l1_", "_l2a")) for filename in filelist]
@@ -96,7 +96,7 @@ def test_ops_produces_expected_file():
     mycaldb.remove_entry(new_nonlinearity)
 
 
-def test_ops_with_user_templates_dir():
+def test_ops_with_user_templates_dir(tmp_path):
     """
     Tests that the ops module works with a custom user_templates_dir argument.
     Same as test_ops_produces_expected_file but with user template override.
@@ -104,7 +104,7 @@ def test_ops_with_user_templates_dir():
     import copy
     import corgidrp.walker as walker
 
-    filelist, main_cal_dir, outputdir, new_nonlinearity = _setup_ops_test_data()
+    filelist, main_cal_dir, outputdir, new_nonlinearity = _setup_ops_test_data(tmp_path)
 
     CPGS_XML_filepath = ""
 
@@ -128,7 +128,7 @@ def test_ops_with_user_templates_dir():
         # Run the full ops chain with custom user_templates_dir
         this_caldb = ops.step_1_initialize(user_templates_dir=user_templates_dir)
         ops.step_2_load_cal(this_caldb, main_cal_dir)
-        ops.step_3_process_data(filelist, CPGS_XML_filepath, outputdir, template="l1_to_l2a_basic.json")
+        ops.step_3_process_data(filelist, CPGS_XML_filepath, str(outputdir), template="l1_to_l2a_basic.json")
 
         # Check output files exist
         output_filelist = [os.path.join(outputdir, os.path.basename(filename).replace("_l1_", "_l2a")) for filename in filelist]

--- a/tests/test_photon_counting.py
+++ b/tests/test_photon_counting.py
@@ -13,6 +13,10 @@ from corgidrp.photon_counting import get_pc_mean, photon_count, PhotonCountExcep
 import io, contextlib
 import warnings
 
+# Mark all tests in this file to run serially (not in parallel)
+# This file uses shared simdata directory without worker isolation, causing file collisions
+pytestmark = pytest.mark.serial
+
 def test_negative():
     """Values at or below the 
     threshold are photon-counted as 0, including negative values."""
@@ -21,7 +25,7 @@ def test_negative():
     assert (pc_fr == np.array([0,0,0])).all()
     
 
-def test_pc():
+def test_pc(tmp_path):
     '''
     Tests that a pixel that is masked heavily (reducing the number of usable frames for that pixel) has a bigger err than the average pixel.
 
@@ -200,17 +204,13 @@ def test_pc_subsets():
     captured = buf.getvalue()
     assert "Number of frames that created the photon-counted master dark should be greater than or equal to the number of illuminated frames in order for the result to be reliable.\n" in captured
 
-def test_no_data():
-    '''Tests that a Dataset with only metadata (and has data read in one 
+def test_no_data(tmp_path):
+    '''Tests that a Dataset with only metadata (and has data read in one
     frame at a time from filepaths) gives same results as a normal Dataset.
     '''
     # check that simulated data folder exists, and create if not
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    for name in os.listdir(datadir):
-            path = os.path.join(datadir, name)
-            os.remove(path)
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
     test_dataset, _, _, _ = mocks.create_photon_countable_frames(Nbrights=3, Ndarks=1, flux=0.1)
     # instead of running through walker, just do the pre-processing steps simply
     # using EM gain=5000 and kgain=7 and bias=20000 and read noise = 100 and QE=0.9 (quantum efficiency), from mocks.create_photon_countable_frames()

--- a/tests/test_polarimetry.py
+++ b/tests/test_polarimetry.py
@@ -38,7 +38,7 @@ from corgidrp.check import (check_filename_convention, check_dimensions,
 warnings.filterwarnings("ignore", message="File collision detected.*already exists")
 
 
-def test_image_splitting():
+def test_image_splitting(tmp_path):
     """
     Create mock L2b polarimetric images, check that it is split correctly
     """
@@ -63,13 +63,11 @@ def test_image_splitting():
 
     ## checks that saving and loading the image doesn't cause any issues
     ### save
-    test_dir = os.path.join(os.getcwd(), 'pol_output')
-    if os.path.isdir(test_dir):
-        shutil.rmtree(test_dir)
-    os.mkdir(test_dir)
-    output_dataset_autocrop_wfov.save(test_dir, ['wfov_pol_img_{0}.fits'.format(i) for i in range(len(output_dataset_autocrop_wfov))])
+    test_dir = tmp_path / 'pol_output'
+    test_dir.mkdir(parents=True, exist_ok=True)
+    output_dataset_autocrop_wfov.save(str(test_dir), ['wfov_pol_img_{0}.fits'.format(i) for i in range(len(output_dataset_autocrop_wfov))])
     ### load
-    autocrop_wfov_filelist = [os.path.join(test_dir, f) for f in os.listdir(test_dir)]
+    autocrop_wfov_filelist = [str(test_dir / f) for f in os.listdir(test_dir)]
     output_dataset_autocrop_wfov = data.Dataset(autocrop_wfov_filelist)
 
     ## create what the expected output data should look like
@@ -173,7 +171,7 @@ def test_image_splitting():
     with pytest.raises(ValueError):
         invalid_output = l2b_to_l3.split_image_by_polarization_state(input_dataset_wfov, image_size=682)
         
-def test_calc_pol_p_and_pa_image(n_sim=100, nsigma_tol=3., seed=0,
+def test_calc_pol_p_and_pa_image(tmp_path, n_sim=100, nsigma_tol=3., seed=0,
                                  logger=None, log_head=""):
     """
     Test `calc_pol_p_and_pa_image` using mock L4 Stokes cubes.
@@ -204,10 +202,10 @@ def test_calc_pol_p_and_pa_image(n_sim=100, nsigma_tol=3., seed=0,
     # ================================================================================
     if logger is None:
         # Create output directory for log file
-        output_dir = os.path.join(os.path.dirname(__file__), 'pol_l4_to_tda_VAP_test2')
-        os.makedirs(output_dir, exist_ok=True)
-        
-        log_file = os.path.join(output_dir, 'pol_l4_to_tda_VAP_test2.log')
+        output_dir = tmp_path / 'pol_l4_to_tda_VAP_test2'
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        log_file = str(output_dir / 'pol_l4_to_tda_VAP_test2.log')
         
         # Create a new logger specifically for this test
         logger = logging.getLogger('pol_l4_to_tda_VAP_test2')
@@ -1284,7 +1282,7 @@ def test_calc_stokes_unocculted(n_sim=10, nsigma_tol=3.):
 
     return
 
-def test_compute_QphiUPhi(): 
+def test_compute_QphiUPhi(tmp_path): 
     '''
     Test that the computer_QphiUphi function behaves as expected in three scenarios:
     1) When the input image center is correct, U_phi should be approximately zero.
@@ -1299,17 +1297,13 @@ def test_compute_QphiUPhi():
     ########## Set up VAP Logger ##########
     #######################################
 
-    current_file_path = os.path.dirname(os.path.abspath(__file__))
-
-    output_dir = os.path.join(current_file_path,'l4_to_tda_compute_quphi')
-    if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
-    os.makedirs(output_dir)
+    output_dir = tmp_path / 'l4_to_tda_compute_quphi'
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     # set up logging
     global logger
 
-    log_file = os.path.join(output_dir, 'l4_to_tda_compute_QphiUphi.log')
+    log_file = str(output_dir / 'l4_to_tda_compute_QphiUphi.log')
     
     # Create a new logger specifically for this test, otherwise things have issues
     logger = logging.getLogger('l4_to_tda_compute_QphiUphi')

--- a/tests/test_prescan_sub.py
+++ b/tests/test_prescan_sub.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import tempfile
 
 import corgidrp
 import corgidrp.data as data
@@ -15,6 +16,11 @@ from pathlib import Path
 from pytest import approx
 
 old_err_tracking = corgidrp.track_individual_errors
+
+# Per-process scratch dir for simulated data written by this module. A unique temp
+# dir (instead of a shared tests/simdata) prevents pytest-xdist workers running
+# other modules from racing on the same files.
+_scratch_dir = tempfile.mkdtemp(prefix="prescan_sub_")
 
 # make a mock DetectorNoiseMaps instance (to get the bias offset input)
 im_rows, im_cols, _ = unpack_geom('SCI', 'image', detector_areas)
@@ -267,7 +273,7 @@ def test_prescan_sub():
     tol = 0.01
 
     ###### create simulated data
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
+    datadir = os.path.join(_scratch_dir, "simdata")
 
     for arrtype in ['SCI','ENG']:
         # create simulated data
@@ -370,7 +376,7 @@ def test_bias_zeros_frame():
     tol = 1e-13
 
     ###### create simulated data
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
+    datadir = os.path.join(_scratch_dir, "simdata")
 
     for arrtype in ['SCI', 'ENG']:
         # create simulated data
@@ -416,7 +422,7 @@ def test_bias_hvoff():
     seed = 12346
 
     ###### create simulated data
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
+    datadir = os.path.join(_scratch_dir, "simdata")
 
     for arrtype in ['SCI', 'ENG']:
         # create simulated data
@@ -460,7 +466,7 @@ def test_bias_hvon():
     seed = 12346
 
     ###### create simulated data
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
+    datadir = os.path.join(_scratch_dir, "simdata")
 
     for arrtype in ['SCI', 'ENG']:
         # create simulated dataset
@@ -490,7 +496,7 @@ def test_bias_uniform_value():
     bval = 1.
 
     ###### create simulated dataset
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
+    datadir = os.path.join(_scratch_dir, "simdata")
 
     for arrtype in ['SCI', 'ENG']:
         # create simulated dataset
@@ -515,7 +521,7 @@ def test_bias_offset():
     tol = 1e-13
 
     ###### create simulated dataset
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
+    datadir = os.path.join(_scratch_dir, "simdata")
 
     for arrtype in ['SCI', 'ENG']:
         # create simulated dataset with 0 bias offset

--- a/tests/test_pumptrap_calibration.py
+++ b/tests/test_pumptrap_calibration.py
@@ -68,7 +68,7 @@ def test_tpump_analysis():
     for temp, temp_files in file_info.items():
         temp_dir = os.path.join(test_data_dir, temp)
         if not os.path.exists(temp_dir):
-            os.mkdir(temp_dir)
+            os.makedirs(temp_dir, exist_ok=True)
         
         # Sort files by filename first to ensure deterministic ordering
         temp_files.sort()
@@ -92,7 +92,7 @@ def test_tpump_analysis():
             if sc_files:  # Only create directory if there are files for this scheme
                 sch_dir = os.path.join(temp_dir, f'Scheme_{sc}')
                 if not os.path.exists(sch_dir):
-                    os.mkdir(sch_dir)
+                    os.makedirs(sch_dir, exist_ok=True)
                 
                 # Sort by phase time, then filename for deterministic ordering,
                 # otherwise tests will sometimes pass, sometimes fail on different systems

--- a/tests/test_sort_pupilimg_frames.py
+++ b/tests/test_sort_pupilimg_frames.py
@@ -15,6 +15,11 @@ from corgidrp.mocks import create_default_L1_headers
 from datetime import timedelta
 from collections import defaultdict
 
+# Mark all tests in this file to run serially (not in parallel)
+# This file has setup_module() creating module-level state
+# Also has inconsistent worker isolation (line 355 has it, line 214 doesn't)
+pytestmark = pytest.mark.serial
+
 np.random.seed(42)  # For reproducibility
 # Functions
 def get_cmdgain_exptime_mean_frame(
@@ -349,9 +354,12 @@ def setup_module():
     
     # DRP Dataset
     # Create directory for temporary data files (not tracked by git)
-    datadir = os.path.join(os.path.dirname(__file__), 'simdata')
+    # Use worker-specific directories for pytest-xdist isolation
+    _worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'master')
+    _worker_suffix = f"_{_worker_id}" if _worker_id != 'master' else ""
+    datadir = os.path.join(os.path.dirname(__file__), f'simdata{_worker_suffix}')
     if not os.path.exists(datadir):
-        os.mkdir(datadir)
+        os.makedirs(datadir, exist_ok=True)
     # clean out any previous files in there; files are not overwritten since their names depend on the present time
     for filename in os.listdir(datadir):
         if not filename.endswith('.fits'):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -19,12 +19,22 @@ from corgidrp.fluxcal import get_filter_name, read_cal_spec, read_filter_curve
 from corgidrp.check import (check_filename_convention, verify_header_keywords,
     check_dimensions)
 
+# Mark all tests in this file to run serially (not in parallel)
+# This file has complex test chain dependencies with shared module-level state
+pytestmark = pytest.mark.serial
 
-spec_datadir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', "corgidrp", "data", "spectroscopy")) 
+
+spec_datadir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', "corgidrp", "data", "spectroscopy"))
 test_datadir = os.path.join(os.path.dirname(__file__), "test_data", "spectroscopy")
 template_dir = os.path.join(spec_datadir, "templates")
 output_dir = os.path.join(os.path.dirname(__file__), "testcalib")
 os.makedirs(output_dir, exist_ok=True)
+
+# Module-level variables set by earlier tests and used by later tests
+# Initialized to None, will be set by test execution
+disp_dict = None
+disp_model = None
+output_dataset = None
 
 def convert_tvac_to_dataset():
     """

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -1,6 +1,7 @@
 """
 Test the walker infrastructure to read and execute recipes
 """
+import pytest
 import os
 import glob
 import json
@@ -21,26 +22,28 @@ import corgidrp.detector as detector
 import datetime
 np.random.seed(456)
 
-def test_autoreducing():
+# Mark all tests in this file to run serially (not in parallel)
+# This file modifies global corgidrp settings and CalDB state
+pytestmark = pytest.mark.serial
+
+def test_autoreducing(tmp_path):
     """
     Tests both generating and processing a basic L1->L2a SCI recipe
     """
     # create dirs
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
-    if not os.path.exists(outputdir):
-        os.mkdir(outputdir)
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+    outputdir = str(tmp_path / "walker_output")
+    os.makedirs(outputdir, exist_ok=True)
 
 
     # create simulated data
-    l1_dataset = mocks.create_prescan_files(filedir=datadir, arrtype="SCI", numfiles=2)
+    l1_dataset = mocks.create_prescan_files(filedir=str(datadir), arrtype="SCI", numfiles=2)
     # simulate the expected CGI naming convention
     fname_template = "cgi_0200001999001000{:03d}_20250415t0305102_l1_.fits"
     for i, image in enumerate(l1_dataset):
         image.filename = fname_template.format(i)
-    l1_dataset.save(filedir=datadir)
+    l1_dataset.save(filedir=str(datadir))
     filelist = [frame.filepath for frame in l1_dataset]
 
 
@@ -111,18 +114,18 @@ def test_auto_template_identification():
     # create dirs
     datadir = os.path.join(os.path.dirname(__file__), "simdata")
     if not os.path.exists(datadir):
-        os.mkdir(datadir)
+        os.makedirs(datadir, exist_ok=True)
     outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
     if not os.path.exists(outputdir):
-        os.mkdir(outputdir)
+        os.makedirs(outputdir, exist_ok=True)
 
     # create simulated data
-    l1_dataset = mocks.create_prescan_files(filedir=datadir, arrtype="SCI", numfiles=2)
+    l1_dataset = mocks.create_prescan_files(filedir=str(datadir), arrtype="SCI", numfiles=2)
     # simulate the expected CGI naming convention
     fname_template = "cgi_0200001999001000{:03d}_20250415t0305102_l1_.fits"
     for i, image in enumerate(l1_dataset):
         image.filename = fname_template.format(i)
-    l1_dataset.save(filedir=datadir)
+    l1_dataset.save(filedir=str(datadir))
     filelist = [frame.filepath for frame in l1_dataset]
 
 
@@ -162,7 +165,7 @@ def test_auto_template_identification():
     kgain_val = 8.7
     kgain = data.KGain(kgain_val, pri_hdr=pri_hdr, ext_hdr=ext_hdr, 
                     input_dataset=mock_input_dataset)
-    kgain.save(filedir=outputdir, filename="mock_kgain.fits")
+    kgain.save(filedir=str(outputdir), filename="mock_kgain.fits")
     this_caldb.create_entry(kgain)
 
     # NoiseMap
@@ -177,13 +180,13 @@ def test_auto_template_identification():
     noise_map = data.DetectorNoiseMaps(noise_map_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr,
                                     input_dataset=mock_input_dataset, err=noise_map_noise,
                                     dq = noise_map_dq, err_hdr=err_hdr)
-    noise_map.save(filedir=outputdir, filename="mock_detnoisemaps.fits")
+    noise_map.save(filedir=str(outputdir), filename="mock_detnoisemaps.fits")
     this_caldb.create_entry(noise_map)
 
     ## Flat field
     flat_dat = np.ones((1024, 1024))
     flat = data.FlatField(flat_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=mock_input_dataset)
-    flat.save(filedir=outputdir, filename="mock_flat.fits")
+    flat.save(filedir=str(outputdir), filename="mock_flat.fits")
     this_caldb.create_entry(flat)
 
     # bad pixel map
@@ -200,7 +203,7 @@ def test_auto_template_identification():
                         err_hdr=fits.Header())
     bp_map_inputs = data.Dataset([bp_dark, flat])
     bp_map = data.BadPixelMap(bp_dat, pri_hdr=pri_hdr, ext_hdr=ext_hdr, input_dataset=bp_map_inputs)
-    bp_map.save(filedir=outputdir, filename="mock_bpmap.fits")
+    bp_map.save(filedir=str(outputdir), filename="mock_bpmap.fits")
     this_caldb.create_entry(bp_map)
 
 
@@ -218,17 +221,15 @@ def test_auto_template_identification():
     this_caldb.remove_entry(bp_map)
 
 
-def test_saving():
+def test_saving(tmp_path):
     """
     Tests the special save function including suffix. Tries both calibration image and non-calibration image
     """
     ### create dirs
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
-    if not os.path.exists(outputdir):
-        os.mkdir(outputdir)
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+    outputdir = str(tmp_path / "walker_output")
+    os.makedirs(outputdir, exist_ok=True)
 
     ### load test recipe
     testdatadir = os.path.join(os.path.dirname(__file__), "test_data")
@@ -245,7 +246,7 @@ def test_saving():
     fname_template = "cgi_0200001999001000{:03d}_20250415t0305102_l1_.fits"
     for i, image in enumerate(l1_dataset):
         image.filename = fname_template.format(i)
-    l1_dataset.save(filedir=datadir)
+    l1_dataset.save(filedir=str(datadir))
     filelist = [frame.filepath for frame in l1_dataset]
 
     this_recipe = walker.autogen_recipe(filelist, outputdir, template=save_recipe)
@@ -296,7 +297,7 @@ def test_saving():
 
 
 
-def test_skip_missing_calib():
+def test_skip_missing_calib(tmp_path):
     """
     Tests the option of skipping steps with missing calibrations
     """
@@ -305,28 +306,25 @@ def test_skip_missing_calib():
     corgidrp.skip_missing_cal_steps = True
 
     # use an empty test caldb
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    testcaldb_filepath = os.path.join(calibdir, "empty_caldb.csv")
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
+    testcaldb_filepath = str(calibdir / "empty_caldb.csv")
     old_caldb_filepath = corgidrp.caldb_filepath
     corgidrp.caldb_filepath = testcaldb_filepath
 
     # create dirs
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
-    if not os.path.exists(outputdir):
-        os.mkdir(outputdir)
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+    outputdir = str(tmp_path / "walker_output")
+    os.makedirs(outputdir, exist_ok=True)
 
     # create simulated data
-    l1_dataset = mocks.create_prescan_files(filedir=datadir, arrtype="SCI", numfiles=2)
+    l1_dataset = mocks.create_prescan_files(filedir=str(datadir), arrtype="SCI", numfiles=2)
     # simulate the expected CGI naming convention
     fname_template = "cgi_0200001999001000{:03d}_20250415t0305102_l1_.fits"
     for i, image in enumerate(l1_dataset):
         image.filename = fname_template.format(i)
-    l1_dataset.save(filedir=datadir)
+    l1_dataset.save(filedir=str(datadir))
     filelist = [frame.filepath for frame in l1_dataset]
 
 
@@ -365,7 +363,7 @@ def test_skip_missing_calib():
 
 
 
-def test_skip_missing_optional_calib():
+def test_skip_missing_optional_calib(tmp_path):
     """
     Tests optional calibrtion behavior when skpip_missing_calibs is True
     The behavior is that the step should not be skipped, given the calibration is optional
@@ -375,28 +373,25 @@ def test_skip_missing_optional_calib():
     corgidrp.skip_missing_cal_steps = True
 
     # use an empty test caldb
-    calibdir = os.path.join(os.path.dirname(__file__), "testcalib")
-    if not os.path.exists(calibdir):
-        os.mkdir(calibdir)
-    testcaldb_filepath = os.path.join(calibdir, "empty_caldb.csv")
+    calibdir = tmp_path / "testcalib"
+    calibdir.mkdir(parents=True, exist_ok=True)
+    testcaldb_filepath = str(calibdir / "empty_caldb.csv")
     old_caldb_filepath = corgidrp.caldb_filepath
     corgidrp.caldb_filepath = testcaldb_filepath
 
     # create dirs
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
-    if not os.path.exists(outputdir):
-        os.mkdir(outputdir)
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+    outputdir = str(tmp_path / "walker_output")
+    os.makedirs(outputdir, exist_ok=True)
 
     # create simulated data
-    l1_dataset = mocks.create_prescan_files(filedir=datadir, arrtype="SCI", numfiles=2)
+    l1_dataset = mocks.create_prescan_files(filedir=str(datadir), arrtype="SCI", numfiles=2)
     # simulate the expected CGI naming convention
     fname_template = "cgi_0200001999001000{:03d}_20250415t0305102_l1_.fits"
     for i, image in enumerate(l1_dataset):
         image.filename = fname_template.format(i)
-    l1_dataset.save(filedir=datadir)
+    l1_dataset.save(filedir=str(datadir))
     filelist = [frame.filepath for frame in l1_dataset]
 
 
@@ -418,7 +413,7 @@ def test_skip_missing_optional_calib():
     corgidrp.skip_missing_cal_steps = old_setting
     corgidrp.caldb_filepath = old_caldb_filepath
 
-def test_jit_calibs():
+def test_jit_calibs(tmp_path):
     """
     Tests defining calibrations just in time
     """
@@ -426,21 +421,19 @@ def test_jit_calibs():
     corgidrp.jit_calib_id = True
 
     # create dirs
-    datadir = os.path.join(os.path.dirname(__file__), "simdata")
-    if not os.path.exists(datadir):
-        os.mkdir(datadir)
-    outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
-    if not os.path.exists(outputdir):
-        os.mkdir(outputdir)
+    datadir = tmp_path / "simdata"
+    datadir.mkdir(parents=True, exist_ok=True)
+    outputdir = str(tmp_path / "walker_output")
+    os.makedirs(outputdir, exist_ok=True)
 
 
     # create simulated data
-    l1_dataset = mocks.create_prescan_files(filedir=datadir, arrtype="SCI", numfiles=2)
+    l1_dataset = mocks.create_prescan_files(filedir=str(datadir), arrtype="SCI", numfiles=2)
     # simulate the expected CGI naming convention
     fname_template = "cgi_0200001999001000{:03d}_20250415t0305102_l1_.fits"
     for i, image in enumerate(l1_dataset):
         image.filename = fname_template.format(i)
-    l1_dataset.save(filedir=datadir)
+    l1_dataset.save(filedir=str(datadir))
     filelist = [frame.filepath for frame in l1_dataset]
 
 
@@ -552,10 +545,10 @@ def test_generate_multiple_recipes():
     # create dirs
     datadir = os.path.join(os.path.dirname(__file__), "simdata")
     if not os.path.exists(datadir):
-        os.mkdir(datadir)
+        os.makedirs(datadir, exist_ok=True)
     outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
     if not os.path.exists(outputdir):
-        os.mkdir(outputdir)
+        os.makedirs(outputdir, exist_ok=True)
     # Make a non-linearity correction calibration file
     input_non_linearity_filename = "nonlin_table_TVAC.txt"
     test_non_linearity_filename = input_non_linearity_filename.split(".")[0] + ".fits"
@@ -638,10 +631,10 @@ def test_cpgs_satspots():
     # create dirs
     datadir = os.path.join(os.path.dirname(__file__), "simdata")
     if not os.path.exists(datadir):
-        os.mkdir(datadir)
+        os.makedirs(datadir, exist_ok=True)
     outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
     if not os.path.exists(outputdir):
-        os.mkdir(outputdir)
+        os.makedirs(outputdir, exist_ok=True)
 
 
     # create simulated data
@@ -730,11 +723,11 @@ def test_l1_to_l2b_default_calibs():
 
     # Create simulated L1 data. The default headers have DPAMNAME='IMAGING',
     # CFAMNAME='1F', which the default TVAC flat (FPAMNAME='OPEN_12') satisfies.
-    l1_dataset = mocks.create_prescan_files(filedir=datadir, arrtype="SCI", numfiles=2)
+    l1_dataset = mocks.create_prescan_files(filedir=str(datadir), arrtype="SCI", numfiles=2)
     fname_template = "cgi_0200001999001000{:03d}_20250415t0305102_l1_.fits"
     for i, image in enumerate(l1_dataset):
         image.filename = fname_template.format(i)
-    l1_dataset.save(filedir=datadir)
+    l1_dataset.save(filedir=str(datadir))
     filelist = [frame.filepath for frame in l1_dataset]
 
     # Ensure the default calibrations are present and indexed in the caldb.
@@ -765,10 +758,10 @@ def test_pc_science_analog_satspots():
     # create dirs
     datadir = os.path.join(os.path.dirname(__file__), "simdata")
     if not os.path.exists(datadir):
-        os.mkdir(datadir)
+        os.makedirs(datadir, exist_ok=True)
     outputdir = os.path.join(os.path.dirname(__file__), "walker_output")
     if not os.path.exists(outputdir):
-        os.mkdir(outputdir)
+        os.makedirs(outputdir, exist_ok=True)
 
     image_shape=(201, 201)
     bg_sigma=1.0


### PR DESCRIPTION
## Describe your changes 

I tried to make tests run in parallel so they take less time to execute for developers. The main problem was linked to multiple tests writing .corgidrp and the caldb so they had to be isolated in their own tmp folder with their own caldb. A lot of tests can be ran in parallel. 

On my mbp m5 pro max (18 cores), all the unit tests now pass in 8mins30.  

### Changes by type

Worker isolation infrastructure
- corgidrp/__init__.py: config/caldb/default-cal paths now derive from a per-worker temp dir (CORGIDRP_WORKER_TMP) when set, falling back to ~/.corgidrp otherwise. Config read uses config_folder
instead of a hardcoded home path.
- tests/conftest.py (new): pytest_configure gives each xdist worker a private .corgidrp temp dir and re-derives corgidrp path globals (handles the fork start method used in CI, where workers inherit
 already-bound paths).
- conftest.py: session-scoped autouse fixture initializes caldb once per worker.

Concurrency-safe directory creation
- Replaced os.mkdir with os.makedirs(..., exist_ok=True) in calibrate_kgain.py, calibrate_nonlin.py, fluxcal.py, and mocks.py (multiple sites) so parallel workers don't race on directory creation.

Serial test handling
- Added a serial marker (pytest.ini) and tagged order-dependent / shared-state tests across 11 unit files plus the E2E data-format consumer.
- tests/conftest.py: pytest_collection_modifyitems sorts items by file/line so serial tests keep deterministic order under --dist loadscope.

test refactors for parallel safety
- Rewrote tests that mutated module-level globals to use local variables / session-scoped fixtures, eliminating cross-test race conditions and redundant data generation.

pytest configuration
- pytest.ini: --dist loadscope (keeps a module's tests on one worker; needed for serial ordering) and the serial marker definition.

CI workflows
- python-app.yml / e2e-testing.yml: install pytest-xdist; run -n auto -m "not serial" then a -m "serial" pass; cap workers to 2 on runners (PYTEST_XDIST_AUTO_NUM_WORKERS); added memory monitoring +
OOM check to the unit workflow.

docs
- README.md: documented the two-command parallel + serial run pattern for both suites.

## Type of change

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
#912 

## Checklist before requesting a review
- [ ] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [ ] I have checked that I am merging into the right branch
- [ ] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [ ] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
