### PR TITLE
Pol flat fixes to address #1003 and #1004

### DIFF
--- a/corgidrp/flat.py
+++ b/corgidrp/flat.py
@@ -561,9 +561,7 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
         elif planet.lower() == 'uranus':
              planet_rad = 65
         else:
-            # A rastered star fills a disk; measure it from the data rather than
-            # assuming a size or a raster pattern. Each pol component is a separate
-            # lit region, so the largest connected disk gives the per-component radius.
+            # a rastered star fills a disk of unknown size; measure it per frame
             radii = [measure_disk_radius(frame.data) for frame in dataset]
             radii = [r for r in radii if r is not None]
             if not radii:
@@ -578,11 +576,8 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
          elif band[0] == "4":
             rad_mask = 1.75
     if n_pix is None:
-        # Size the final flat to the full illuminated disk (radius planet_rad) that the
-        # rastered source actually covers, the same region regular imaging keeps via its
-        # n_pix=None auto-sizing. The fixed NFOV/WFOV values clipped the flat to a disk
-        # (radius n_pix//2 = 22 for NFOV) far smaller than what the star illuminates,
-        # throwing away most of the good flat data.
+        # size the flat to the full illuminated disk (radius planet_rad); the flat
+        # keeps radius n_pix//2, so use the disk diameter
         n_pix = 2 * planet_rad
     
     # wollaston prism angle, used below to place the combined rasters
@@ -591,18 +586,15 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
     else:
         angle_rad = (alignment_angle_WP2 * np.pi) / 180
 
-    # the planet images with two pol components are downsampled by a factor of 8 for finding the centroids using daostarfinder
+    # find the two pol spots in each frame, then flatten each one
     raster_frames_pol1=[];raster_frames_pol2=[]; cent_pol1=[]; cent_pol2=[]; act_cents_1=[]; act_cents_2=[];
     for j in range(len(dataset)):
         planet_image=dataset[j].data.copy()  # copy: the sky subtraction below is in-place
         planet_image_err=dataset[j].err[0]
         prihdr=dataset[j].pri_hdr
         exthdr=dataset[j].ext_hdr
-        # Median-filter before detection so a multi-pixel hot-pixel/cosmic-ray
-        # cluster brighter than the (prism-split, so individually fainter) spots
-        # cannot set the detection threshold and cause DAOStarFinder to miss the
-        # real spots. Threshold off a robust statistic of the smoothed
-        # downsampled image rather than the raw full-frame max.
+        # detect on a median-filtered, 8x-downsampled image with a median+5*std
+        # threshold, so hot pixels/cosmic rays don't hide the (fainter) split spots
         planet_image_downsampled = zoom(median_filter(np.nan_to_num(planet_image), 5), 1/8)
         med = np.nanmedian(planet_image_downsampled)
         std = np.nanstd(planet_image_downsampled)
@@ -622,10 +614,8 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
         x_centroids[np.isnan(x_centroids)] = 0
         y_centroids[np.isnan(y_centroids)] = 0
 
-        # The two orthogonal pol spots are separated by a known distance
-        # (separation_diameter_arcsec / plate_scale). Of all detected sources,
-        # pick the pair whose separation best matches that, so a spurious
-        # detection (e.g. a residual hot pixel) cannot be mistaken for a spot.
+        # the two spots sit a known distance apart, so pick the detected pair whose
+        # separation best matches it 
         expected_sep = separation_diameter_arcsec / plate_scale
         n_src = len(x_centroids)
         best = None
@@ -645,13 +635,9 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
         else:
             i1, i2 = b, a
 
-        # DAOStarFinder ran on an 8x-downsampled image, so these centers are only
-        # accurate to ~8 detector pixels. That is good enough to identify which two
-        # sources are the pol spots, but not to register the crops: the flat math
-        # median-combines source-centered crops and divides each frame by that median,
-        # so a compact stellar PSF misregistered by several pixels between frames leaves
-        # PSF-shaped residuals instead of a flat. Refine each spot at full resolution
-        # with the same disk-overlap centroid the regular imaging flat uses.
+        # the downsampled centers are only accurate to ~8 px, too coarse to register
+        # the crops (mis-registered PSFs leave PSF-shaped residuals, not a flat).
+        # refine each spot at full resolution, as the regular imaging flat does.
         coarse_centers = [(int(x_centroids[i1]), int(y_centroids[i1])),
                           (int(x_centroids[i2]), int(y_centroids[i2]))]
         refined_centers = []
@@ -675,10 +661,8 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
         act_cents_1.append((pol1_x,pol1_y))
         act_cents_2.append((pol2_x,pol2_y))
 
-        # sky subtraction if needed: estimate the sky per pol component from an annulus
-        # centered on that component's own disk (create_onsky_flatfield does this for its
-        # single source; centering on the midpoint between the two disks would sample the
-        # disks themselves rather than blank sky).
+        # estimate sky per spot from an annulus around that spot; a shared annulus on
+        # the midpoint between them would fall on the disks, not blank sky
         sky_pol1 = 0.0
         sky_pol2 = 0.0
         if sky_annulus_rin is not None and sky_annulus_rout is not None:

--- a/corgidrp/flat.py
+++ b/corgidrp/flat.py
@@ -519,10 +519,11 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
         N (int): Number of images to be combined for creating a matched filter (defaults to 1, may not work for N>1 right now)
         rad_mask (float): radius in pixels used for creating a mask for band (band1=1.25, band4=1.75)
         planet_rad (int): radius of the planet in pixels (planet_rad=50 for neptune, planet_rad=65)
