### PR TITLE
Add filename suffixes to auto-generated data format docs

### DIFF
--- a/docs/source/data_formats/astrom.rst
+++ b/docs/source/data_formats/astrom.rst
@@ -3,6 +3,10 @@
 AstrometricCalibration Data Product
 ========================================
 
+**Filename Suffix:** **ast_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_ast_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/bpmap.rst
+++ b/docs/source/data_formats/bpmap.rst
@@ -3,6 +3,10 @@
 BadPixelMap Data Product
 ========================================
 
+**Filename Suffix:** **bpm_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_bpm_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/corethroughput.rst
+++ b/docs/source/data_formats/corethroughput.rst
@@ -3,6 +3,10 @@
 CoreThroughputCalibration Data Product
 ========================================
 
+**Filename Suffix:** **ctp_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_ctp_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/corethroughput_map.rst
+++ b/docs/source/data_formats/corethroughput_map.rst
@@ -3,6 +3,10 @@
 CoreThroughputMap Data Product
 ========================================
 
+**Filename Suffix:** **ctm_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_ctm_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/dark.rst
+++ b/docs/source/data_formats/dark.rst
@@ -3,6 +3,10 @@
 Dark Data Product
 ========================================
 
+**Filename Suffix:** **drk_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_drk_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/dpm_cal.rst
+++ b/docs/source/data_formats/dpm_cal.rst
@@ -3,6 +3,10 @@
 DispersionModel Data Product
 ========================================
 
+**Filename Suffix:** **dpm_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_dpm_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/flat.rst
+++ b/docs/source/data_formats/flat.rst
@@ -3,6 +3,10 @@
 FlatField Data Product
 ========================================
 
+**Filename Suffix:** **flt_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_flt_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/fluxcal.rst
+++ b/docs/source/data_formats/fluxcal.rst
@@ -3,6 +3,10 @@
 FluxcalFactor Data Product
 ========================================
 
+**Filename Suffix:** **abf_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_abf_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/fluxcal_pol.rst
+++ b/docs/source/data_formats/fluxcal_pol.rst
@@ -3,6 +3,10 @@
 FluxcalFactor Data Product
 ========================================
 
+**Filename Suffix:** **abf_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_abf_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/fluxcal_spec.rst
+++ b/docs/source/data_formats/fluxcal_spec.rst
@@ -3,6 +3,10 @@
 Spectroscopy Flux Calibration Data Product
 ===========================================
 
+**Filename Suffix:** **sfl_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_sfl_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/kgain.rst
+++ b/docs/source/data_formats/kgain.rst
@@ -3,6 +3,10 @@
 KGain Data Product
 ========================================
 
+**Filename Suffix:** **krn_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_krn_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/l2a.rst
+++ b/docs/source/data_formats/l2a.rst
@@ -3,6 +3,10 @@
 L2a Data Product
 ========================================
 
+**Filename Suffix:** **l2a**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_l2a.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/l2b_analog.rst
+++ b/docs/source/data_formats/l2b_analog.rst
@@ -3,6 +3,10 @@
 L2b-Analog Data Product
 ========================================
 
+**Filename Suffix:** **l2b**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_l2b.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/l2b_pc.rst
+++ b/docs/source/data_formats/l2b_pc.rst
@@ -3,6 +3,10 @@
 L2b-PhotonCounting Data Product
 ========================================
 
+**Filename Suffix:** **l2b**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_l2b.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/l3.rst
+++ b/docs/source/data_formats/l3.rst
@@ -3,6 +3,10 @@
 L3 Data Product
 ========================================
 
+**Filename Suffix:** **l3_**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_l3_.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/l3_pol_analog.rst
+++ b/docs/source/data_formats/l3_pol_analog.rst
@@ -3,6 +3,10 @@
 L3 Polarimetry Analog Data Product
 ========================================
 
+**Filename Suffix:** **l3_**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_l3_.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/l3_spec_analog.rst
+++ b/docs/source/data_formats/l3_spec_analog.rst
@@ -3,6 +3,10 @@
 L3 Spectroscopy Analog Data Product
 ========================================
 
+**Filename Suffix:** **l3_**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_l3_.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/l4_pol.rst
+++ b/docs/source/data_formats/l4_pol.rst
@@ -3,6 +3,10 @@
 L4 Data Product
 ========================================
 
