### PR TITLE
added dither to mock polcal data and test

### DIFF
--- a/corgidrp/mocks.py
+++ b/corgidrp/mocks.py
@@ -5581,7 +5581,7 @@ def get_pol_image_centers(image_separation_arcsec, alignment_angle, pixel_scale 
 
 def generate_mock_polcal_dataset(path_to_pol_ref_file, read_noise=200,
                             image_separation_arcsec=7.5, q_inst=0.5,u_inst=-0.1,
-                            q_eff=0.8,uq_ct=0.05,u_eff=0.7,qu_ct=0.03):
+                            q_eff=0.8,uq_ct=0.05,u_eff=0.7,qu_ct=0.03, fsmx=0, fsmy=0):
     '''
     Generate a mock L2b polarimetric dataset for polcal testing
 
@@ -5595,6 +5595,8 @@ def generate_mock_polcal_dataset(path_to_pol_ref_file, read_noise=200,
         uq_ct (float): U to Q crosstalk
         u_eff (float): U efficiency
         qu_ct (float): Q to U crosstalk
+        fsmx (float): X-axis dither position of the fast steering mirror
+        fsmy (float): Y-axis dither position of the fast steering mirror
 
     Returns:
         corgidrp.data.Dataset: The simulated L2b polarimetric dataset for polcal testing
@@ -5654,6 +5656,8 @@ observing_mode='NFOV', left_image_value=0, right_image_value=0)
     mock_dataset = data.Dataset(image_list)
     for frame in mock_dataset.frames:
         frame.pri_hdr['VISTYPE'] = "CGIVST_CAL_POL_SETUP"
+        frame.ext_hdr['FSMX'] = fsmx
+        frame.ext_hdr['FSMY'] = fsmy
 
     return mock_dataset
 

--- a/tests/e2e_tests/polcal_e2e.py
+++ b/tests/e2e_tests/polcal_e2e.py
@@ -43,14 +43,29 @@ def run_polcal_test(output_dir, do_ND=False,
 #To test this we need this catalog with the same values as the test data also in corgidrp/data/stellar_polarization_database.csv
     path_to_pol_ref_file = os.path.join(current_file_path, "..","test_data","stellar_polarization_database.csv")
 
-    
-    mock_dataset = mocks.generate_mock_polcal_dataset(path_to_pol_ref_file,
+    # create a mock dataset with two dithers
+    mock_dataset_dither_1 = mocks.generate_mock_polcal_dataset(path_to_pol_ref_file,
                                            q_inst=q_instrumental_polarization,
                                            u_inst=u_instrumental_polarization,
                                            q_eff=q_efficiency,
                                            u_eff=u_efficiency,
                                            uq_ct=uq_cross_talk,
-                                           qu_ct=qu_cross_talk)
+                                           qu_ct=qu_cross_talk,
+                                           fsmx=-20,
+                                           fsmy=20)
+
+    mock_dataset_dither_2 = mocks.generate_mock_polcal_dataset(path_to_pol_ref_file,
+                                               q_inst=q_instrumental_polarization,
+                                               u_inst=u_instrumental_polarization,
+                                               q_eff=q_efficiency,
+                                               u_eff=u_efficiency,
+                                               uq_ct=uq_cross_talk,
+                                               qu_ct=qu_cross_talk,
+                                               fsmx=20,
+                                               fsmy=-20)
+
+    # combine the two dither datasets
+    mock_dataset = Dataset(list(mock_dataset_dither_1.frames) + list(mock_dataset_dither_2.frames))
     
     frames = [frame for frame in mock_dataset]
     if do_ND: 


### PR DESCRIPTION
## Describe your changes
- Added FSMX/FSMY dither information to both mock polcal data and the simulated L1 data on the sharepoint so the walker can select the right recipe template for the polcal end-to-end tests. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Reference any relevant issues (don't forget the #)
#1023 

## Checklist before requesting a review
- [x] I have verified that all unit tests pass in a clean environment and added new unit tests, as appropriate
- [x] I have checked that I am merging into the right branch
- [x] I have checked the output of the latest Github Actions run associated with this PR and confirmed running `pytest` did not produce any warnings
- [x] I have checked if my code modifies an existing step function or modifies the data format docs. If it does, I've added my PR to the [list maintained here](https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/212028061/Log+of+PRs+that+could+affect+existing+VAP+Tests). 