-        n_pix (int): Number of pixels in radius covering the Roman CGI imaging FOV (defaults to 44 pix for Band1 HLC; 165 pixels for full shaped pupil FOV).
-        observing_mode (string): observing mode of the coronagraph
+        n_pix (int): Diameter in pixels of the final flat's characterized region; beyond this radius (n_pix//2) the flat is set to 1. Defaults to 2*planet_rad so the flat covers the full illuminated disk the rastered source produces.
+        observing_mode (string): observing mode of the coronagraph (retained for backward compatibility; no longer used to set n_pix)
         n_pad (int): Number of pixels padded with '1s'  to generate the image size 1024X1024 pixels around imaging FOV (defaults to None; rest of the FOV to reach 1024)
-        fwhm_guess (int):FWHM guess for the planet image which is downsampled by a factor of 8
+        fwhm_guess (int): FWHM (in downsampled pixels) passed to DAOStarFinder when
+            locating the two polarized spots
         sky_annulus_rin (float): Inner radius of annulus to use for sky subtraction. In units of planet_rad.
             If both sky_annulus_rin and sky_annulus_rout = None, skips sky subtraciton.
         sky_annulus_rout (float): Outer radius of annulus to use for sky subtraction. In units of planet_rad.
@@ -559,60 +560,140 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
              planet_rad = 50
         elif planet.lower() == 'uranus':
              planet_rad = 65
-    
+        else:
+            # A rastered star fills a disk; measure it from the data rather than
+            # assuming a size or a raster pattern. Each pol component is a separate
+            # lit region, so the largest connected disk gives the per-component radius.
+            radii = [measure_disk_radius(frame.data) for frame in dataset]
+            radii = [r for r in radii if r is not None]
+            if not radii:
+                raise ValueError("Could not measure the radius of the illuminated "
+                                 "disk in any frame. Pass planet_rad explicitly.")
+            # median over frames
+            planet_rad = min(int(np.ceil(np.median(radii))), up_radius - 1)
+
     if rad_mask is None:
          if band[0] == "1":
             rad_mask = 1.25
          elif band[0] == "4":
             rad_mask = 1.75
     if n_pix is None:
-        if observing_mode=='NFOV':
-            n_pix=44
-        elif observing_mode=='WFOV':
-            n_pix=174
+        # Size the final flat to the full illuminated disk (radius planet_rad) that the
+        # rastered source actually covers, the same region regular imaging keeps via its
+        # n_pix=None auto-sizing. The fixed NFOV/WFOV values clipped the flat to a disk
+        # (radius n_pix//2 = 22 for NFOV) far smaller than what the star illuminates,
+        # throwing away most of the good flat data.
+        n_pix = 2 * planet_rad
     
+    # wollaston prism angle, used below to place the combined rasters
+    if dpamname == 'POL0':
+        angle_rad = (alignment_angle_WP1 * np.pi) / 180
+    else:
+        angle_rad = (alignment_angle_WP2 * np.pi) / 180
+
     # the planet images with two pol components are downsampled by a factor of 8 for finding the centroids using daostarfinder
     raster_frames_pol1=[];raster_frames_pol2=[]; cent_pol1=[]; cent_pol2=[]; act_cents_1=[]; act_cents_2=[];
     for j in range(len(dataset)):
-        planet_image=dataset[j].data
+        planet_image=dataset[j].data.copy()  # copy: the sky subtraction below is in-place
         planet_image_err=dataset[j].err[0]
         prihdr=dataset[j].pri_hdr
         exthdr=dataset[j].ext_hdr
-        planet_image_downsampled = zoom(planet_image, 1/8)
-        threshold_value = np.max(planet_image)
+        # Median-filter before detection so a multi-pixel hot-pixel/cosmic-ray
+        # cluster brighter than the (prism-split, so individually fainter) spots
+        # cannot set the detection threshold and cause DAOStarFinder to miss the
+        # real spots. Threshold off a robust statistic of the smoothed
+        # downsampled image rather than the raw full-frame max.
+        planet_image_downsampled = zoom(median_filter(np.nan_to_num(planet_image), 5), 1/8)
+        med = np.nanmedian(planet_image_downsampled)
+        std = np.nanstd(planet_image_downsampled)
+        threshold_value = med + 5.0 * std
         daofind = DAOStarFinder(fwhm=fwhm_guess, threshold=threshold_value, min_separation=10.0)
         sources = daofind(planet_image_downsampled)
 
-        if sources is not None:
+        if sources is None or len(sources) < 2:
+            raise ValueError("create_onsky_pol_flatfield: expected two polarization "
+                             "spots but DAOStarFinder found "
+                             f"{0 if sources is None else len(sources)} source(s) "
+                             f"in frame {j}.")
 
-            x_centroids = sources['x_centroid']*8
-            y_centroids = sources['y_centroid']*8
+        x_centroids = np.array(sources['xcentroid']) * 8
+        y_centroids = np.array(sources['ycentroid']) * 8
+        fluxes = np.array(sources['flux'])
+        x_centroids[np.isnan(x_centroids)] = 0
+        y_centroids[np.isnan(y_centroids)] = 0
 