+**Filename Suffix:** **l4_**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_l4_.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/l4_spec_coron.rst
+++ b/docs/source/data_formats/l4_spec_coron.rst
@@ -3,6 +3,10 @@
 L4-Spec-Coronagraphic Data Product
 ========================================
 
+**Filename Suffix:** **l4_**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_l4_.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/l4_spec_noncoron.rst
+++ b/docs/source/data_formats/l4_spec_noncoron.rst
@@ -3,6 +3,10 @@
 L4-Spec-Noncoron Data Product
 ========================================
 
+**Filename Suffix:** **l4_**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_l4_.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/l4coron.rst
+++ b/docs/source/data_formats/l4coron.rst
@@ -3,6 +3,10 @@
 L4-Coronagraphic Data Product
 ========================================
 
+**Filename Suffix:** **l4_**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_l4_.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/l4noncoron.rst
+++ b/docs/source/data_formats/l4noncoron.rst
@@ -3,6 +3,10 @@
 L4-Noncoron Data Product
 ========================================
 
+**Filename Suffix:** **l4_**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_l4_.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/lsf_cal.rst
+++ b/docs/source/data_formats/lsf_cal.rst
@@ -3,6 +3,10 @@
 LineSpread Data Product
 ========================================
 
+**Filename Suffix:** **lsf_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_lsf_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/mmx_cal.rst
+++ b/docs/source/data_formats/mmx_cal.rst
@@ -3,6 +3,10 @@
 MuellerMatrix Data Product
 ========================================
 
+**Filename Suffix:** **mmx_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_mmx_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/ndfilter.rst
+++ b/docs/source/data_formats/ndfilter.rst
@@ -3,6 +3,10 @@
 NDFilterSweetSpotDataset Data Product
 ========================================
 
+**Filename Suffix:** **ndf_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_ndf_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/ndfilter_spec.rst
+++ b/docs/source/data_formats/ndfilter_spec.rst
@@ -3,6 +3,10 @@
 ND Filter Spectroscopy Data Product
 ========================================
 
+**Filename Suffix:** **nds_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_nds_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/ndm_cal.rst
+++ b/docs/source/data_formats/ndm_cal.rst
@@ -3,6 +3,10 @@
 NDMuellerMatrix Data Product
 ========================================
 
+**Filename Suffix:** **ndm_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_ndm_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/noisemaps.rst
+++ b/docs/source/data_formats/noisemaps.rst
@@ -3,6 +3,10 @@
 DetectorNoiseMaps Data Product
 ========================================
 
+**Filename Suffix:** **dnm_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_dnm_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/nonlin.rst
+++ b/docs/source/data_formats/nonlin.rst
@@ -3,6 +3,10 @@
 NonLinearityCalibration Data Product
 ========================================
 
+**Filename Suffix:** **nln_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_nln_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/polflt.rst
+++ b/docs/source/data_formats/polflt.rst
@@ -3,6 +3,10 @@
 PolFlatField Data Product
 ========================================
 
+**Filename Suffix:** **flt_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_flt_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/docs/source/data_formats/tpump.rst
+++ b/docs/source/data_formats/tpump.rst
@@ -3,6 +3,10 @@
 TrapCalibration Data Product
 ========================================
 
+**Filename Suffix:** **tpu_cal**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_tpu_cal.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/tests/e2e_tests/data_format_template.rst
+++ b/tests/e2e_tests/data_format_template.rst
@@ -3,6 +3,10 @@
 {1} Data Product
 ========================================
 
+**Filename Suffix:** **{4}**
+
+Filenames follow the convention ``cgi_<visitid>_<timestamp>_{4}.fits``.
+
 
 FITS HDU Structure
 ------------------

--- a/tests/e2e_tests/zz_dataformat_e2e.py
+++ b/tests/e2e_tests/zz_dataformat_e2e.py
@@ -12,13 +12,16 @@ import csv
 
 thisfile_dir = os.path.dirname(__file__) # this file's folder
 
