### PR TITLE
generate_mueller_matrix_cal should look in .corgidrp for a calfile (#947)

### DIFF
--- a/corgidrp/pol.py
+++ b/corgidrp/pol.py
@@ -1,5 +1,6 @@
 # A file that holds the functions to handle polarimetry data 
 import os
+import corgidrp
 import numpy as np
 import pandas as pd
 
@@ -243,7 +244,7 @@ def generate_mueller_matrix_cal(input_dataset,
     TARGET, P, P_err, PA, PA_err
     where TARGET is the name of the target, P is the degree of polarization in percent, P_err is the error
     in the degree of polarization in percent, PA is the polarization angle in degrees, and PA_err is the
-    error in the polarization angle in degrees.
+    error in the polarization angle in degrees. Each target must appear in exactly one row.
 
     The error calculation propagates both the photometric measurement noise on the observed Stokes vectors
     and the uncertainties in the reference star polarization fraction and angle (P_err, PA_err from the
@@ -252,8 +253,12 @@ def generate_mueller_matrix_cal(input_dataset,
     Args: 
         input_dataset (corgidrp.data.Dataset): A CorgiDRP dataset consisting of stokes vectors.
             This data should be either all ND datasets or all non-ND datasets.
-        path_to_pol_ref_file (str): The path to the polarization reference file. 
-            Default is "./data/stellar_polarization_database.csv".
+        path_to_pol_ref_file (str, optional): The path to the polarization reference file.
+            If None (default), "stellar_polarization_database.csv" is looked for in the corgidrp
+            configuration directory (the directory holding corgidrp.config_filepath, normally
+            ~/.corgidrp), which allows the file to be overridden without modifying the installed
+            pipeline. If that file does not exist, the copy shipped with the pipeline in
+            ./data/stellar_polarization_database.csv is used.
         svd_threshold (float, optional): The threshold for singular values in the SVD inversion. Defaults to 1e-5 (semi-arbitrary).
     
     Returns:
@@ -263,7 +268,11 @@ def generate_mueller_matrix_cal(input_dataset,
     dataset = input_dataset.copy()
 
     if path_to_pol_ref_file is None:
-        path_to_pol_ref_file = os.path.join(os.path.dirname(__file__), "data", "stellar_polarization_database.csv")
+        user_pol_ref_path = os.path.join(os.path.dirname(corgidrp.config_filepath), "stellar_polarization_database.csv")
+        if os.path.isfile(user_pol_ref_path):
+            path_to_pol_ref_file = user_pol_ref_path
+        else:
+            path_to_pol_ref_file = os.path.join(os.path.dirname(__file__), "data", "stellar_polarization_database.csv")
 
     # check that all the data in the dataset is either ND or non-ND, by looking for ND in the FPAMNAME keyword
     nd_flags = [("ND" in data.ext_hdr["FPAMNAME"]) for data in dataset]
@@ -276,6 +285,14 @@ def generate_mueller_matrix_cal(input_dataset,
 
     # Read in the polarization reference file
     pol_ref = pd.read_csv(path_to_pol_ref_file, skipinitialspace=True)
+    # check the reference file has the columns this function needs, since it may be user-supplied
+    missing_columns = [col for col in ("TARGET", "P", "P_err", "PA", "PA_err") if col not in pol_ref.columns]
+    if missing_columns:
+        raise ValueError(f"Polarization reference file {path_to_pol_ref_file} is missing required column(s): {missing_columns}")
+    # a repeated target would silently resolve to whichever row happens to come first
+    duplicate_targets = pol_ref["TARGET"][pol_ref["TARGET"].duplicated()].unique().tolist()
+    if duplicate_targets:
+        raise ValueError(f"Polarization reference file {path_to_pol_ref_file} has more than one row for target(s): {duplicate_targets}")
     # extract the target names
     pol_ref_targets = pol_ref["TARGET"].tolist()
 
@@ -396,6 +413,8 @@ def generate_mueller_matrix_cal(input_dataset,
         mueller_matrix_obj = MuellerMatrix(mueller_matrix,pri_hdr=dataset[0].pri_hdr.copy(),
                          ext_hdr=dataset[0].ext_hdr.copy(), input_dataset=dataset,
                          err=mueller_matrix_err)
+
+    mueller_matrix_obj.ext_hdr.add_history(f"Pol reference file: {path_to_pol_ref_file}")
 
     return mueller_matrix_obj
 

--- a/tests/test_polarimetry.py
+++ b/tests/test_polarimetry.py
@@ -706,6 +706,25 @@ def test_mueller_matrix_cal_source_pol_errors_increase_mm_err():
             os.unlink(zero_err_path)
 
 
+def test_shipped_pol_ref_file_is_valid():
+    """
+    Tests that the polarization reference file shipped with the pipeline parses and has the
+    columns generate_mueller_matrix_cal requires. This is the file used when neither an explicit
+    path nor a user-supplied file in the corgidrp config directory is available, so it must stay
+    readable even though nothing in the frozen environment can fix it.
+    """
+    shipped_pol_ref_file = os.path.join(os.path.dirname(pol.__file__), "data",
+                                        "stellar_polarization_database.csv")
+
+    assert os.path.isfile(shipped_pol_ref_file), \
+        f"shipped pol reference file is missing: {shipped_pol_ref_file}"
+
+    shipped = pd.read_csv(shipped_pol_ref_file, skipinitialspace=True)
+    for column in ("TARGET", "P", "P_err", "PA", "PA_err"):
+        assert column in shipped.columns, \
+            f"shipped pol reference file is missing required column {column}"
+
+
 def test_subtract_stellar_polarization():
     """
     Test that the subtract_stellar_polarization step function separates the input dataset by target star


### PR DESCRIPTION
## Describe your changes

I implemented a minimal fix on feature/issue_947. Importing corgidrp to access the path, and then check by lookup priority: first check explicit path, then .corgidrp, then default file provided in the repo. The provided file is checked for having the required columns and no duplicate targets. It then adds a history to the extended header to keep track of which file was used: mueller_matrix_obj.ext_hdr.add_history(f"Pol reference file: {path_to_pol_ref_file}"). Docstring is updated.

The logic is simple enough that I didn't add any new tests, except applying the column and duplication check to the existing shipped file. However, I noticed that there is a test_data/stellar_polarization_database.csv, which is identical with the corgidrp/data/stellar_polarization_database.csv. There is another potential issue in that the e2e test follows the new decision tree, so if a tester has a stray stellar_polarization_database.csv in their .corgidrp folder, this will be used for the e2e test, because no explicit file is passed there. So I'd appreciate feedback which file should be used in what circumstances.

## Type of change

Please delete options that are not relevant (and this line).

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Reference any relevant issues (don't forget the #)
#947  

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [ ] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [ ] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
