### PR TITLE
Standardize unpack_geom() Returns docstring to type-first format

### DIFF
--- a/corgidrp/detector.py
+++ b/corgidrp/detector.py
@@ -298,9 +298,10 @@ def unpack_geom(arrtype, key, detector_regions=None):
         detector_regions (dict): a dictionary of detector geometry properties.  Keys should be as found in detector_areas in detector.py.  Defaults to that dictionary.
 
     Returns:
-        rows (int): Number of rows of frame
-        cols (int): Number of columns of frame
-        r0c0 (tuple): Tuple of (row position, column position) of corner closest to (0,0)
+        tuple:
+            - rows (int): Number of rows of frame
+            - cols (int): Number of columns of frame
+            - r0c0 (tuple): Tuple of (row position, column position) of corner closest to (0,0)
     """
     if detector_regions is None:
         detector_regions = detector_areas
@@ -320,9 +321,10 @@ def imaging_area_geom(arrtype, detector_regions=None):
         detector_regions (dict): a dictionary of detector geometry properties.  Keys should be as found in detector_areas in detector.py.  Defaults to that dictionary.
 
     Returns:
-        rows (int): Number of rows of imaging area
-        cols (int): Number of columns of imaging area
-        r0c0 (tuple): Tuple of (row position, column position) of corner closest to (0,0)
+        tuple:
+            - rows (int): Number of rows of imaging area
+            - cols (int): Number of columns of imaging area
+            - r0c0 (tuple): Tuple of (row position, column position) of corner closest to (0,0)
     """
     if detector_regions is None:
         detector_regions = detector_areas
@@ -352,7 +354,7 @@ def imaging_slice(arrtype, frame, detector_regions=None):
         detector_regions (dict): a dictionary of detector geometry properties.  Keys should be as found in detector_areas in detector.py.  Defaults to that dictionary.
 
     Returns:
-        sl (array_like): Imaging slice
+        array_like: Imaging slice
     """
     rows, cols, r0c0 = imaging_area_geom(arrtype, detector_regions)
     sl = frame[r0c0[0]:r0c0[0]+rows, r0c0[1]:r0c0[1]+cols]


### PR DESCRIPTION
Describe your changes
Per #983, the Returns: section should specify the data type (tuple, here) before describing each element, matching the style already used by e.g. calibrate_darks_lsq(). unpack_geom() previously listed the three return values directly with no top-level type.

Only unpack_geom() in corgidrp/detector.py was changed — a docstring-only fix, no functional/behavioral change. calibrate_darks_lsq() needed no change since it was already the correctly-formatted example cited in the issue.

Type of change
Bug fix (non-breaking change which fixes an issue)
Reference any relevant issues (don't forget the #)
Closes #983

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