-            pol1_x = int(x_centroids[0])
-            pol1_y = int(y_centroids[0])
-            pol2_x = int(x_centroids[1])
-            pol2_y = int(y_centroids[1])
+        # The two orthogonal pol spots are separated by a known distance
+        # (separation_diameter_arcsec / plate_scale). Of all detected sources,
+        # pick the pair whose separation best matches that, so a spurious
+        # detection (e.g. a residual hot pixel) cannot be mistaken for a spot.
+        expected_sep = separation_diameter_arcsec / plate_scale
+        n_src = len(x_centroids)
+        best = None
+        for a in range(n_src):
+            for b in range(a + 1, n_src):
+                sep = np.hypot(x_centroids[a] - x_centroids[b],
+                               y_centroids[a] - y_centroids[b])
+                cost = abs(sep - expected_sep)
+                # tie-break toward the brighter pair
+                score = (cost, -(fluxes[a] + fluxes[b]))
+                if best is None or score < best[0]:
+                    best = (score, a, b)
+        a, b = best[1], best[2]
+        # order deterministically: pol1 = left (smaller x), pol2 = right
+        if x_centroids[a] <= x_centroids[b]:
+            i1, i2 = a, b
+        else:
+            i1, i2 = b, a
 
-            x_centroids[np.isnan(x_centroids)]=0
-            y_centroids[np.isnan(y_centroids)]=0
-            act_cents_1.append((pol1_x,pol1_y))
-            act_cents_2.append((pol2_x,pol2_y))
+        # DAOStarFinder ran on an 8x-downsampled image, so these centers are only
+        # accurate to ~8 detector pixels. That is good enough to identify which two
+        # sources are the pol spots, but not to register the crops: the flat math
+        # median-combines source-centered crops and divides each frame by that median,
+        # so a compact stellar PSF misregistered by several pixels between frames leaves
+        # PSF-shaped residuals instead of a flat. Refine each spot at full resolution
+        # with the same disk-overlap centroid the regular imaging flat uses.
+        coarse_centers = [(int(x_centroids[i1]), int(y_centroids[i1])),
+                          (int(x_centroids[i2]), int(y_centroids[i2]))]
+        refined_centers = []
+        for cx, cy in coarse_centers:
+            y0 = max(0, cy - up_radius)
+            y1 = min(planet_image.shape[0], cy + up_radius)
+            x0 = max(0, cx - up_radius)
+            x1 = min(planet_image.shape[1], cx + up_radius)
+            window = planet_image[y0:y1, x0:x1]
+            center = find_disk_center(window, planet_rad)
+            if center is None:
+                center = source_centroid(window)
+            if center is None:
+                # fall back to the coarse DAOStarFinder position
+                refined_centers.append((cx, cy))
+            else:
+                refined_centers.append((int(round(x0 + center[0])),
+                                        int(round(y0 + center[1]))))
+        pol1_x, pol1_y = refined_centers[0]
+        pol2_x, pol2_y = refined_centers[1]
+        act_cents_1.append((pol1_x,pol1_y))
+        act_cents_2.append((pol2_x,pol2_y))
 
-
-        # sky subtraction if needed
-        xc=np.mean([pol1_x,pol2_x])
-        yc=np.mean([pol1_y,pol2_y])
+        # sky subtraction if needed: estimate the sky per pol component from an annulus
+        # centered on that component's own disk (create_onsky_flatfield does this for its
+        # single source; centering on the midpoint between the two disks would sample the
+        # disks themselves rather than blank sky).
+        sky_pol1 = 0.0
+        sky_pol2 = 0.0
         if sky_annulus_rin is not None and sky_annulus_rout is not None:
             ycoords, xcoords = np.indices(planet_image.shape)
-            dist_from_planet = np.sqrt((xcoords - xc)**2 + (ycoords - yc)**2)
-            sky_annulus = np.where((dist_from_planet >= sky_annulus_rin*planet_rad) & (dist_from_planet < sky_annulus_rout*planet_rad))
-            planet_image -= np.nanmedian(planet_image[sky_annulus])
+            dist_pol1 = np.sqrt((xcoords - pol1_x)**2 + (ycoords - pol1_y)**2)
+            annulus_pol1 = (dist_pol1 >= sky_annulus_rin*planet_rad) & (dist_pol1 < sky_annulus_rout*planet_rad)
+            sky_pol1 = np.nanmedian(planet_image[annulus_pol1])
+            dist_pol2 = np.sqrt((xcoords - pol2_x)**2 + (ycoords - pol2_y)**2)
+            annulus_pol2 = (dist_pol2 >= sky_annulus_rin*planet_rad) & (dist_pol2 < sky_annulus_rout*planet_rad)
+            sky_pol2 = np.nanmedian(planet_image[annulus_pol2])
 
-        
-        # cropping the raster scanned images
-        raster_images_pol1=planet_image[pol1_y-up_radius:pol1_y+up_radius,pol1_x-up_radius:pol1_x+up_radius]
-        raster_images_pol2=planet_image[pol2_y-up_radius:pol2_y+up_radius,pol2_x-up_radius:pol2_x+up_radius]
-        
+        # cropping the raster scanned images (subtract each component's own sky level)
+        raster_images_pol1=planet_image[pol1_y-up_radius:pol1_y+up_radius,pol1_x-up_radius:pol1_x+up_radius] - sky_pol1
+        raster_images_pol2=planet_image[pol2_y-up_radius:pol2_y+up_radius,pol2_x-up_radius:pol2_x+up_radius] - sky_pol2
+
         raster_images_pol1_err=planet_image_err[pol1_y-up_radius:pol1_y+up_radius,pol1_x-up_radius:pol1_x+up_radius]
         raster_images_pol2_err=planet_image_err[pol2_y-up_radius:pol2_y+up_radius,pol2_x-up_radius:pol2_x+up_radius]
         
