### PR TITLE
Identify PUPIL images with FPAMNAME == 'OPEN_34'

### DIFF
--- a/corgidrp/corethroughput.py
+++ b/corgidrp/corethroughput.py
@@ -196,7 +196,7 @@ def estimate_psf_pix_and_ct(
         # DPAM=PUPIL, LSAM=OPEN, FSAM=OPEN and FPAM=OPEN_12
             exthd = frame.ext_hdr
             if (exthd['DPAMNAME']=='PUPIL' and exthd['LSAMNAME']=='OPEN' and
-                exthd['FSAMNAME']=='OPEN' and exthd['FPAMNAME']=='OPEN_12'):
+                exthd['FSAMNAME']=='OPEN' and exthd['FPAMNAME'] in ['OPEN_12','OPEN_34']):
                 pupil_img_frames += [frame]
         except:
             pass


### PR DESCRIPTION
CT correctly identifies PUPIL images with FPAMNAME == 'OPEN_34'

## Describe your changes


## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