-def generate_template(hdulist, dtype_name=None):
+def generate_template(hdulist, dtype_name=None, filename_suffix=None):
     """
     Generates an rst documentation page of the data entries
 
     Args:
         hdulist (astropy.io.fits.HDUList): hdulist from fits file to be documented
         dtype_name (str): if not None, custom name to use for page title and label
+        filename_suffix (str): the CGI filename suffix used for this data product
+            (e.g. 'l2a', 'l3_', 'bpm_cal'), as validated by validate_cgi_filename.
+            If None, a placeholder is shown instead.
 
     Returns:
         str: the rst page contents
@@ -65,7 +68,8 @@ def generate_template(hdulist, dtype_name=None):
         hdr_tables += "\n\n"
 
 
-    doc = template.format(datatype.lower(), datatype, hdu_table, hdr_tables)
+    suffix_display = filename_suffix if filename_suffix is not None else "N/A"
+    doc = template.format(datatype.lower(), datatype, hdu_table, hdr_tables, suffix_display)
 
     return doc
 
@@ -458,7 +462,7 @@ def test_l2a_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(l2a_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='l2a')
 
     doc_filepath = os.path.join(doc_output_dir, "l2a.rst")
     with open(doc_filepath, "w") as f:
@@ -489,7 +493,7 @@ def test_l2b_analog_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(l2b_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L2b-Analog")
+        doc_contents = generate_template(hdulist, dtype_name="L2b-Analog", filename_suffix='l2b')
 
     doc_filepath = os.path.join(doc_dir, "l2b_analog.rst")
     with open(doc_filepath, "w") as f:
@@ -520,7 +524,7 @@ def test_l2b_pc_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(l2b_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L2b-PhotonCounting")
+        doc_contents = generate_template(hdulist, dtype_name="L2b-PhotonCounting", filename_suffix='l2b')
 
     doc_filepath = os.path.join(doc_dir, "l2b_pc.rst")
     with open(doc_filepath, "w") as f:
@@ -552,7 +556,7 @@ def test_l3_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(l3_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='l3_')
 
     doc_filepath = os.path.join(doc_dir, "l3.rst")
     with open(doc_filepath, "w") as f:
@@ -582,7 +586,7 @@ def test_l3_spec_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(l3_spec_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='l3_')
 
     doc_filepath = os.path.join(doc_dir, "l3_spec_analog.rst")
     with open(doc_filepath, "w") as f:
@@ -612,7 +616,7 @@ def test_l3_pol_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(l3_pol_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='l3_')
 
     doc_filepath = os.path.join(doc_dir, "l3_pol_analog.rst")
     with open(doc_filepath, "w") as f:
@@ -643,7 +647,7 @@ def test_l4_coron_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(l4_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L4-Coronagraphic")
+        doc_contents = generate_template(hdulist, dtype_name="L4-Coronagraphic", filename_suffix='l4_')
 
     doc_filepath = os.path.join(doc_dir, "l4coron.rst")
     with open(doc_filepath, "w") as f:
@@ -673,7 +677,7 @@ def test_l4_noncoron_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(kgain_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L4-Noncoron")
+        doc_contents = generate_template(hdulist, dtype_name="L4-Noncoron", filename_suffix='l4_')
 
     doc_filepath = os.path.join(doc_dir, "l4noncoron.rst")
     with open(doc_filepath, "w") as f:
@@ -703,7 +707,7 @@ def test_l4_pol_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(l4_pol_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='l4_')
 
     doc_filepath = os.path.join(doc_dir, "l4_pol.rst")
     with open(doc_filepath, "w") as f:
@@ -733,7 +737,7 @@ def test_l4_spec_coron_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(l4_spec_coron_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L4-Spec-Coronagraphic")
+        doc_contents = generate_template(hdulist, dtype_name="L4-Spec-Coronagraphic", filename_suffix='l4_')
 
     doc_filepath = os.path.join(doc_dir, "l4_spec_coron.rst")
     with open(doc_filepath, "w") as f:
@@ -763,7 +767,7 @@ def test_l4_spec_noncoron_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(l4_spec_noncoron_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L4-Spec-Noncoron")
+        doc_contents = generate_template(hdulist, dtype_name="L4-Spec-Noncoron", filename_suffix='l4_')
 
     doc_filepath = os.path.join(doc_dir, "l4_spec_noncoron.rst")
     with open(doc_filepath, "w") as f:
@@ -793,7 +797,7 @@ def test_astrom_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(astrom_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='ast_cal')
 
     doc_filepath = os.path.join(doc_dir, "astrom.rst")
     with open(doc_filepath, "w") as f:
@@ -824,7 +828,7 @@ def test_bpmap_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(bpmap_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='bpm_cal')
 
     doc_filepath = os.path.join(doc_dir, "bpmap.rst")
     with open(doc_filepath, "w") as f:
@@ -855,7 +859,7 @@ def test_flat_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(flat_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='flt_cal')
 
     doc_filepath = os.path.join(doc_dir, "flat.rst")
     with open(doc_filepath, "w") as f:
@@ -884,7 +888,7 @@ def test_polflat_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(polflat_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="PolFlatField")
+        doc_contents = generate_template(hdulist, dtype_name="PolFlatField", filename_suffix='flt_cal')
 
     doc_filepath = os.path.join(doc_dir, "polflt.rst")
     with open(doc_filepath, "w") as f:
@@ -915,7 +919,7 @@ def test_ct_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(ct_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='ctp_cal')
 
     doc_filepath = os.path.join(doc_dir, "corethroughput.rst")
     with open(doc_filepath, "w") as f:
@@ -945,7 +949,7 @@ def test_ctmap_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(ctmap_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="CoreThroughputMap")
+        doc_contents = generate_template(hdulist, dtype_name="CoreThroughputMap", filename_suffix='ctm_cal')
 
     doc_filepath = os.path.join(doc_dir, "corethroughput_map.rst")
     with open(doc_filepath, "w") as f:
@@ -977,7 +981,7 @@ def test_fluxcal_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(fluxcal_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='abf_cal')
 
     doc_filepath = os.path.join(doc_dir, "fluxcal.rst")
     with open(doc_filepath, "w") as f:
@@ -1007,7 +1011,7 @@ def test_kgain_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(kgain_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='krn_cal')
 
     doc_filepath = os.path.join(doc_dir, "kgain.rst")
     with open(doc_filepath, "w") as f:
@@ -1038,7 +1042,7 @@ def test_nonlin_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(nonlin_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='nln_cal')
 
     doc_filepath = os.path.join(doc_dir, "nonlin.rst")
     with open(doc_filepath, "w") as f:
@@ -1068,7 +1072,7 @@ def test_ndfilter_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(nd_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='ndf_cal')
 
     doc_filepath = os.path.join(doc_dir, "ndfilter.rst")
     with open(doc_filepath, "w") as f:
@@ -1097,7 +1101,7 @@ def test_ndfilter_spec_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(nds_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='nds_cal')
 
     doc_filepath = os.path.join(doc_dir, "ndfilter_spec.rst")
     with open(doc_filepath, "w") as f:
@@ -1125,7 +1129,7 @@ def test_specfluxcal_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(sfl_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='sfl_cal')
 
     doc_filepath = os.path.join(doc_dir, "fluxcal_spec.rst")
     with open(doc_filepath, "w") as f:
@@ -1154,7 +1158,7 @@ def test_noisemaps_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(noisemaps_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='dnm_cal')
 
     doc_filepath = os.path.join(doc_dir, "noisemaps.rst")
     with open(doc_filepath, "w") as f:
@@ -1185,7 +1189,7 @@ def test_dark_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(dark_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='drk_cal')
 
     doc_filepath = os.path.join(doc_dir, "dark.rst")
     with open(doc_filepath, "w") as f:
@@ -1223,11 +1227,11 @@ def test_darks_comparison_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(trad_data_file) as hdulist:
-        trad_doc_contents = generate_template(hdulist)
+        trad_doc_contents = generate_template(hdulist, filename_suffix='drk_cal')
     with fits.open(pc_data_file) as hdulist:
-        pc_doc_contents = generate_template(hdulist)
+        pc_doc_contents = generate_template(hdulist, filename_suffix='drk_cal')
     with fits.open(synth_data_file) as hdulist:
-        synth_doc_contents = generate_template(hdulist)
+        synth_doc_contents = generate_template(hdulist, filename_suffix='drk_cal')
 
     # files' array shapes will be different, but check that the headers are the same
     compare_docs(trad_doc_contents, pc_doc_contents, data_product_name="Dark (Traditional vs Photon Counting)", skip_hdu_structure_check=True)
@@ -1250,7 +1254,7 @@ def test_tpump_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(tpump_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='tpu_cal')
 
     doc_filepath = os.path.join(doc_dir, "tpump.rst")
     with open(doc_filepath, "w") as f:
@@ -1277,7 +1281,7 @@ def test_fluxcal_pol_dataformat_e2e(e2edata_path, e2eoutput_path):
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
 
     with fits.open(fluxcal_pol_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='abf_cal')
 
     doc_filepath = os.path.join(doc_dir, "fluxcal_pol.rst")
     with open(doc_filepath, "w") as f:
@@ -1306,7 +1310,7 @@ def test_mueller_matrix_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(polcal_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='mmx_cal')
 
     doc_filepath = os.path.join(doc_dir, "mmx_cal.rst")
     with open(doc_filepath, "w") as f:
@@ -1335,7 +1339,7 @@ def test_nd_mueller_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(polcal_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='ndm_cal')
 
     doc_filepath = os.path.join(doc_dir, "ndm_cal.rst")
     with open(doc_filepath, "w") as f:
@@ -1365,7 +1369,7 @@ def test_spec_linespread_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(spec_linespread_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='lsf_cal')
 
     doc_filepath = os.path.join(doc_dir, "lsf_cal.rst")
     with open(doc_filepath, "w") as f:
@@ -1394,7 +1398,7 @@ def test_spec_prism_disp_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(spec_prism_disp_data_file) as hdulist:
-        doc_contents = generate_template(hdulist)
+        doc_contents = generate_template(hdulist, filename_suffix='dpm_cal')
 
     doc_filepath = os.path.join(doc_dir, "dpm_cal.rst")
     with open(doc_filepath, "w") as f:

--- a/tests/e2e_tests/zz_dataformat_e2e.py
+++ b/tests/e2e_tests/zz_dataformat_e2e.py
@@ -1,4 +1,5 @@
 import os
+import re
 import argparse
 import difflib
 import glob
@@ -12,6 +13,34 @@ import csv
 
 thisfile_dir = os.path.dirname(__file__) # this file's folder
 
+# Matches the CGI filename convention checked by validate_cgi_filename():
+# cgi_VISITID(19 digits)_YYYYMMDDtHHMMSSS_SUFFIX.fits
+CGI_FILENAME_SUFFIX_PATTERN = re.compile(r'^cgi_\d{19}_\d{8}t\d{7}_(.+)\.fits$')
+
+def parse_filename_suffix(hdulist):
+    """
+    Derives the CGI filename suffix (e.g. 'l2a', 'l3_', 'bpm_cal') from the
+    filename of the FITS file backing hdulist, using the same
+    'cgi_VISITID_YYYYMMDDtHHMMSSS_suffix.fits' convention checked by
+    validate_cgi_filename().
+
+    Args:
+        hdulist (astropy.io.fits.HDUList): hdulist from fits file to be documented
+
+    Returns:
+        str: the parsed filename suffix, or None if the filename is
+            unavailable or doesn't match the CGI naming convention
+    """
+    filepath = hdulist.filename()
+    if filepath is None:
+        return None
+
+    match = CGI_FILENAME_SUFFIX_PATTERN.match(os.path.basename(filepath))
+    if match is None:
+        return None
+
+    return match.group(1)
+
 def generate_template(hdulist, dtype_name=None, filename_suffix=None):
     """
     Generates an rst documentation page of the data entries