@@ -633,16 +714,10 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
     resi_images_pol1_dataset=flatfield_residuals(raster_images_pol1_dataset,N=N)
     resi_images_pol2_dataset=flatfield_residuals(raster_images_pol2_dataset,N=N)
 
-    combined_rasters_pol1=combine_flatfield_rasters(resi_images_pol1_dataset,planet=planet,band=band,cent=cent_pol1, im_size=im_size, rad_mask=rad_mask,planet_rad=planet_rad,n_pix=n_pix, n_pad=n_pad,image_center_x=512,image_center_y=512)
-    combined_rasters_pol2=combine_flatfield_rasters(resi_images_pol2_dataset,planet=planet,band=band,cent=cent_pol2, im_size=im_size, rad_mask=rad_mask,planet_rad=planet_rad,n_pix=n_pix, n_pad=n_pad,image_center_x=512,image_center_y=512)
+    combined_rasters_pol1=combine_flatfield_rasters(resi_images_pol1_dataset,planet=planet,band=band,cent=cent_pol1, im_size=im_size, rad_mask=rad_mask,planet_rad=planet_rad,n_pix=n_pix, n_pad=n_pad,image_center_x=image_center_x,image_center_y=image_center_y)
+    combined_rasters_pol2=combine_flatfield_rasters(resi_images_pol2_dataset,planet=planet,band=band,cent=cent_pol2, im_size=im_size, rad_mask=rad_mask,planet_rad=planet_rad,n_pix=n_pix, n_pad=n_pad,image_center_x=image_center_x,image_center_y=image_center_y)
     
-    if dpamname == 'POL0':
-    #place image according to specified angle
-        angle_rad = (alignment_angle_WP1 * np.pi) / 180
-    else:
-        angle_rad = (alignment_angle_WP2 * np.pi) / 180
-     
-    
+    # place image according to specified angle (angle_rad computed above from dpamname)
     displacement_x = int(round((separation_diameter_arcsec * np.cos(angle_rad)) / (2 * plate_scale)))
     displacement_y = int(round((separation_diameter_arcsec * np.sin(angle_rad)) / (2 * plate_scale)))
     center_left = (image_center_x - displacement_x, image_center_y + displacement_y)

--- a/corgidrp/flat.py
+++ b/corgidrp/flat.py
@@ -7,13 +7,11 @@ from scipy.ndimage import gaussian_filter as gauss
 from scipy import ndimage
 from scipy.signal import convolve2d
 from scipy.signal import fftconvolve
-from scipy.ndimage import zoom
 import astropy.io.fits as fits
 from astropy.convolution import convolve_fft
 from astropy.utils.exceptions import AstropyUserWarning
 import photutils.centroids as centr
 from photutils.aperture import CircularAperture
-from photutils.detection import DAOStarFinder
 import corgidrp.data as data
 import corgidrp.mocks as mocks
 
