### PR TITLE
Update nd filter cal

### DIFF
--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -66,7 +66,7 @@ class Dataset():
                 each frame will have the default loaded in (arrays of zeros).  Defaults to False.
             no_err (bool): If True, no err arrays are loaded in.  This overrides the condition concerning err in the no_data description above.  Defaults to False.
             no_dq (bool): If True, no dq arrays are loaded in.  This overrides the condition concerning dq in the no_data description above.  Defaults to False.
-            allow_inhomogeneous_data (bool): If True, disables the creation of all_data/all_err/all_dq datacubes so the dataset can contain frames of differing dimensions. Defaults to False.
+            allow_inhomogeneous_frames (bool): If True, disables the creation of all_data/all_err/all_dq datacubes so the dataset can contain frames of differing dimensions. Defaults to False.
         """
         if len(frames_or_filepaths) == 0:
             raise ValueError("Empty list passed in")

--- a/corgidrp/data.py
+++ b/corgidrp/data.py
@@ -58,7 +58,7 @@ class Dataset():
         all_data (np.array): an array with all the data combined together. First dimension is always number of images
         frames (np.array): list of data objects (probably corgidrp.data.Image)
     """
-    def __init__(self, frames_or_filepaths, no_data=False, no_err=False, no_dq=False):
+    def __init__(self, frames_or_filepaths, no_data=False, no_err=False, no_dq=False, allow_inhomogeneous_frames=False):
         """
         Args:
             frames_or_filepaths (list): list of either filepaths or data objects (e.g., Image class)
@@ -66,6 +66,7 @@ class Dataset():
                 each frame will have the default loaded in (arrays of zeros).  Defaults to False.
             no_err (bool): If True, no err arrays are loaded in.  This overrides the condition concerning err in the no_data description above.  Defaults to False.
             no_dq (bool): If True, no dq arrays are loaded in.  This overrides the condition concerning dq in the no_data description above.  Defaults to False.
+            allow_inhomogeneous_data (bool): If True, disables the creation of all_data/all_err/all_dq datacubes so the dataset can contain frames of differing dimensions. Defaults to False.
         """
         if len(frames_or_filepaths) == 0:
             raise ValueError("Empty list passed in")
@@ -102,16 +103,25 @@ class Dataset():
         if isinstance(self.frames, list):
             self.frames = np.array(self.frames) # list of objects
 
-        # create 3-D cube of all the data
-        self.all_data = np.array([frame.data for frame in self.frames])
-        self.all_err = np.array([frame.err for frame in self.frames])
-        self.all_dq = np.array([frame.dq for frame in self.frames])
-        # do a clever thing to point all the individual frames to the data in this cube
-        # this way editing a single frame will also edit the entire datacube
-        for i, frame in enumerate(self.frames):
-            frame.data = self.all_data[i]
-            frame.err = self.all_err[i]
-            frame.dq = self.all_dq[i]
+        if allow_inhomogeneous_frames:
+            # set all_data, all_err, and all_dq to None
+            self.all_data = None
+            self.all_err = None
+            self.all_dq = None
+        else:
+            # create 3-D cube of all the data
+            self.all_data = np.array([frame.data for frame in self.frames])
+            self.all_err = np.array([frame.err for frame in self.frames])
+            self.all_dq = np.array([frame.dq for frame in self.frames])
+            # do a clever thing to point all the individual frames to the data in this cube
+            # this way editing a single frame will also edit the entire datacube
+            for i, frame in enumerate(self.frames):
+                frame.data = self.all_data[i]
+                frame.err = self.all_err[i]
+                frame.dq = self.all_dq[i]
+
+        # keep track of this to guard against calling all_data/all_err/all_dq in other places when it's none
+        self.contain_inhomogeneous_frames = allow_inhomogeneous_frames
 
     def __iter__(self):
         return self.frames.__iter__()
@@ -166,7 +176,7 @@ class Dataset():
             frame.pri_hdr['FILENAME'] = frame.filename
             frame.save(filename=filename, filedir=filedir)
 