@@ -21,7 +50,10 @@ def generate_template(hdulist, dtype_name=None, filename_suffix=None):
         dtype_name (str): if not None, custom name to use for page title and label
         filename_suffix (str): the CGI filename suffix used for this data product
             (e.g. 'l2a', 'l3_', 'bpm_cal'), as validated by validate_cgi_filename.
-            If None, a placeholder is shown instead.
+            If None (the default), the suffix is parsed automatically from
+            hdulist's filename via parse_filename_suffix(). If that also
+            fails (e.g. the filename doesn't follow the CGI convention), a
+            placeholder is shown instead.
 
     Returns:
         str: the rst page contents
@@ -68,6 +100,8 @@ def generate_template(hdulist, dtype_name=None, filename_suffix=None):
         hdr_tables += "\n\n"
 
 
+    if filename_suffix is None:
+        filename_suffix = parse_filename_suffix(hdulist)
     suffix_display = filename_suffix if filename_suffix is not None else "N/A"
     doc = template.format(datatype.lower(), datatype, hdu_table, hdr_tables, suffix_display)
 
@@ -462,7 +496,7 @@ def test_l2a_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(l2a_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='l2a')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_output_dir, "l2a.rst")
     with open(doc_filepath, "w") as f:
@@ -493,7 +527,7 @@ def test_l2b_analog_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(l2b_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L2b-Analog", filename_suffix='l2b')
+        doc_contents = generate_template(hdulist, dtype_name="L2b-Analog")
 
     doc_filepath = os.path.join(doc_dir, "l2b_analog.rst")
     with open(doc_filepath, "w") as f:
@@ -524,7 +558,7 @@ def test_l2b_pc_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(l2b_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L2b-PhotonCounting", filename_suffix='l2b')
+        doc_contents = generate_template(hdulist, dtype_name="L2b-PhotonCounting")
 
     doc_filepath = os.path.join(doc_dir, "l2b_pc.rst")
     with open(doc_filepath, "w") as f:
@@ -556,7 +590,7 @@ def test_l3_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(l3_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='l3_')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "l3.rst")
     with open(doc_filepath, "w") as f:
@@ -586,7 +620,7 @@ def test_l3_spec_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(l3_spec_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='l3_')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "l3_spec_analog.rst")
     with open(doc_filepath, "w") as f:
@@ -616,7 +650,7 @@ def test_l3_pol_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(l3_pol_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='l3_')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "l3_pol_analog.rst")
     with open(doc_filepath, "w") as f:
@@ -647,7 +681,7 @@ def test_l4_coron_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(l4_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L4-Coronagraphic", filename_suffix='l4_')
+        doc_contents = generate_template(hdulist, dtype_name="L4-Coronagraphic")
 
     doc_filepath = os.path.join(doc_dir, "l4coron.rst")
     with open(doc_filepath, "w") as f:
@@ -677,7 +711,7 @@ def test_l4_noncoron_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(kgain_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L4-Noncoron", filename_suffix='l4_')
+        doc_contents = generate_template(hdulist, dtype_name="L4-Noncoron")
 
     doc_filepath = os.path.join(doc_dir, "l4noncoron.rst")
     with open(doc_filepath, "w") as f:
@@ -707,7 +741,7 @@ def test_l4_pol_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(l4_pol_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='l4_')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "l4_pol.rst")
     with open(doc_filepath, "w") as f:
@@ -737,7 +771,7 @@ def test_l4_spec_coron_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(l4_spec_coron_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L4-Spec-Coronagraphic", filename_suffix='l4_')
+        doc_contents = generate_template(hdulist, dtype_name="L4-Spec-Coronagraphic")
 
     doc_filepath = os.path.join(doc_dir, "l4_spec_coron.rst")
     with open(doc_filepath, "w") as f:
@@ -767,7 +801,7 @@ def test_l4_spec_noncoron_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(l4_spec_noncoron_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="L4-Spec-Noncoron", filename_suffix='l4_')
+        doc_contents = generate_template(hdulist, dtype_name="L4-Spec-Noncoron")
 
     doc_filepath = os.path.join(doc_dir, "l4_spec_noncoron.rst")
     with open(doc_filepath, "w") as f:
@@ -797,7 +831,7 @@ def test_astrom_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(astrom_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='ast_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "astrom.rst")
     with open(doc_filepath, "w") as f:
@@ -828,7 +862,7 @@ def test_bpmap_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(bpmap_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='bpm_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "bpmap.rst")
     with open(doc_filepath, "w") as f:
@@ -859,7 +893,7 @@ def test_flat_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(flat_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='flt_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "flat.rst")
     with open(doc_filepath, "w") as f:
@@ -888,7 +922,7 @@ def test_polflat_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(polflat_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="PolFlatField", filename_suffix='flt_cal')
+        doc_contents = generate_template(hdulist, dtype_name="PolFlatField")
 
     doc_filepath = os.path.join(doc_dir, "polflt.rst")
     with open(doc_filepath, "w") as f:
@@ -919,7 +953,7 @@ def test_ct_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(ct_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='ctp_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "corethroughput.rst")
     with open(doc_filepath, "w") as f:
@@ -949,7 +983,7 @@ def test_ctmap_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(ctmap_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, dtype_name="CoreThroughputMap", filename_suffix='ctm_cal')
+        doc_contents = generate_template(hdulist, dtype_name="CoreThroughputMap")
 
     doc_filepath = os.path.join(doc_dir, "corethroughput_map.rst")
     with open(doc_filepath, "w") as f:
@@ -981,7 +1015,7 @@ def test_fluxcal_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(fluxcal_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='abf_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "fluxcal.rst")
     with open(doc_filepath, "w") as f:
@@ -1011,7 +1045,7 @@ def test_kgain_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(kgain_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='krn_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "kgain.rst")
     with open(doc_filepath, "w") as f:
@@ -1042,7 +1076,7 @@ def test_nonlin_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(nonlin_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='nln_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "nonlin.rst")
     with open(doc_filepath, "w") as f:
@@ -1072,7 +1106,7 @@ def test_ndfilter_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(nd_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='ndf_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "ndfilter.rst")
     with open(doc_filepath, "w") as f:
@@ -1101,7 +1135,7 @@ def test_ndfilter_spec_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(nds_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='nds_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "ndfilter_spec.rst")
     with open(doc_filepath, "w") as f:
@@ -1129,7 +1163,7 @@ def test_specfluxcal_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(sfl_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='sfl_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "fluxcal_spec.rst")
     with open(doc_filepath, "w") as f:
@@ -1158,7 +1192,7 @@ def test_noisemaps_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(noisemaps_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='dnm_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "noisemaps.rst")
     with open(doc_filepath, "w") as f:
@@ -1189,7 +1223,7 @@ def test_dark_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(dark_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='drk_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "dark.rst")
     with open(doc_filepath, "w") as f:
@@ -1227,11 +1261,11 @@ def test_darks_comparison_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(trad_data_file) as hdulist:
-        trad_doc_contents = generate_template(hdulist, filename_suffix='drk_cal')
+        trad_doc_contents = generate_template(hdulist)
     with fits.open(pc_data_file) as hdulist:
-        pc_doc_contents = generate_template(hdulist, filename_suffix='drk_cal')
+        pc_doc_contents = generate_template(hdulist)
     with fits.open(synth_data_file) as hdulist:
-        synth_doc_contents = generate_template(hdulist, filename_suffix='drk_cal')
+        synth_doc_contents = generate_template(hdulist)
 
     # files' array shapes will be different, but check that the headers are the same
     compare_docs(trad_doc_contents, pc_doc_contents, data_product_name="Dark (Traditional vs Photon Counting)", skip_hdu_structure_check=True)
@@ -1254,7 +1288,7 @@ def test_tpump_dataformat_e2e(e2edata_path, e2eoutput_path):
 
 
     with fits.open(tpump_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='tpu_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "tpump.rst")
     with open(doc_filepath, "w") as f:
@@ -1281,7 +1315,7 @@ def test_fluxcal_pol_dataformat_e2e(e2edata_path, e2eoutput_path):
     doc_dir = os.path.join(e2eoutput_path, "data_format_docs")
 
     with fits.open(fluxcal_pol_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='abf_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "fluxcal_pol.rst")
     with open(doc_filepath, "w") as f:
@@ -1310,7 +1344,7 @@ def test_mueller_matrix_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(polcal_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='mmx_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "mmx_cal.rst")
     with open(doc_filepath, "w") as f:
@@ -1339,7 +1373,7 @@ def test_nd_mueller_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(polcal_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='ndm_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "ndm_cal.rst")
     with open(doc_filepath, "w") as f:
@@ -1369,7 +1403,7 @@ def test_spec_linespread_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(spec_linespread_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='lsf_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "lsf_cal.rst")
     with open(doc_filepath, "w") as f:
@@ -1398,7 +1432,7 @@ def test_spec_prism_disp_dataformat_e2e(e2edata_path, e2eoutput_path):
         os.mkdir(doc_dir)
 
     with fits.open(spec_prism_disp_data_file) as hdulist:
-        doc_contents = generate_template(hdulist, filename_suffix='dpm_cal')
+        doc_contents = generate_template(hdulist)
 
     doc_filepath = os.path.join(doc_dir, "dpm_cal.rst")
     with open(doc_filepath, "w") as f:


### PR DESCRIPTION


Closes #462

## Describe your changes
Adds a "Filename Suffix" field to the data format doc template and each generated page in docs/source/data_formats/, showing the CGI filename suffix (e.g. l3_, bpm_cal) for that data product, sourced from the same suffix each e2e test already validates via validate_cgi_filename().

data_format_template.rst: new Filename Suffix field under the title
zz_dataformat_e2e.py: generate_template() takes filename_suffix; all 34 call sites pass the suffix already asserted by validate_cgi_filename() for that test
docs/source/data_formats/*.rst: 31 reference pages updated to match (hand-patched since e2e regeneration requires TVAC data not available locally; suffixes verified against the test file)


## Type of change
- New feature (non-breaking change which adds functionality)


## Reference any relevant issues (don't forget the #)
Closes #462

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