@@ -278,8 +276,10 @@ def combine_flatfield_rasters(resi_images_dataset,cent=None,planet=None,band=Non
     
     full_residuals=np.pad(p_flat, ((n_pad,n_pad),(n_pad,n_pad)), mode='constant',constant_values=(1))
     err_residuals=np.pad(p_flat_err, ((n_pad,n_pad),(n_pad,n_pad)), mode='constant',constant_values=(0))
-    
-    return (full_residuals,err_residuals,cent_n)
+
+    # return n_pix too: when passed as None it is auto-sized to the largest hole-free
+    # disk, and the pol placement needs that value to crop each component's region
+    return (full_residuals,err_residuals,cent_n,n_pix)
     
     
 def source_centroid(image, threshold_frac=0.3, smooth_size=3):
@@ -389,6 +389,43 @@ def find_disk_center(image, radius_pix, threshold_frac=0.3, smooth_size=5):
         cy_local, cx_local = ndimage.center_of_mass(w)
         return float(x0 + cx_local), float(y0 + cy_local)
     return float(peak_x), float(peak_y)
+
+
+def find_two_sources(image, threshold_frac=0.3, smooth_size=5, min_area=4):
+    """Locate the two illuminated sources (the two pol spots) in a frame.
+
+    Smooths, thresholds, and labels connected regions, returning the flux-weighted
+    centroid and area of each region above min_area. Works for both a compact star
+    PSF and an extended planet disk; DAOStarFinder is avoided because it is tuned for
+    point sources and rejects extended (and coadded) disks on shape.
+
+    Args:
+        image (np.array): 2-D image containing the two sources.
+        threshold_frac (float): cut as a fraction of the peak of the smoothed image.
+        smooth_size (int): median-filter size applied before thresholding.
+        min_area (int): drop regions smaller than this (specks, cosmic rays).
+
+    Returns:
+        tuple: (xs, ys, areas) arrays for the detected sources, or None if fewer than
+        two survive.
+    """
+    smoothed = median_filter(np.nan_to_num(image), smooth_size)
+    peak = np.nanmax(smoothed)
+    if not np.isfinite(peak) or peak <= 0:
+        return None
+    mask = smoothed >= threshold_frac * peak
+    labels, n_features = ndimage.label(mask)
+    if n_features < 2:
+        return None
+    ids = np.arange(1, n_features + 1)
+    areas = ndimage.sum(mask, labels, ids)
+    keep = ids[areas >= min_area]
+    if len(keep) < 2:
+        return None
+    centroids = ndimage.center_of_mass(smoothed, labels, keep)
+    xs = np.array([c[1] for c in centroids])
+    ys = np.array([c[0] for c in centroids])
+    return xs, ys, ndimage.sum(mask, labels, keep)
 
 
 def create_onsky_flatfield(dataset, planet=None,band=None,up_radius=55,im_size=None,N=1,rad_mask=None, planet_rad=None, n_pix=None, n_pad=None, sky_annulus_rin=2, sky_annulus_rout=4,image_center_x=512,image_center_y=512):
@@ -522,8 +559,8 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
         n_pix (int): Diameter in pixels of the final flat's characterized region; beyond this radius (n_pix//2) the flat is set to 1. Defaults to 2*planet_rad so the flat covers the full illuminated disk the rastered source produces.
         observing_mode (string): observing mode of the coronagraph (retained for backward compatibility; no longer used to set n_pix)
         n_pad (int): Number of pixels padded with '1s'  to generate the image size 1024X1024 pixels around imaging FOV (defaults to None; rest of the FOV to reach 1024)
-        fwhm_guess (int): FWHM (in downsampled pixels) passed to DAOStarFinder when
-            locating the two polarized spots
+        fwhm_guess (int): retained for backward compatibility; no longer used now that
+            the two spots are located by segmentation
         sky_annulus_rin (float): Inner radius of annulus to use for sky subtraction. In units of planet_rad.
             If both sky_annulus_rin and sky_annulus_rout = None, skips sky subtraciton.
         sky_annulus_rout (float): Outer radius of annulus to use for sky subtraction. In units of planet_rad.
@@ -575,11 +612,9 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
             rad_mask = 1.25
          elif band[0] == "4":
             rad_mask = 1.75
-    if n_pix is None:
-        # size the flat to the full illuminated disk (radius planet_rad); the flat
-        # keeps radius n_pix//2, so use the disk diameter
-        n_pix = 2 * planet_rad
-    
+    # n_pix is left as passed (None -> combine_flatfield_rasters auto-sizes each
+    # component's region to its largest hole-free disk, avoiding in-FOV NaNs)
+
     # wollaston prism angle, used below to place the combined rasters
     if dpamname == 'POL0':
         angle_rad = (alignment_angle_WP1 * np.pi) / 180
@@ -593,29 +628,16 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
         planet_image_err=dataset[j].err[0]
         prihdr=dataset[j].pri_hdr
         exthdr=dataset[j].ext_hdr
-        # detect on a median-filtered, 8x-downsampled image with a median+5*std
-        # threshold, so hot pixels/cosmic rays don't hide the (fainter) split spots
-        planet_image_downsampled = zoom(median_filter(np.nan_to_num(planet_image), 5), 1/8)
-        med = np.nanmedian(planet_image_downsampled)
-        std = np.nanstd(planet_image_downsampled)
-        threshold_value = med + 5.0 * std
-        daofind = DAOStarFinder(fwhm=fwhm_guess, threshold=threshold_value, min_separation=10.0)
-        sources = daofind(planet_image_downsampled)
-
-        if sources is None or len(sources) < 2:
+        # find the two spots by segmentation, which works for both a compact star and
+        # an extended (coadded) planet disk
+        sources = find_two_sources(planet_image)
+        if sources is None:
             raise ValueError("create_onsky_pol_flatfield: expected two polarization "
-                             "spots but DAOStarFinder found "
-                             f"{0 if sources is None else len(sources)} source(s) "
-                             f"in frame {j}.")
-
-        x_centroids = np.array(sources['xcentroid']) * 8
-        y_centroids = np.array(sources['ycentroid']) * 8
-        fluxes = np.array(sources['flux'])
-        x_centroids[np.isnan(x_centroids)] = 0
-        y_centroids[np.isnan(y_centroids)] = 0
+                             f"spots but found fewer than two in frame {j}.")
+        x_centroids, y_centroids, weights = sources
 
         # the two spots sit a known distance apart, so pick the detected pair whose
-        # separation best matches it 
+        # separation best matches it (a spurious detection won't fit the geometry)
         expected_sep = separation_diameter_arcsec / plate_scale
         n_src = len(x_centroids)
         best = None
@@ -624,8 +646,8 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
                 sep = np.hypot(x_centroids[a] - x_centroids[b],
                                y_centroids[a] - y_centroids[b])
                 cost = abs(sep - expected_sep)
-                # tie-break toward the brighter pair
-                score = (cost, -(fluxes[a] + fluxes[b]))
+                # tie-break toward the larger (brighter) pair
+                score = (cost, -(weights[a] + weights[b]))
                 if best is None or score < best[0]:
                     best = (score, a, b)
         a, b = best[1], best[2]
@@ -635,11 +657,11 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
         else:
             i1, i2 = b, a
 
-        # the downsampled centers are only accurate to ~8 px, too coarse to register
-        # the crops (mis-registered PSFs leave PSF-shaped residuals, not a flat).
-        # refine each spot at full resolution, as the regular imaging flat does.
-        coarse_centers = [(int(x_centroids[i1]), int(y_centroids[i1])),
-                          (int(x_centroids[i2]), int(y_centroids[i2]))]
+        # refine each spot at full resolution with the same disk-overlap centroid the
+        # regular imaging flat uses, so the crops register to sub-pixel accuracy
+        # (mis-registered spots leave source-shaped residuals instead of a flat)
+        coarse_centers = [(int(round(x_centroids[i1])), int(round(y_centroids[i1]))),
+                          (int(round(x_centroids[i2])), int(round(y_centroids[i2])))]
         refined_centers = []
         for cx, cy in coarse_centers:
             y0 = max(0, cy - up_radius)
