### PR TITLE
Added exthd['FPAMNAME'] in ['OPEN_12', 'OPEN_34'] when constructing t…

### DIFF
--- a/corgidrp/corethroughput.py
+++ b/corgidrp/corethroughput.py
@@ -353,7 +353,7 @@ def generate_psf_cube(
         try:
             exthd = frame.ext_hdr
             if (exthd['DPAMNAME']=='PUPIL' and exthd['LSAMNAME']=='OPEN' and
-                exthd['FSAMNAME']=='OPEN' and exthd['FPAMNAME']=='OPEN_12'):
+                exthd['FSAMNAME']=='OPEN' and exthd['FPAMNAME'] in ['OPEN_12','OPEN_34']):
                 continue
         except:
             pass
@@ -422,7 +422,7 @@ def generate_psf_cube(
     for frame in dataset:
         exthd = frame.ext_hdr
         if not (exthd['DPAMNAME'] == 'PUPIL' and exthd['LSAMNAME'] == 'OPEN' and
-                exthd['FSAMNAME'] == 'OPEN' and exthd['FPAMNAME'] == 'OPEN_12'):
+                exthd['FSAMNAME'] == 'OPEN' and exthd['FPAMNAME'] in ['OPEN_12', 'OPEN_34']):
             first_offaxis_frame = frame
             break
     if first_offaxis_frame is None:


### PR DESCRIPTION
…he psf cube. Needed for skipping pupil images.

## Describe your changes
Added `exthd['FPAMNAME'] in ['OPEN_12', 'OPEN_34']`  in  `generate_psf_cube` . First to skip pupil images, then to get the header from the first off axis frame (line 424)

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Reference any relevant issues (don't forget the #)
#1015 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
