### PR TITLE
add HD37962 as additional faint calspec standard

### DIFF
--- a/corgidrp/fluxcal.py
+++ b/corgidrp/fluxcal.py
@@ -34,7 +34,8 @@ calspec_names= {
 'bps bs 17447-0067': '1802271_stiswfcnic_006.fits',
 'tyc 4424-1286-1': '1732526_stisnic_009.fits',
 'gsc 02581-02323': 'p330e_stiswfcnic_007.fits',
-'tyc 4207-219-1': '1740346_stisnic_005.fits'
+'tyc 4207-219-1': '1740346_stisnic_005.fits',
+'tyc 7056-1141-1': 'hd37962_stis_011.fits'
 }
 
 calspec_url = 'https://archive.stsci.edu/hlsps/reference-atlases/cdbs/current_calspec/'


### PR DESCRIPTION
## Describe your changes
add HD37962 faint standard to the calstar list in fluxcal.py, needed for spec CAR tests

## Type of change

- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)


## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