@@ -651,7 +673,7 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
             if center is None:
                 center = source_centroid(window)
             if center is None:
-                # fall back to the coarse DAOStarFinder position
+                # fall back to the coarse segmentation centroid
                 refined_centers.append((cx, cy))
             else:
                 refined_centers.append((int(round(x0 + center[0])),
@@ -701,28 +723,30 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
     combined_rasters_pol1=combine_flatfield_rasters(resi_images_pol1_dataset,planet=planet,band=band,cent=cent_pol1, im_size=im_size, rad_mask=rad_mask,planet_rad=planet_rad,n_pix=n_pix, n_pad=n_pad,image_center_x=image_center_x,image_center_y=image_center_y)
     combined_rasters_pol2=combine_flatfield_rasters(resi_images_pol2_dataset,planet=planet,band=band,cent=cent_pol2, im_size=im_size, rad_mask=rad_mask,planet_rad=planet_rad,n_pix=n_pix, n_pad=n_pad,image_center_x=image_center_x,image_center_y=image_center_y)
     
+    # each component is auto-sized (n_pix=None) to its own largest hole-free disk,
+    # so crop/place each one with its own radius rather than a shared n_pix
+    cent_n_pol1=combined_rasters_pol1[2]; n_pix_pol1=combined_rasters_pol1[3]
+    cent_n_pol2=combined_rasters_pol2[2]; n_pix_pol2=combined_rasters_pol2[3]
+    radius_left=n_pix_pol1//2
+    radius_right=n_pix_pol2//2
+
     # place image according to specified angle (angle_rad computed above from dpamname)
     displacement_x = int(round((separation_diameter_arcsec * np.cos(angle_rad)) / (2 * plate_scale)))
     displacement_y = int(round((separation_diameter_arcsec * np.sin(angle_rad)) / (2 * plate_scale)))
     center_left = (image_center_x - displacement_x, image_center_y + displacement_y)
     center_right = (image_center_x + displacement_x, image_center_y - displacement_y)
 
+    start_left = (center_left[0] - radius_left, center_left[1] - radius_left)
+    start_right = (center_right[0] - radius_right, center_right[1] - radius_right)
 
-    image_radius = n_pix // 2
-    start_left = (center_left[0] - image_radius, center_left[1] - image_radius)
-    start_right = (center_right[0] - image_radius, center_right[1] - image_radius)
-    
-    cent_n_pol1=combined_rasters_pol1[2]
-    cent_n_pol2=combined_rasters_pol2[2]
-    
     onsky_polflat=np.ones((n,n))
     onsky_polflat_error=np.zeros((n,n))
 
-    onsky_polflat[start_left[1]:start_left[1]+n_pix, start_left[0]:start_left[0]+n_pix]=combined_rasters_pol1[0][int(cent_n_pol1[1]) - n_pix//2:int(cent_n_pol1[1]) + n_pix//2,int(cent_n_pol1[0]) - n_pix//2:int(cent_n_pol1[0]) + n_pix//2]
-    onsky_polflat[start_right[1]:start_right[1]+n_pix, start_right[0]:start_right[0]+n_pix]=combined_rasters_pol2[0][int(cent_n_pol2[1])- n_pix//2:int(cent_n_pol2[1]) + n_pix//2,int(cent_n_pol2[0]) - n_pix//2:int(cent_n_pol2[0]) + n_pix//2]
+    onsky_polflat[start_left[1]:start_left[1]+2*radius_left, start_left[0]:start_left[0]+2*radius_left]=combined_rasters_pol1[0][int(cent_n_pol1[1]) - radius_left:int(cent_n_pol1[1]) + radius_left,int(cent_n_pol1[0]) - radius_left:int(cent_n_pol1[0]) + radius_left]
+    onsky_polflat[start_right[1]:start_right[1]+2*radius_right, start_right[0]:start_right[0]+2*radius_right]=combined_rasters_pol2[0][int(cent_n_pol2[1])- radius_right:int(cent_n_pol2[1]) + radius_right,int(cent_n_pol2[0]) - radius_right:int(cent_n_pol2[0]) + radius_right]
 
-    onsky_polflat_error[start_left[1]:start_left[1]+n_pix, start_left[0]:start_left[0]+n_pix]=combined_rasters_pol1[1][int(cent_n_pol1[1]) - n_pix//2:int(cent_n_pol1[1]) + n_pix//2,int(cent_n_pol1[0]) - n_pix//2:int(cent_n_pol1[0]) + n_pix//2]
-    onsky_polflat_error[start_right[1]:start_right[1]+n_pix, start_right[0]:start_right[0]+n_pix]=combined_rasters_pol2[1][int(cent_n_pol2[1]) - n_pix//2:int(cent_n_pol2[1]) + n_pix//2,int(cent_n_pol2[0]) - n_pix//2:int(cent_n_pol2[0]) + n_pix//2]   
+    onsky_polflat_error[start_left[1]:start_left[1]+2*radius_left, start_left[0]:start_left[0]+2*radius_left]=combined_rasters_pol1[1][int(cent_n_pol1[1]) - radius_left:int(cent_n_pol1[1]) + radius_left,int(cent_n_pol1[0]) - radius_left:int(cent_n_pol1[0]) + radius_left]
+    onsky_polflat_error[start_right[1]:start_right[1]+2*radius_right, start_right[0]:start_right[0]+2*radius_right]=combined_rasters_pol2[1][int(cent_n_pol2[1]) - radius_right:int(cent_n_pol2[1]) + radius_right,int(cent_n_pol2[0]) - radius_right:int(cent_n_pol2[0]) + radius_right]
     
     
     onsky_pol_flatfield = data.FlatField(onsky_polflat, pri_hdr=prihdr, ext_hdr=exthdr, input_dataset=dataset)

--- a/corgidrp/flat.py
+++ b/corgidrp/flat.py
@@ -732,12 +732,12 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
     combined_rasters_pol1=combine_flatfield_rasters(resi_images_pol1_dataset,planet=planet,band=band,cent=cent_pol1, im_size=im_size, rad_mask=rad_mask,planet_rad=planet_rad,n_pix=n_pix, n_pad=n_pad,image_center_x=image_center_x,image_center_y=image_center_y)
     combined_rasters_pol2=combine_flatfield_rasters(resi_images_pol2_dataset,planet=planet,band=band,cent=cent_pol2, im_size=im_size, rad_mask=rad_mask,planet_rad=planet_rad,n_pix=n_pix, n_pad=n_pad,image_center_x=image_center_x,image_center_y=image_center_y)
     
-    # each component is auto-sized (n_pix=None) to its own largest hole-free disk,
-    # so crop/place each one with its own radius rather than a shared n_pix
-    cent_n_pol1=combined_rasters_pol1[2]; n_pix_pol1=combined_rasters_pol1[3]
-    cent_n_pol2=combined_rasters_pol2[2]; n_pix_pol2=combined_rasters_pol2[3]
-    radius_left=n_pix_pol1//2
-    radius_right=n_pix_pol2//2
+    # both spots are the same source split by the Wollaston, so they auto-size to the
+    # same region; use one radius (the smaller, in case of a 1-px rounding difference,
+    # so neither crop reaches into an uncovered region)
+    cent_n_pol1=combined_rasters_pol1[2]
+    cent_n_pol2=combined_rasters_pol2[2]
+    image_radius=min(combined_rasters_pol1[3], combined_rasters_pol2[3])//2
 
     # place image according to specified angle (angle_rad computed above from dpamname)
     displacement_x = int(round((separation_diameter_arcsec * np.cos(angle_rad)) / (2 * plate_scale)))
@@ -745,17 +745,17 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
     center_left = (image_center_x - displacement_x, image_center_y + displacement_y)
     center_right = (image_center_x + displacement_x, image_center_y - displacement_y)
 
-    start_left = (center_left[0] - radius_left, center_left[1] - radius_left)
-    start_right = (center_right[0] - radius_right, center_right[1] - radius_right)
+    start_left = (center_left[0] - image_radius, center_left[1] - image_radius)
+    start_right = (center_right[0] - image_radius, center_right[1] - image_radius)
 
     onsky_polflat=np.ones((n,n))
     onsky_polflat_error=np.zeros((n,n))
 
-    onsky_polflat[start_left[1]:start_left[1]+2*radius_left, start_left[0]:start_left[0]+2*radius_left]=combined_rasters_pol1[0][int(cent_n_pol1[1]) - radius_left:int(cent_n_pol1[1]) + radius_left,int(cent_n_pol1[0]) - radius_left:int(cent_n_pol1[0]) + radius_left]
-    onsky_polflat[start_right[1]:start_right[1]+2*radius_right, start_right[0]:start_right[0]+2*radius_right]=combined_rasters_pol2[0][int(cent_n_pol2[1])- radius_right:int(cent_n_pol2[1]) + radius_right,int(cent_n_pol2[0]) - radius_right:int(cent_n_pol2[0]) + radius_right]
+    onsky_polflat[start_left[1]:start_left[1]+2*image_radius, start_left[0]:start_left[0]+2*image_radius]=combined_rasters_pol1[0][int(cent_n_pol1[1]) - image_radius:int(cent_n_pol1[1]) + image_radius,int(cent_n_pol1[0]) - image_radius:int(cent_n_pol1[0]) + image_radius]
+    onsky_polflat[start_right[1]:start_right[1]+2*image_radius, start_right[0]:start_right[0]+2*image_radius]=combined_rasters_pol2[0][int(cent_n_pol2[1])- image_radius:int(cent_n_pol2[1]) + image_radius,int(cent_n_pol2[0]) - image_radius:int(cent_n_pol2[0]) + image_radius]
 
-    onsky_polflat_error[start_left[1]:start_left[1]+2*radius_left, start_left[0]:start_left[0]+2*radius_left]=combined_rasters_pol1[1][int(cent_n_pol1[1]) - radius_left:int(cent_n_pol1[1]) + radius_left,int(cent_n_pol1[0]) - radius_left:int(cent_n_pol1[0]) + radius_left]
-    onsky_polflat_error[start_right[1]:start_right[1]+2*radius_right, start_right[0]:start_right[0]+2*radius_right]=combined_rasters_pol2[1][int(cent_n_pol2[1]) - radius_right:int(cent_n_pol2[1]) + radius_right,int(cent_n_pol2[0]) - radius_right:int(cent_n_pol2[0]) + radius_right]
+    onsky_polflat_error[start_left[1]:start_left[1]+2*image_radius, start_left[0]:start_left[0]+2*image_radius]=combined_rasters_pol1[1][int(cent_n_pol1[1]) - image_radius:int(cent_n_pol1[1]) + image_radius,int(cent_n_pol1[0]) - image_radius:int(cent_n_pol1[0]) + image_radius]
+    onsky_polflat_error[start_right[1]:start_right[1]+2*image_radius, start_right[0]:start_right[0]+2*image_radius]=combined_rasters_pol2[1][int(cent_n_pol2[1]) - image_radius:int(cent_n_pol2[1]) + image_radius,int(cent_n_pol2[0]) - image_radius:int(cent_n_pol2[0]) + image_radius]
     
     
     onsky_pol_flatfield = data.FlatField(onsky_polflat, pri_hdr=prihdr, ext_hdr=exthdr, input_dataset=dataset)

--- a/corgidrp/flat.py
+++ b/corgidrp/flat.py
@@ -489,6 +489,7 @@ def create_onsky_flatfield(dataset, planet=None,band=None,up_radius=55,im_size=N
             rad_mask = 1.25
          elif band[0] == "4":
             rad_mask = 1.75
+    
 
     raster_frames = []
     cent = []
@@ -612,6 +613,11 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
             rad_mask = 1.25
          elif band[0] == "4":
             rad_mask = 1.75
+    if n_pix is None:
+        if observing_mode=='NFOV':
+            n_pix=44
+        elif observing_mode=='WFOV':
+            n_pix=174
     # n_pix is left as passed (None -> combine_flatfield_rasters auto-sizes each
     # component's region to its largest hole-free disk, avoiding in-FOV NaNs)
 
@@ -622,6 +628,7 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
         angle_rad = (alignment_angle_WP2 * np.pi) / 180
 
     # find the two pol spots in each frame, then flatten each one
+    is_planet = planet.lower() in ('neptune', 'uranus')
     raster_frames_pol1=[];raster_frames_pol2=[]; cent_pol1=[]; cent_pol2=[]; act_cents_1=[]; act_cents_2=[];
     for j in range(len(dataset)):
         planet_image=dataset[j].data.copy()  # copy: the sky subtraction below is in-place
@@ -637,7 +644,7 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
         x_centroids, y_centroids, weights = sources
 
         # the two spots sit a known distance apart, so pick the detected pair whose
-        # separation best matches it (a spurious detection won't fit the geometry)
+        # separation best matches it
         expected_sep = separation_diameter_arcsec / plate_scale
         n_src = len(x_centroids)
         best = None
@@ -657,29 +664,31 @@ def create_onsky_pol_flatfield(dataset, planet=None,band=None,up_radius=55,im_si
         else:
             i1, i2 = b, a
 
-        # refine each spot at full resolution with the same disk-overlap centroid the
-        # regular imaging flat uses, so the crops register to sub-pixel accuracy
-        # (mis-registered spots leave source-shaped residuals instead of a flat)
-        coarse_centers = [(int(round(x_centroids[i1])), int(round(y_centroids[i1]))),
-                          (int(round(x_centroids[i2])), int(round(y_centroids[i2])))]
-        refined_centers = []
-        for cx, cy in coarse_centers:
-            y0 = max(0, cy - up_radius)
-            y1 = min(planet_image.shape[0], cy + up_radius)
-            x0 = max(0, cx - up_radius)
-            x1 = min(planet_image.shape[1], cx + up_radius)
-            window = planet_image[y0:y1, x0:x1]
-            center = find_disk_center(window, planet_rad)
-            if center is None:
-                center = source_centroid(window)
-            if center is None:
-                # fall back to the coarse segmentation centroid
-                refined_centers.append((cx, cy))
+        # center each spot the way imaging mode does, by source type: a planet keeps its
+        # flux-weighted centroid (find_two_sources already returns it); a rastered star is
+        # located by sliding a disk of the measured radius over the lit pixels
+        centers = []
+        for idx in (i1, i2):
+            if is_planet:
+                cx, cy = x_centroids[idx], y_centroids[idx]
             else:
-                refined_centers.append((int(round(x0 + center[0])),
-                                        int(round(y0 + center[1]))))
-        pol1_x, pol1_y = refined_centers[0]
-        pol2_x, pol2_y = refined_centers[1]
+                cx0 = int(round(x_centroids[idx]))
+                cy0 = int(round(y_centroids[idx]))
+                y0 = max(0, cy0 - up_radius)
+                y1 = min(planet_image.shape[0], cy0 + up_radius)
+                x0 = max(0, cx0 - up_radius)
+                x1 = min(planet_image.shape[1], cx0 + up_radius)
+                window = planet_image[y0:y1, x0:x1]
+                center = find_disk_center(window, planet_rad)
+                if center is None:
+                    center = source_centroid(window)
+                if center is None:
+                    cx, cy = cx0, cy0  # fall back to the segmentation centroid
+                else:
+                    cx, cy = x0 + center[0], y0 + center[1]
+            centers.append((int(round(cx)), int(round(cy))))
+        pol1_x, pol1_y = centers[0]
+        pol2_x, pol2_y = centers[1]
         act_cents_1.append((pol1_x,pol1_y))
         act_cents_2.append((pol2_x,pol2_y))
 

--- a/corgidrp/recipe_templates/l2a_to_polflat.json
+++ b/corgidrp/recipe_templates/l2a_to_polflat.json
@@ -48,6 +48,12 @@
             }
         },
         {
+            "name" : "combine_subexposures",
+            "keywords" : {
+                "num_frames_per_group" : 6
+            }
+        },
+        {
             "name" : "create_onsky_pol_flatfield"
         },
         {


### PR DESCRIPTION
## Describe your changes
Median filter the pol flat images and adapt the imaging mode flat fielding spot detection algorithms so that flat fielding works in polarimetry mode with a star raster. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Reference any relevant issues (don't forget the #)
#1003 and #1004 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