-        if not ram_heavy_save:
+        if not ram_heavy_save and not self.contain_inhomogeneous_frames:
             # relink frames with all_data
             self.all_data = np.array([frame.data for frame in self.frames])
             self.all_err = np.array([frame.err for frame in self.frames])

--- a/corgidrp/nd_filter_calibration.py
+++ b/corgidrp/nd_filter_calibration.py
@@ -436,7 +436,8 @@ def create_nd_filter_cal(stars_dataset,
         gaussian_kernel_size (int): Size of gaussian kernel used to make the PSF centroid algorithm more robust against noise.
 
     Returns:
-        sweet_spot_dataset (corgidrp.Data.NDFilterSweetSpotDataset): ND Filter calibration product for the dataset given
+        sweet_spot_and_fluxcal_dataset (list): Length 2 list containing a ND Filter calibration product (corgidrp.Data.NDFilterSweetSpotDataset) 
+            for the dataset given and an absolute flux calibration product (corgidrp.Data.FluxcalFactor) used to create the ND filter calibration.
     """
     if phot_kwargs is None:
         phot_kwargs = {}
@@ -530,8 +531,14 @@ def create_nd_filter_cal(stars_dataset,
         common_metadata=common_metadata, od_var_flag = od_var_flag, input_dataset = stars_dataset
     )
 
-    #TO DO: do we want to return flux?
-    return sweet_spot_dataset
+    # 6. Create abs flux calibration used
+    if fluxcal_factor is not None:
+        fluxcal_data = fluxcal_factor.copy()
+    else:
+        fluxcal_data = FluxcalFactor(cal_factor, input_dataset=dim_stars_dataset)
+
+    #7. Return a length 2 list consisting of the ND filter calibration and the abs flux calibration
+    return [sweet_spot_dataset, fluxcal_data]
 
 
 # =============================================================================

--- a/corgidrp/nd_filter_calibration.py
+++ b/corgidrp/nd_filter_calibration.py
@@ -436,7 +436,7 @@ def create_nd_filter_cal(stars_dataset,
         gaussian_kernel_size (int): Size of gaussian kernel used to make the PSF centroid algorithm more robust against noise.
 
     Returns:
-        sweet_spot_and_fluxcal_dataset (list): Length 2 list containing a ND Filter calibration product (corgidrp.Data.NDFilterSweetSpotDataset) 
+        sweet_spot_and_fluxcal_dataset (Dataset): Length 2 dataset containing a ND Filter calibration product (corgidrp.Data.NDFilterSweetSpotDataset) 
             for the dataset given and an absolute flux calibration product (corgidrp.Data.FluxcalFactor) used to create the ND filter calibration.
     """
     if phot_kwargs is None:
@@ -537,8 +537,8 @@ def create_nd_filter_cal(stars_dataset,
     else:
         fluxcal_data = FluxcalFactor(cal_factor, input_dataset=dim_stars_dataset)
 
-    #7. Return a length 2 list consisting of the ND filter calibration and the abs flux calibration
-    return [sweet_spot_dataset, fluxcal_data]
+    #7. Return dataset consisting of the ND filter calibration and the abs flux calibration
+    return Dataset([sweet_spot_dataset, fluxcal_data], allow_inhomogeneous_frames=True)
 
 
 # =============================================================================

--- a/corgidrp/nd_filter_calibration.py
+++ b/corgidrp/nd_filter_calibration.py
@@ -436,8 +436,9 @@ def create_nd_filter_cal(stars_dataset,
         gaussian_kernel_size (int): Size of gaussian kernel used to make the PSF centroid algorithm more robust against noise.
 
     Returns:
-        sweet_spot_and_fluxcal_dataset (Dataset): Length 2 dataset containing a ND Filter calibration product (corgidrp.Data.NDFilterSweetSpotDataset) 
-            for the dataset given and an absolute flux calibration product (corgidrp.Data.FluxcalFactor) used to create the ND filter calibration.
+        sweet_spot_dataset (corgidrp.Data.NDFilterSweetSpotDataset or Dataset): If an abs flux calibration is created with a dim dataset, returns a 
+        length 2 dataset containing a ND Filter calibration product (corgidrp.Data.NDFilterSweetSpotDataset) and the created absolute flux calibration 
+        product (corgidrp.Data.FluxcalFactor). Otherwise, returns just the ND Filter calibration product. 
     """
     if phot_kwargs is None:
         phot_kwargs = {}
@@ -531,14 +532,14 @@ def create_nd_filter_cal(stars_dataset,
         common_metadata=common_metadata, od_var_flag = od_var_flag, input_dataset = stars_dataset
     )
 
-    # 6. Create abs flux calibration used
+    # 6. Return the relevant data
     if fluxcal_factor is not None:
-        fluxcal_data = fluxcal_factor.copy()
+        # if a fluxcal file is passed in, return just the ND filter calibration
+        return sweet_spot_dataset
     else:
+        # if a new abs flux calibration is created, return that along wtih the ND filter calibration
         fluxcal_data = FluxcalFactor(cal_factor, input_dataset=dim_stars_dataset)
-
-    #7. Return dataset consisting of the ND filter calibration and the abs flux calibration
-    return Dataset([sweet_spot_dataset, fluxcal_data], allow_inhomogeneous_frames=True)
+        return Dataset([sweet_spot_dataset, fluxcal_data], allow_inhomogeneous_frames=True)
 
 
 # =============================================================================

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -695,7 +695,7 @@ def save_data(dataset_or_image, outputdir, suffix="", ram_heavy_save=False):
     Records calibration frames into the caldb during the process
 
     Args:
-        dataset_or_image (corgidrp.data.Dataset or corgidrp.data.Image): data to save
+        dataset_or_image (corgidrp.data.Dataset or corgidrp.data.Image or list of Dataset/Image): data to save
         outputdir (str): path to directory where files should be saved
         suffix (str): optional suffix to tack onto the filename.
                       E.g.: `test.fits` with `suffix="dark"` becomes `test_dark.fits`
@@ -706,6 +706,11 @@ def save_data(dataset_or_image, outputdir, suffix="", ram_heavy_save=False):
     # convert everything to dataset to make life easier
     if isinstance(dataset_or_image, data.Image):
         dataset = data.Dataset([dataset_or_image])
+    elif isinstance (dataset_or_image, list):
+        # if a list of datasets or images is passed in, call save on each individual item in the list
+        for item in dataset_or_image:
+            save_data(item, outputdir, suffix=suffix, ram_heavy_save=ram_heavy_save)
+        return
     else:
         dataset = dataset_or_image
 
@@ -835,6 +840,12 @@ def run_recipe(recipe, save_recipe_file=True):
                     save_data(curr_dataset, recipe["outputdir"], suffix=suffix, ram_heavy_save=ram_heavy_save)
                     if isinstance(curr_dataset, data.Dataset):
                         output_filepaths += [frame.filepath for frame in curr_dataset]
+                    elif isinstance(curr_dataset, list):
+                        for item in curr_dataset:
+                            if isinstance(item, data.Dataset):
+                                output_filepaths += [frame.filepath for frame in item]
+                            else:
+                                output_filepaths += [item.filepath]
                     else:
                         output_filepaths += [curr_dataset.filepath]
                     save_step = True

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -559,17 +559,17 @@ def guess_template(dataset):
                     chained = True
             else:
                 _, vistype_unique = dataset.split_dataset(prihdr_keywords=['VISTYPE'])
+                # pol fluxcal
+                if image.ext_hdr.get('DPAMNAME', '') in ['POL0', 'POL45']:
+                    recipe_filename = ["l1_to_l2a_basic.json", "l2a_to_l2b_pol.json", "l2b_to_fluxcal_factor_pol.json"]
+                    chained = True
                 # ND filter calibration if bright targets in dataset
-                if len(vistype_unique) > 1 or vistype_unique[0][0].pri_hdr['VISTYPE'] == 'CGIVST_CAL_ABSFLUX_BRIGHT':
+                elif len(vistype_unique) > 1 or vistype_unique[0] == 'CGIVST_CAL_ABSFLUX_BRIGHT':
                     recipe_filename = ["l1_to_l2a_basic.json", "l2a_to_l2b.json", "l2b_to_nd_filter.json"]
                     chained = True
                 # abs flux if dataset contains dim targets only
                 else:
-                    # Check for polarimetry mode to use appropriate flux calibration recipe
-                    if image.ext_hdr.get('DPAMNAME', '') in ['POL0', 'POL45']:
-                        recipe_filename = ["l1_to_l2a_basic.json", "l2a_to_l2b_pol.json", "l2b_to_fluxcal_factor_pol.json"]
-                    else:
-                        recipe_filename = ["l1_to_l2a_basic.json", "l2a_to_l2b.json", "l2b_to_fluxcal_factor.json"]
+                    recipe_filename = ["l1_to_l2a_basic.json", "l2a_to_l2b.json", "l2b_to_fluxcal_factor.json"]
                     chained = True
         elif image.pri_hdr['VISTYPE'] == 'CGIVST_CAL_CORETHRPT':
             recipe_filename = ["l1_to_l2a_basic.json", "l2a_to_l2b.json", 'l2b_to_corethroughput.json']

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -558,10 +558,12 @@ def guess_template(dataset):
                     recipe_filename = ["l1_to_l2a_basic.json", "l2a_to_l2b_spec.json", "l2b_to_spec_flux.json"]
                     chained = True
             else:
-                _, fsm_unique = dataset.split_dataset(exthdr_keywords=['FSMX', 'FSMY'])
-                if len(fsm_unique) > 1:
+                _, vistype_unique = dataset.split_dataset(prihdr_keywords=['VISTYPE'])
+                # ND filter calibration if bright targets in dataset
+                if len(vistype_unique) > 1 or vistype_unique[0][0].pri_hdr['VISTYPE'] == 'CGIVST_CAL_ABSFLUX_BRIGHT':
                     recipe_filename = ["l1_to_l2a_basic.json", "l2a_to_l2b.json", "l2b_to_nd_filter.json"]
                     chained = True
+                # abs flux if dataset contains dim targets only
                 else:
                     # Check for polarimetry mode to use appropriate flux calibration recipe
                     if image.ext_hdr.get('DPAMNAME', '') in ['POL0', 'POL45']:

--- a/corgidrp/walker.py
+++ b/corgidrp/walker.py
@@ -695,7 +695,7 @@ def save_data(dataset_or_image, outputdir, suffix="", ram_heavy_save=False):
     Records calibration frames into the caldb during the process
 
     Args:
-        dataset_or_image (corgidrp.data.Dataset or corgidrp.data.Image or list of Dataset/Image): data to save
+        dataset_or_image (corgidrp.data.Dataset or corgidrp.data.Image): data to save
         outputdir (str): path to directory where files should be saved
         suffix (str): optional suffix to tack onto the filename.
                       E.g.: `test.fits` with `suffix="dark"` becomes `test_dark.fits`
@@ -706,11 +706,6 @@ def save_data(dataset_or_image, outputdir, suffix="", ram_heavy_save=False):
     # convert everything to dataset to make life easier
     if isinstance(dataset_or_image, data.Image):
         dataset = data.Dataset([dataset_or_image])
-    elif isinstance (dataset_or_image, list):
-        # if a list of datasets or images is passed in, call save on each individual item in the list
-        for item in dataset_or_image:
-            save_data(item, outputdir, suffix=suffix, ram_heavy_save=ram_heavy_save)
-        return
     else:
         dataset = dataset_or_image
 
@@ -840,12 +835,6 @@ def run_recipe(recipe, save_recipe_file=True):
                     save_data(curr_dataset, recipe["outputdir"], suffix=suffix, ram_heavy_save=ram_heavy_save)
                     if isinstance(curr_dataset, data.Dataset):
                         output_filepaths += [frame.filepath for frame in curr_dataset]
-                    elif isinstance(curr_dataset, list):
-                        for item in curr_dataset:
-                            if isinstance(item, data.Dataset):
-                                output_filepaths += [frame.filepath for frame in item]
-                            else:
-                                output_filepaths += [item.filepath]
                     else:
                         output_filepaths += [curr_dataset.filepath]
                     save_step = True

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -535,7 +535,7 @@ def test_nd_filter_calibration_with_fluxcal(dim_dir, stars_dataset_cached, phot_
         FLUX_OR_IRR,
         PHOT_ARGS,
         fluxcal_factor=fluxcal_obj
-    )[0]
+    )
 
     # 3) Check that the calibration worked
     ods = results.data

--- a/tests/test_nd_filter_calibration.py
+++ b/tests/test_nd_filter_calibration.py
@@ -286,7 +286,7 @@ def test_nd_filter_calibration_object_with_calspec(bright_files_cached):
     ds_copy[1].ext_hdr["FPAMNAME"] = 'OPEN_12'
     results = nd_filter_calibration.create_nd_filter_cal(
         ds_copy, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 
-        fluxcal_factor = None, calspec_files = [calspec_filepath])
+        fluxcal_factor = None, calspec_files = [calspec_filepath])[0]
     
     test_output_dir = os.path.join(os.path.dirname(__file__), "testcalib")
     os.makedirs(test_output_dir, exist_ok=True)
@@ -310,7 +310,7 @@ def test_nd_filter_calibration_object(stars_dataset_cached):
     ds_copy = copy.deepcopy(stars_dataset_cached)
     results = nd_filter_calibration.create_nd_filter_cal(
         ds_copy, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 
-        fluxcal_factor = None)
+        fluxcal_factor = None)[0]
     
     test_output_dir = os.path.join(os.path.dirname(__file__), "testcalib")
     os.makedirs(test_output_dir, exist_ok=True)
@@ -347,7 +347,7 @@ def test_output_filename_convention(stars_dataset_cached):
     results = nd_filter_calibration.create_nd_filter_cal(
         ds_copy, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS,
         fluxcal_factor=None
-    )
+    )[0]
     results.save(filedir=test_output_dir)
     
     assert os.path.exists(full_expected_path), (
@@ -361,7 +361,7 @@ def test_average_od_within_tolerance(stars_dataset_cached_bright_count):
     ds_copy, n_bright = copy.deepcopy(stars_dataset_cached_bright_count)
     results = nd_filter_calibration.create_nd_filter_cal(
         ds_copy, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 
-        fluxcal_factor = None)
+        fluxcal_factor = None)[0]
     ods = results.data
     avg_od = np.mean(ods[:, 0])
     std_od = np.std(ods[:,0])
@@ -438,7 +438,7 @@ def test_nd_filter_calibration_phot_methods(stars_dataset_cached, phot_method):
     ds_copy = copy.deepcopy(stars_dataset_cached)
     results = nd_filter_calibration.create_nd_filter_cal(
         ds_copy, OD_RASTER_THRESHOLD, phot_method, FLUX_OR_IRR, phot_args, 
-        fluxcal_factor = None)
+        fluxcal_factor = None)[0]
     ods = results.data
     avg_od = np.mean(ods[:, 0])
     assert abs(avg_od - INPUT_OD) < OD_TEST_TOLERANCE, (
@@ -465,7 +465,7 @@ def test_multiple_nd_levels(dim_dir, output_dir, test_od):
 
     results = nd_filter_calibration.create_nd_filter_cal(
         combined_dataset, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 
-        fluxcal_factor = None)
+        fluxcal_factor = None)[0]
     ods = results.data
     avg_od = np.mean(ods[:, 0])
     assert abs(avg_od - test_od) < 0.2, (
@@ -535,7 +535,7 @@ def test_nd_filter_calibration_with_fluxcal(dim_dir, stars_dataset_cached, phot_
         FLUX_OR_IRR,
         PHOT_ARGS,
         fluxcal_factor=fluxcal_obj
-    )
+    )[0]
 
     # 3) Check that the calibration worked
     ods = results.data
@@ -567,7 +567,7 @@ def test_aperture_radius_sensitivity(stars_dataset_cached, aper_radius):
     ds_copy = copy.deepcopy(stars_dataset_cached)
     results = nd_filter_calibration.create_nd_filter_cal(
         ds_copy, OD_RASTER_THRESHOLD, "Aperture", "irr", phot_args, 
-        fluxcal_factor = None)
+        fluxcal_factor = None)[0]
     ods = results.data
     avg_od = np.mean(ods[:, 0])
     assert abs(avg_od - INPUT_OD) < 0.3, (
@@ -612,11 +612,11 @@ def test_background_effect(tmp_path):
     
     results_no = nd_filter_calibration.create_nd_filter_cal(
         ds_no, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 
-        fluxcal_factor = None)
+        fluxcal_factor = None)[0]
     results_bg = nd_filter_calibration.create_nd_filter_cal(
         ds_bg, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS,
         fluxcal_factor = None
-    )
+    )[0]
 
     ods_no = results_no.data
     avg_od_no = np.mean(ods_no[:, 0])
@@ -829,6 +829,38 @@ def test_calculate_od_spec_at_new_location(output_dir):
         print('')
         print(f"estimated flux = {output_spec[i]}, expected flux = {expected_value}")
     print(f"test_calculate_od_spec_at_new_location PASSED")
+
+def test_fluxcal_file_generation(dim_dir, output_dir):
+    """
+    Test that the ND filter calibration also returns an abs flux calibration file.
+    """
+
+    # create a dataset consisting of bright and dim stars
+    bright_mocks_dir = os.path.join(output_dir, f"mock_OD{2.25}")
+    bright_images = mock_bright_dataset_files(
+        BRIGHT_EXPTIME, FILTER_USED, 2.25, CAL_FACTOR, save_mocks=True, output_path=bright_mocks_dir
+    )
+    
+    dim_filepaths = glob.glob(os.path.join(dim_dir, "*")) # use cached dim images
+    dim_images = [Image(path) for path in dim_filepaths]
+    # Update BUNIT for ND filter calibration requirements
+    for img in dim_images:
+        img.ext_hdr['BUNIT'] = 'photoelectron/s'
+        img.ext_hdr['DATALVL'] = 'L3'
+    combined_files = bright_images + dim_images
+    combined_dataset = Dataset(combined_files)
+    
+    results = nd_filter_calibration.create_nd_filter_cal(
+        combined_dataset, OD_RASTER_THRESHOLD, PHOT_METHOD, FLUX_OR_IRR, PHOT_ARGS, 
+        fluxcal_factor = None)
+
+    # separate out the ND filter calibration and the associated abs flux calibration 
+    nd_cal_file = results[0]
+    abs_flux_cal_file = results[1]
+
+    # check that the returned files are of the expected datatype
+    assert isinstance(nd_cal_file, NDFilterSweetSpotDataset)
+    assert isinstance(abs_flux_cal_file, FluxcalFactor)
 
 '''
 BRIGHT_CACHE_DIR = "/Users/jmilton/Github/corgidrp/corgidrp/data/nd_filter_mocks/bright"


### PR DESCRIPTION
## Describe your changes
- ND filter calibration now returns a size 2 dataset that also includes the abs flux calibration created from the dim dataset
- walker distinguishes between abs flux and ND filter calibrations using bright/dim datasets instead of fsmx/fsmy dithering.
- added a new argument to the dataset class constructor to disable the creation of all_data/all_err/all_dq to construct a dataset from frames that have mismatched dimensions (ND filter cal and abs flux cal).

## Type of change
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
#1014

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
